### PR TITLE
update exclude to reflect rename to Rely, additionally take advantage of matchers directory

### DIFF
--- a/src/rely/library/Rely.re
+++ b/src/rely/library/Rely.re
@@ -138,7 +138,7 @@ module Make = (UserConfig: FrameworkConfig) => {
       module StackTrace =
         StackTrace.Make({
           let baseDir = UserConfig.config.projectDir;
-          let exclude = ["TestRunner.re", "Matcher"];
+          let exclude = ["Rely.re", "matchers/"];
           let formatLink = Pastel.cyan;
           let formatText = Pastel.dim;
         });

--- a/src/rely/test/lib/__snapshots__/FnMatchers.2113922b.0.snapshot
+++ b/src/rely/test/lib/__snapshots__/FnMatchers.2113922b.0.snapshot
@@ -6,34 +6,14 @@ FnMatchers › FnMatchers failure output
 \027[39m\027[22m    \027[2mexpect.fn(\027[22m\027[31mfunction\027[39m\027[2m).toThrow(\027[22m\027[2m)\027[22m
     
     Expected the function to throw an error.
-    But it didn't throw anything.      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+    But it didn't throw anything.
 
 \027[1m\027[31m  \226\128\162 FnMatchers failure output \226\128\186 Expect not to throw and does
 \027[39m\027[22m    \027[2mexpect.fn(\027[22m\027[31mfunction\027[39m\027[2m)toThrow(\027[22m\027[2m)\027[22m
     
     Expected the function not to throw an error.
     Instead, it threw: 
-      \027[31mInvalid_argument(\"the earth is flat\")\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+      \027[31mInvalid_argument(\"the earth is flat\")\027[39m
 
 \027[1m\027[31m  \226\128\162 FnMatchers failure output \226\128\186 Expect the wrong exception
 \027[39m\027[22m    \027[2mexpect.fn(\027[22m\027[31mfunction\027[39m\027[2m).toThrowException(\027[22m\027[32mexception\027[39m\027[2m)\027[22m
@@ -41,31 +21,11 @@ FnMatchers › FnMatchers failure output
     Expected the function to throw an error matching:
       \027[32mInvalid_argument(\"with some other message\")\027[39m
     Instead, it threw:
-      \027[31mInvalid_argument(\"with some message\")\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+      \027[31mInvalid_argument(\"with some message\")\027[39m
 
 \027[1m\027[31m  \226\128\162 FnMatchers failure output \226\128\186 Expect an exception that doesn't throw
 \027[39m\027[22m    \027[2mexpect.fn(\027[22m\027[31mfunction\027[39m\027[2m).toThrowException(\027[22m\027[32mexception\027[39m\027[2m)\027[22m
     
     Expected the function to throw an error matching:
       \027[32mNot_found\027[39m
-    But it didn't throw anything.      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+    But it didn't throw anything.

--- a/src/rely/test/lib/__snapshots__/TestRunner.1e3e5d03.0.snapshot
+++ b/src/rely/test/lib/__snapshots__/TestRunner.1e3e5d03.0.snapshot
@@ -5,32 +5,12 @@ TestRunner › failing tests
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.toBeEmpty
 \027[39m\027[22m    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).toBeEmpty(\027[22m\027[2m)\027[22m
     
-    Received: \027[31m\"foo\"\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+    Received: \027[31m\"foo\"\027[39m
 
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.not.toBeEmpty
 \027[39m\027[22m    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).not.toBeEmpty(\027[22m\027[2m)\027[22m
     
-    Expected value not to be empty, but received: \027[31m\"\"\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+    Expected value not to be empty, but received: \027[31m\"\"\027[39m
 
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.toEqual
 \027[39m\027[22m    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).toEqual(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
@@ -41,17 +21,7 @@ TestRunner › failing tests
       \027[31m\"bacon\"\027[39m
     
     Difference:
-      \027[31mbacon\027[39m\027[32mdelicious\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+      \027[31mbacon\027[39m\027[32mdelicious\027[39m
 
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.not.toEqual
 \027[39m\027[22m    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).not.toEqual(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
@@ -59,17 +29,7 @@ TestRunner › failing tests
     Expected value to not equal:
       \027[32m\"bacon\"\027[39m
     Received:
-      \027[31m\"bacon\"\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+      \027[31m\"bacon\"\027[39m
 
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.toEqualFile\027[39m\027[22m
     Exception \027[2mSys_error(\"tests/testFiles/foo.txt: No such file or directory\")\027[22m
@@ -90,109 +50,39 @@ TestRunner › failing tests
 \027[39m\027[22m    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).toBe(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
     
     Expected: \027[32mtrue\027[39m
-    Received: \027[31mfalse\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+    Received: \027[31mfalse\027[39m
 
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.not.toBe(false)
 \027[39m\027[22m    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).not.toBe(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
     
     Expected: \027[32mfalse\027[39m
-    Received: \027[31mfalse\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+    Received: \027[31mfalse\027[39m
 
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.toBeTrue
 \027[39m\027[22m    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).toBeTrue(\027[22m\027[2m)\027[22m
     
-    Received: \027[31mfalse\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+    Received: \027[31mfalse\027[39m
 
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.not.toBeTrue
 \027[39m\027[22m    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).not.toBeTrue(\027[22m\027[2m)\027[22m
     
-    Received: \027[31mtrue\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+    Received: \027[31mtrue\027[39m
 
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.toBeFalse
 \027[39m\027[22m    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).toBeFalse(\027[22m\027[2m)\027[22m
     
-    Received: \027[31mtrue\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+    Received: \027[31mtrue\027[39m
 
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.not.toBeFalse
 \027[39m\027[22m    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).not.toBeFalse(\027[22m\027[2m)\027[22m
     
-    Received: \027[31mfalse\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+    Received: \027[31mfalse\027[39m
 
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.int.toBe
 \027[39m\027[22m    \027[2mexpect.int(\027[22m\027[31mreceived\027[39m\027[2m).toBe(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
     
     Expected: \027[32m43\027[39m
-    Received: \027[31m42\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+    Received: \027[31m42\027[39m
 
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.toMatchSnapshot mismatch
 \027[39m\027[22m    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).toMatchSnapshot(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
@@ -201,29 +91,9 @@ TestRunner › failing tests
     \027[31m+ bacon3\027[39m
     
     Difference:
-      \027[31mbacon3\027[39m\027[32mbacon2\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+      \027[31mbacon3\027[39m\027[32mbacon2\027[39m
 
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.toMatchSnapshot no snapshot exists
 \027[39m\027[22m    New snapshot was \027[31mnot written\027[39m. The update flag must be explicitly passed to write a new snapshot.
     
-    Received: \027[31mmore bacon!\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+    Received: \027[31mmore bacon!\027[39m

--- a/src/rely/test/lib/__snapshots__/TestRunner.6dcf4d83.0.snapshot
+++ b/src/rely/test/lib/__snapshots__/TestRunner.6dcf4d83.0.snapshot
@@ -11,17 +11,7 @@ TestRunner › exceptions in tests
       \027[31m\"foo\"\027[39m
     
     Difference:
-      \027[31mfoo\027[39m\027[32mbar\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+      \027[31mfoo\027[39m\027[32mbar\027[39m
 
 \027[1m\027[31m  \226\128\162 exceptions in tests \226\128\186 test framework handling of exceptions \226\128\186 uninlineable exception output\027[39m\027[22m
     Exception \027[2mInvalid_argument(\"I'm invalid :(\")\027[22m
@@ -35,7 +25,6 @@ TestRunner › exceptions in tests
       \027[2m171 \226\148\134 \027[22m\027[2m});\027[22m
 
       \027[2mRaised at \027[22m\027[36msrc/rely/test/lib/TestRunner_test.re:168:24\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
 
 \027[1m\027[31m  \226\128\162 exceptions in tests \226\128\186 test framework handling of exceptions \226\128\186 inline exception output\027[39m\027[22m
     Exception \027[2mNot_found\027[22m
@@ -50,4 +39,3 @@ TestRunner › exceptions in tests
 
       \027[2mRaised at \027[22m\027[36msrc/rely/test/lib/TestRunner_test.re:173:24\027[39m\027[2m (inlined)\027[22m
       \027[2mCalled from \027[22m\027[36msrc/rely/test/lib/TestRunner_test.re:175:8\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m

--- a/src/rely/test/lib/__snapshots__/TestRunner.813890c0.0.snapshot
+++ b/src/rely/test/lib/__snapshots__/TestRunner.813890c0.0.snapshot
@@ -11,14 +11,4 @@ TestRunner › mixed tests
       \027[31m\"foo\"\027[39m
     
     Difference:
-      \027[31mfoo\027[39m\027[32mbar\027[39m      \027[2m256 \226\148\134 \027[22m\027[33m\027[2mswitch\027[22m\027[39m\027[2m (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {\027[22m
-      \027[2m257 \226\148\134 \027[22m\027[2m| (messageThunk, true)\027[22m\027[31m\027[2m => \027[22m\027[39m\027[2m()\027[22m
-      \027[2m258 \226\148\134 \027[22m\027[2m| (messageThunk, false) =>\027[22m
-      \027[31m\027[2m259 \226\148\134 \027[22m\027[39m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stackTrace = \027[22m\027[31m\027[1m\027[4mStackTrace.getStackTrace()\027[24m\027[22m\027[39m\027[2m;\027[22m
-      \027[2m260 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m location = \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.getTopLocation(stackTrace);\027[22m
-      \027[2m261 \226\148\134 \027[22m\027[2m  \027[22m\027[35m\027[2mlet\027[22m\027[39m\027[2m stack =\027[22m
-      \027[2m262 \226\148\134 \027[22m\027[2m    \027[22m\027[34m\027[2mStackTrace\027[22m\027[39m\027[2m.stackTraceToString(\027[22m
-
-      \027[2mRaised by primitive operation at \027[22m\027[36msrc/rely/library/Rely.re:259:33\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:285:19\027[39m
-      \027[2mCalled from \027[22m\027[36msrc/rely/library/Rely.re:387:14\027[39m
+      \027[31mfoo\027[39m\027[32mbar\027[39m


### PR DESCRIPTION
@jordwalke noticed that this was a problem, we can do a patch release as well