### PR TITLE
Support Console.out not outputting newlines.

### DIFF
--- a/src/console/README.md
+++ b/src/console/README.md
@@ -50,11 +50,11 @@ like.
 
 
 ### `Console.log(anything)`
-Output a string or object to standard output. Suitable for writing to logs, or
-for outputting user messaging in command line applications. If you pass a
-string, it will not be wrapped in quotes. If you pass an object, `Console.log`
-will attempt to print the object dynamically. Strings deep in objects will be
-wrapped in quotes.
+Output a string or object to standard output followed by a newline. Suitable
+for writing to logs, or for outputting user messaging in command line
+applications. If you pass a string, it will not be wrapped in quotes. If you
+pass an object, `Console.log` will attempt to print the object dynamically.
+Strings deep in objects will be wrapped in quotes.
 
 ```reason
 let log: 'a => unit;
@@ -62,15 +62,19 @@ let log: 'a => unit;
 
 ### `Console.out(anything)`
 
-Same as `Console.log` but does not append a newline.
+Same as `Console.log` but attempts to avoid printing a final newline. Not all
+backends will support omitting the newline (such as in the browser where
+`console` only supports outputting with final newlines.)
 
 ```reason
 let out: 'a => unit;
 ```
 
 ### `Console.debug(anything)`
-Outputs developer-only messaging to standard out. Suitable for writing to log
-files. In production mode, would typically be suppressed entirely.
+Same as `Console.log` but used for developer-facing messaging to standard out.
+Suitable for writing to log files. In production mode, would typically be
+suppressed entirely. Custom `Console.t` implementations may implement custom
+behavior for `Console.debug` that behaves differently from `Console.log`.
 
 ```reason
 let debug: 'a => unit;

--- a/src/console/library/Console.re
+++ b/src/console/library/Console.re
@@ -16,23 +16,15 @@ type t = {
 
 let makeStandardChannelsConsole = (objectPrinter: ObjectPrinter.t): t => {
   log: a =>
-    NativeChannels._log(
-      objectPrinter.polymorphicPrint(objectPrinter, a) ++ "\n",
-    ),
-  out: a =>
     NativeChannels._log(objectPrinter.polymorphicPrint(objectPrinter, a)),
+  out: a =>
+    NativeChannels._out(objectPrinter.polymorphicPrint(objectPrinter, a)),
   debug: a =>
-    NativeChannels._debug(
-      objectPrinter.polymorphicPrint(objectPrinter, a) ++ "\n",
-    ),
+    NativeChannels._debug(objectPrinter.polymorphicPrint(objectPrinter, a)),
   error: a =>
-    NativeChannels._error(
-      objectPrinter.polymorphicPrint(objectPrinter, a) ++ "\n",
-    ),
+    NativeChannels._error(objectPrinter.polymorphicPrint(objectPrinter, a)),
   warn: a =>
-    NativeChannels._warn(
-      objectPrinter.polymorphicPrint(objectPrinter, a) ++ "\n",
-    ),
+    NativeChannels._warn(objectPrinter.polymorphicPrint(objectPrinter, a)),
 };
 
 let defaultGlobalConsole = makeStandardChannelsConsole(ObjectPrinter.base);

--- a/src/console/library/Console.rei
+++ b/src/console/library/Console.rei
@@ -96,11 +96,11 @@ let defaultGlobalConsole: t;
 let makeStandardChannelsConsole: ObjectPrinter.t => t;
 
 /**
- * Output a string or object to standard output. Suitable for writing to logs,
- * or for outputting user messaging in command line applications. If you pass a
- * string, it will not be wrapped in quotes. If you pass an object,
- * `Console.log` will attempt to print the object dynamically. Strings deep in
- * objects will be wrapped in quotes.
+ * Output a string or object to standard output followed by a newline. Suitable
+ * for writing to logs, or for outputting user messaging in command line
+ * applications. If you pass a string, it will not be wrapped in quotes. If you
+ * pass an object, `Console.log` will attempt to print the object dynamically.
+ * Strings deep in objects will be wrapped in quotes.
  */
 let log: 'a => unit;
 
@@ -110,8 +110,11 @@ let log: 'a => unit;
 let out: 'a => unit;
 
 /**
- * Outputs developer-only messaging to standard out. Suitable for writing to
- * log files. In production mode, would typically be suppressed entirely.
+ * Same as `Console.log` but used for developer-facing messaging to standard
+ * out. Suitable for writing to log files. In production mode, would typically
+ * be suppressed entirely. Custom `Console.t` implementations may implement
+ * custom behavior for `Console.debug` that behaves differently from
+ * `Console.log`.
  */
 let debug: 'a => unit;
 

--- a/src/console/library/NativeChannels.re
+++ b/src/console/library/NativeChannels.re
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
+external _out: string => unit = "native_out";
 external _log: string => unit = "native_log";
 external _debug: string => unit = "native_debug";
 external _error: string => unit = "native_error";

--- a/src/console/library/nativeChannels.c
+++ b/src/console/library/nativeChannels.c
@@ -11,30 +11,37 @@
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 
-CAMLprim value native_log(value str)
+CAMLprim value native_out(value str)
 {
   CAMLparam1(str);
   printf("%s", String_val(str));
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value native_log(value str)
+{
+  CAMLparam1(str);
+  printf("%s\n", String_val(str));
   CAMLreturn(Val_unit);
 }
 
 CAMLprim value native_debug(value str)
 {
   CAMLparam1(str);
-  printf("%s", String_val(str));
+  printf("%s\n", String_val(str));
   CAMLreturn(Val_unit);
 }
 
 CAMLprim value native_error(value str)
 {
   CAMLparam1(str);
-  fprintf(stderr, "%s", String_val(str));
+  fprintf(stderr, "%s\n", String_val(str));
   CAMLreturn(Val_unit);
 }
 
 CAMLprim value native_warn(value str)
 {
   CAMLparam1(str);
-  fprintf(stderr, "%s", String_val(str));
+  fprintf(stderr, "%s\n", String_val(str));
   CAMLreturn(Val_unit);
 }

--- a/src/console/library/nativeChannels.js
+++ b/src/console/library/nativeChannels.js
@@ -10,7 +10,7 @@ function native_out(s) {
   // In node, you can omit the newline, but not in the browser.
   if (typeof process != "undefined" &&
     typeof process.stdout != "undefined") {
-    process.stdout.write(s)
+    process.stdout.write(s.c)
   } else {
     joo_global_object.console.log(s.c);
   }

--- a/src/console/library/nativeChannels.js
+++ b/src/console/library/nativeChannels.js
@@ -10,7 +10,7 @@ function native_out(s) {
   // In node, you can omit the newline, but not in the browser.
   if (typeof process != "undefined" &&
     typeof process.stdout != "undefined") {
-    process.stdout.write(s + '\n')
+    process.stdout.write(s)
   } else {
     joo_global_object.console.log(s.c);
   }

--- a/src/console/library/nativeChannels.js
+++ b/src/console/library/nativeChannels.js
@@ -5,6 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+//Provides: native_out
+function native_out(s) {
+  // In node, you can omit the newline, but not in the browser.
+  if (typeof process != "undefined" &&
+    typeof process.stdout != "undefined") {
+    process.stdout.write(s + '\n')
+  } else {
+    joo_global_object.console.log(s.c);
+  }
+}
+
 //Provides: native_log
 function native_log(s) {
   joo_global_object.console.log(s.c);


### PR DESCRIPTION
Summary:Right now, the JS backend will always print newlines even for
Console.out, but in node we have the ability to avoid that.

Test Plan:

Reviewers:kad

CC: