### PR TITLE
Fix ASCII capitalization warning

### DIFF
--- a/src/refmterr/lib/reportWarning.re
+++ b/src/refmterr/lib/reportWarning.re
@@ -46,7 +46,7 @@ module Make = (Styl: Stylish.StylishSig) => {
         sp(
           "File name potentially invalid. The OCaml ecosystem's build systems usually turn file names into module names by simply upper-casing the first letter. In this case, `%s` %s.\nNote: some build systems might e.g. turn kebab-case into CamelCase module, which is why this isn't a hard error.",
           /* "%s\n\n%s 24: \"%s\" isn't a valid file name; OCaml file names are often turned into modules, which need to start with a capitalized letter." */
-          Filename.basename(filePath) |> String.capitalize,
+          Filename.basename(filePath) |> String.capitalize_ascii,
           switch (offendingChar) {
           | Leading(ch) =>
             sp("starts with `%s`, which doesn't form a legal module name", ch)


### PR DESCRIPTION
Compiling refmterr used to generate a warning about `String.capitalize` being deprecated. 

![image](https://user-images.githubusercontent.com/4126319/49837109-15d58980-fd5a-11e8-9d6b-f6052b434d36.png)

This PR fixes that