### PR TITLE
Add sandboxes to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Monorepo for hosting libraries for the Reason Native toolchain (such as the Chal
 
 ## Getting started:
 * install esy (https://esy.sh/)
-* run ```esy install``` and ```esy build```
+* Run ```esy install``` and ```esy build```
 * test executables are currently defined in the respective .json files for each repository, to run them run ```esy x ExecutableName.exe```
-  
+* This project uses Esy Sandboxes for its respective projects, check out https://esy.sh/docs/en/multiple-sandboxes.html
+
 ## License
 reason-native is MIT licensed, as found in the LICENSE file.


### PR DESCRIPTION
Add Esy sandboxes to readme. I think this will help onboard people and prevent confusion if they try to esy build