### PR TITLE
update README to reflect separate test package paradigm

### DIFF
--- a/src/test-runner/README.md
+++ b/src/test-runner/README.md
@@ -9,27 +9,28 @@ We recommend that you use [`esy`](https://esy.sh/) to handle your package manage
 npm install -g esy
 ```
 
-Add it as a dev dependency to your package.json (or esy.json) and run ```esy install```
+Add it as a dependency to your package.json (or esy.json) and run ```esy install```. If you don't want to distribute your tests as part of your release, you can utilize  [multiple sandboxes](https://esy.sh/docs/en/multiple-sandboxes.html) and .opam files to separate your dependencies
 
 **package.json**
 ```
 ...
 
-devDependencies": {
+dependencies": {
     ...
     "@reason-native/test-runner": "*",
     ...
 },
 ...
 ```
-## Creating a test project
+## Creating a test package
 
-Let's start by creating a library for our tests inside a directory called test and create a dune file to handle building our code (if you wish to use another build system, the important thing here is to pass the -linkall flag to the compiler)
+Let's start by creating a library for our tests. First create an opam file for your test package (it should be empty). Then let's create a directory called test and create a dune file four our library (if you wish to use another build system, the important thing here is to pass the -linkall flag to the compiler)
 ```
 │
+├─my-lib-test.opam
 ├─test/
 │   lib/
-|       dune
+│       dune
 │
 ```
 
@@ -37,7 +38,7 @@ Let's start by creating a library for our tests inside a directory called test a
 ```
 (library
    (name MyLibTest)
-   (public_name my-lib.test)
+   (public_name my-lib-test.lib)
    ; the linkall flag ensures that all of our tests are compiled and the
    ; -g flag emits debugging information
    (ocamlopt_flags -linkall -g)
@@ -50,10 +51,11 @@ Let's start by creating a library for our tests inside a directory called test a
 Now let's create a file to initialize the test framework. Here we are specifying where snapshots should be stored as well as the root directory of your project for the formatting of terminal output.
 ```
 │
+├─my-lib-test.opam
 ├─test/
 │   lib/
-|       dune
-|       TestFramework.re
+│       dune
+│       TestFramework.re
 ```
 
 #### TestFramework.re
@@ -70,11 +72,12 @@ include TestRunner.Make({
 Now we can finally write our first test!
 ```
 │
+├─my-lib-test.opam
 ├─test/
 │   lib/
-|       dune
-|       TestFramework.re
-|       MyFirstTest.re
+│       dune
+│       TestFramework.re
+│       MyFirstTest.re
 ```
 
 ```reason
@@ -90,14 +93,15 @@ describe("my first test suite", ({test}) => {
 From here let's create an executable to actually run our tests.
 ```
 │
+├─my-lib-test.opam
 ├─test/
 │   lib/
-|       dune
-|       TestFramework.re
-|       MyFirstTest.re
-|   exe/
-|       dune
-|       MyLibTest.re
+│       dune
+│       TestFramework.re
+│       MyFirstTest.re
+│   exe/
+│       dune
+│       MyLibTest.re
 ```
 
 #### dune
@@ -106,6 +110,7 @@ From here let's create an executable to actually run our tests.
    (name MyLibTest)
    (public_name MyLibTest.exe)
    (libraries  my-lib.test )
+   (package my-lib-test)
 )
 ```
 
@@ -133,3 +138,4 @@ esy x TestRunnerTest.exe
 
 ## License
 @reason-native/test-runner is MIT licensed, as found in the LICENSE file at the root of the reason-native repository.
+

--- a/src/test-runner/README.md
+++ b/src/test-runner/README.md
@@ -24,7 +24,7 @@ dependencies": {
 ```
 ## Creating a test package
 
-Let's start by creating a library for our tests. First create an opam file for your test package (it should be empty). Then let's create a directory called test and create a dune file four our library (if you wish to use another build system, the important thing here is to pass the -linkall flag to the compiler)
+Let's start by creating a library for our tests. First create an opam file for your test package (it should be empty). Then let's create a directory called test and create a dune file for our library (if you wish to use another build system, the important thing here is to pass the -linkall flag to the compiler)
 ```
 │
 ├─my-lib-test.opam


### PR DESCRIPTION
Recommending separate test project as part of docs. Unsure how in the weeds to get with this/I imagine at some point we are going to want to have separate documentation unrelated to test-runner on "what does a basic project look like" and maybe a create-reason-native-app script and/or a pesy update