### PR TITLE
Add 'esy test' command

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -16,7 +16,9 @@
       "esy-installer refmterr.install"
     ]
   },
-  "scripts": {},
+  "scripts": {
+    "test": "./runTests.sh"
+  },
   "dependencies": {
     "@opam/dune": "*",
     "@esy-ocaml/reason": "*",

--- a/refmterr.json
+++ b/refmterr.json
@@ -23,5 +23,8 @@
   "esy": {
     "build": "refmterr dune build -p refmterr",
     "install": "esy-installer refmterr.install"
+  },
+  "scripts": {
+    "test": "esy src/refmterr/runTests.sh"
   }
 }

--- a/runTests.sh
+++ b/runTests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+esy @chalk-console test
+esy @chalk test
+esy @console test
+esy @refmterr test
+esy @test-runner test


### PR DESCRIPTION
Put all the commands in a new `runTests.sh` file as the `scripts` section of `esy.json` does not support array-format multi-commands. 
^Not sure if this is the best approach though

Also this command won't work until we fix the self dependencies (i.e. publish to npm)