### PR TITLE
Copy README.md from src/packageName/README.md when running publish script

### DIFF
--- a/scripts/esy-prepublish.js
+++ b/scripts/esy-prepublish.js
@@ -89,7 +89,7 @@ try {
     process.chdir(projectRoot);
     let jsonRelativePath = relativeJsonPaths[i];
     let jsonResolvedPath = path.resolve(projectRoot, jsonRelativePath);
-    
+
     let subpackageReleaseDir = path.resolve(_releaseDir, jsonRelativePath);
     let subpackageReleasePrepDir = path.resolve(_releaseDir, path.join(jsonRelativePath), '_prep');
     cp.spawnSync('mkdir', ['-p', subpackageReleaseDir]);
@@ -112,13 +112,13 @@ try {
     let readmePkgPath =
       path.resolve(
         subpackageReleasePrepDir,
-        path.basename(jsonRelativePath, '.json') + '.README.md'
+        path.join("src", path.basename(jsonRelativePath, '.json'), 'README.md')
       );
     let readmeResolvedPath =
       fs.existsSync(readmePkgPath) ? readmePkgPath :
       fs.existsSync(readmePath) ? readmePath :
       null;
-    
+
     let toCopy = [
       {
         originPath: path.resolve(subpackageReleasePrepDir, jsonRelativePath),

--- a/scripts/esy-prepublish.js
+++ b/scripts/esy-prepublish.js
@@ -112,7 +112,7 @@ try {
     let readmePkgPath =
       path.resolve(
         subpackageReleasePrepDir,
-        path.join("src", path.basename(jsonRelativePath, '.json'), 'README.md')
+        path.join('src', path.basename(jsonRelativePath, '.json'), 'README.md')
       );
     let readmeResolvedPath =
       fs.existsSync(readmePkgPath) ? readmePkgPath :


### PR DESCRIPTION
Updated esy-prepublish to copy README from the subdirectories themselves. This lets us have a better github user experience when browsing the package directories without playing around with symlinks which could cause windows problems and didn't play nicely with the prepublish script.