### PR TITLE
Benderson/failure stack formatting fix

### DIFF
--- a/src/rely/test/exe/dune
+++ b/src/rely/test/exe/dune
@@ -2,6 +2,6 @@
 (executable
    (name TestRely)
    (public_name TestRely.exe)
-   (libraries  rely-test.lib )
+   (libraries rely-test.lib )
    (package rely-test)
 )

--- a/src/rely/test/lib/__snapshots__/FnMatchers.2113922b.0.snapshot
+++ b/src/rely/test/lib/__snapshots__/FnMatchers.2113922b.0.snapshot
@@ -2,29 +2,29 @@ FnMatchers › FnMatchers failure output
 \027[97mFnMatchers failure output\027[39m
 \r[4/4] Pending  \027[2m[0/4] Passed\027[22m  \027[2m[0/4] Failed\027[22m\r[3/4] Pending  \027[2m[0/4] Passed\027[22m  \027[31m[1/4] Failed\027[39m\r[2/4] Pending  \027[2m[0/4] Passed\027[22m  \027[31m[2/4] Failed\027[39m\r[1/4] Pending  \027[2m[0/4] Passed\027[22m  \027[31m[3/4] Failed\027[39m\r\027[2m[0/4] Pending\027[22m  \027[2m[0/4] Passed\027[22m  \027[31m[4/4] Failed\027[39m
 
-\027[1m\027[31m  \226\128\162 FnMatchers failure output \226\128\186 Expect to throw, but doesn't
-\027[39m\027[22m    \027[2mexpect.fn(\027[22m\027[31mfunction\027[39m\027[2m).toThrow(\027[22m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 FnMatchers failure output \226\128\186 Expect to throw, but doesn't\027[39m\027[22m
+    \027[2mexpect.fn(\027[22m\027[31mfunction\027[39m\027[2m).toThrow(\027[22m\027[2m)\027[22m
     
     Expected the function to throw an error.
     But it didn't throw anything.
 
-\027[1m\027[31m  \226\128\162 FnMatchers failure output \226\128\186 Expect not to throw and does
-\027[39m\027[22m    \027[2mexpect.fn(\027[22m\027[31mfunction\027[39m\027[2m)toThrow(\027[22m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 FnMatchers failure output \226\128\186 Expect not to throw and does\027[39m\027[22m
+    \027[2mexpect.fn(\027[22m\027[31mfunction\027[39m\027[2m)toThrow(\027[22m\027[2m)\027[22m
     
     Expected the function not to throw an error.
     Instead, it threw: 
       \027[31mInvalid_argument(\"the earth is flat\")\027[39m
 
-\027[1m\027[31m  \226\128\162 FnMatchers failure output \226\128\186 Expect the wrong exception
-\027[39m\027[22m    \027[2mexpect.fn(\027[22m\027[31mfunction\027[39m\027[2m).toThrowException(\027[22m\027[32mexception\027[39m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 FnMatchers failure output \226\128\186 Expect the wrong exception\027[39m\027[22m
+    \027[2mexpect.fn(\027[22m\027[31mfunction\027[39m\027[2m).toThrowException(\027[22m\027[32mexception\027[39m\027[2m)\027[22m
     
     Expected the function to throw an error matching:
       \027[32mInvalid_argument(\"with some other message\")\027[39m
     Instead, it threw:
       \027[31mInvalid_argument(\"with some message\")\027[39m
 
-\027[1m\027[31m  \226\128\162 FnMatchers failure output \226\128\186 Expect an exception that doesn't throw
-\027[39m\027[22m    \027[2mexpect.fn(\027[22m\027[31mfunction\027[39m\027[2m).toThrowException(\027[22m\027[32mexception\027[39m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 FnMatchers failure output \226\128\186 Expect an exception that doesn't throw\027[39m\027[22m
+    \027[2mexpect.fn(\027[22m\027[31mfunction\027[39m\027[2m).toThrowException(\027[22m\027[32mexception\027[39m\027[2m)\027[22m
     
     Expected the function to throw an error matching:
       \027[32mNot_found\027[39m

--- a/src/rely/test/lib/__snapshots__/TestRunner.1e3e5d03.0.snapshot
+++ b/src/rely/test/lib/__snapshots__/TestRunner.1e3e5d03.0.snapshot
@@ -2,18 +2,18 @@ TestRunner › failing tests
 \027[97mfailing tests\027[39m
 \r[16/16] Pending  \027[2m[0/16] Passed\027[22m  \027[2m[0/16] Failed\027[22m\r[15/16] Pending  \027[2m[0/16] Passed\027[22m  \027[31m[1/16] Failed\027[39m\r[14/16] Pending  \027[2m[0/16] Passed\027[22m  \027[31m[2/16] Failed\027[39m\r[13/16] Pending  \027[2m[0/16] Passed\027[22m  \027[31m[3/16] Failed\027[39m\r[12/16] Pending  \027[2m[0/16] Passed\027[22m  \027[31m[4/16] Failed\027[39m\r[11/16] Pending  \027[2m[0/16] Passed\027[22m  \027[31m[5/16] Failed\027[39m\r[10/16] Pending  \027[2m[0/16] Passed\027[22m  \027[31m[6/16] Failed\027[39m\027[1D\027[K\r[9/16] Pending  \027[2m[0/16] Passed\027[22m  \027[31m[7/16] Failed\027[39m\r[8/16] Pending  \027[2m[0/16] Passed\027[22m  \027[31m[8/16] Failed\027[39m\r[7/16] Pending  \027[2m[0/16] Passed\027[22m  \027[31m[9/16] Failed\027[39m\r[6/16] Pending  \027[2m[0/16] Passed\027[22m  \027[31m[10/16] Failed\027[39m\r[5/16] Pending  \027[2m[0/16] Passed\027[22m  \027[31m[11/16] Failed\027[39m\r[4/16] Pending  \027[2m[0/16] Passed\027[22m  \027[31m[12/16] Failed\027[39m\r[3/16] Pending  \027[2m[0/16] Passed\027[22m  \027[31m[13/16] Failed\027[39m\r[2/16] Pending  \027[2m[0/16] Passed\027[22m  \027[31m[14/16] Failed\027[39m\r[1/16] Pending  \027[2m[0/16] Passed\027[22m  \027[31m[15/16] Failed\027[39m\r\027[2m[0/16] Pending\027[22m  \027[2m[0/16] Passed\027[22m  \027[31m[16/16] Failed\027[39m
 
-\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.toBeEmpty
-\027[39m\027[22m    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).toBeEmpty(\027[22m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.toBeEmpty\027[39m\027[22m
+    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).toBeEmpty(\027[22m\027[2m)\027[22m
     
     Received: \027[31m\"foo\"\027[39m
 
-\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.not.toBeEmpty
-\027[39m\027[22m    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).not.toBeEmpty(\027[22m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.not.toBeEmpty\027[39m\027[22m
+    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).not.toBeEmpty(\027[22m\027[2m)\027[22m
     
     Expected value not to be empty, but received: \027[31m\"\"\027[39m
 
-\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.toEqual
-\027[39m\027[22m    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).toEqual(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.toEqual\027[39m\027[22m
+    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).toEqual(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
     
     Expected value to equal:
       \027[32m\"delicious\"\027[39m
@@ -23,8 +23,8 @@ TestRunner › failing tests
     Difference:
       \027[31mbacon\027[39m\027[32mdelicious\027[39m
 
-\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.not.toEqual
-\027[39m\027[22m    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).not.toEqual(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.not.toEqual\027[39m\027[22m
+    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).not.toEqual(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
     
     Expected value to not equal:
       \027[32m\"bacon\"\027[39m
@@ -35,57 +35,54 @@ TestRunner › failing tests
     Exception \027[2mSys_error(\"tests/testFiles/foo.txt: No such file or directory\")\027[22m
 
 
-
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.not.toEqualFile\027[39m\027[22m
     Exception \027[2mSys_error(\"tests/testFiles/simple.txt: No such file or directory\")\027[22m
-
 
 
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.file.not.toEqualFile\027[39m\027[22m
     Exception \027[2mSys_error(\"tests/testFiles/simple.txt: No such file or directory\")\027[22m
 
 
-
-\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.toBe(true)
-\027[39m\027[22m    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).toBe(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.toBe(true)\027[39m\027[22m
+    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).toBe(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
     
     Expected: \027[32mtrue\027[39m
     Received: \027[31mfalse\027[39m
 
-\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.not.toBe(false)
-\027[39m\027[22m    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).not.toBe(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.not.toBe(false)\027[39m\027[22m
+    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).not.toBe(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
     
     Expected: \027[32mfalse\027[39m
     Received: \027[31mfalse\027[39m
 
-\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.toBeTrue
-\027[39m\027[22m    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).toBeTrue(\027[22m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.toBeTrue\027[39m\027[22m
+    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).toBeTrue(\027[22m\027[2m)\027[22m
     
     Received: \027[31mfalse\027[39m
 
-\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.not.toBeTrue
-\027[39m\027[22m    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).not.toBeTrue(\027[22m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.not.toBeTrue\027[39m\027[22m
+    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).not.toBeTrue(\027[22m\027[2m)\027[22m
     
     Received: \027[31mtrue\027[39m
 
-\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.toBeFalse
-\027[39m\027[22m    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).toBeFalse(\027[22m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.toBeFalse\027[39m\027[22m
+    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).toBeFalse(\027[22m\027[2m)\027[22m
     
     Received: \027[31mtrue\027[39m
 
-\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.not.toBeFalse
-\027[39m\027[22m    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).not.toBeFalse(\027[22m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.not.toBeFalse\027[39m\027[22m
+    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).not.toBeFalse(\027[22m\027[2m)\027[22m
     
     Received: \027[31mfalse\027[39m
 
-\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.int.toBe
-\027[39m\027[22m    \027[2mexpect.int(\027[22m\027[31mreceived\027[39m\027[2m).toBe(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.int.toBe\027[39m\027[22m
+    \027[2mexpect.int(\027[22m\027[31mreceived\027[39m\027[2m).toBe(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
     
     Expected: \027[32m43\027[39m
     Received: \027[31m42\027[39m
 
-\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.toMatchSnapshot mismatch
-\027[39m\027[22m    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).toMatchSnapshot(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.toMatchSnapshot mismatch\027[39m\027[22m
+    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).toMatchSnapshot(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
     
     \027[32m- bacon2\027[39m
     \027[31m+ bacon3\027[39m
@@ -93,7 +90,7 @@ TestRunner › failing tests
     Difference:
       \027[31mbacon3\027[39m\027[32mbacon2\027[39m
 
-\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.toMatchSnapshot no snapshot exists
-\027[39m\027[22m    New snapshot was \027[31mnot written\027[39m. The update flag must be explicitly passed to write a new snapshot.
+\027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.string.toMatchSnapshot no snapshot exists\027[39m\027[22m
+    New snapshot was \027[31mnot written\027[39m. The update flag must be explicitly passed to write a new snapshot.
     
     Received: \027[31mmore bacon!\027[39m

--- a/src/rely/test/lib/__snapshots__/TestRunner.6dcf4d83.0.snapshot
+++ b/src/rely/test/lib/__snapshots__/TestRunner.6dcf4d83.0.snapshot
@@ -2,8 +2,8 @@ TestRunner › exceptions in tests
 \027[97mexceptions in tests \226\128\186 test framework handling of exceptions\027[39m
 \r[3/3] Pending  \027[2m[0/3] Passed\027[22m  \027[2m[0/3] Failed\027[22m\r[2/3] Pending  \027[2m[0/3] Passed\027[22m  \027[31m[1/3] Failed\027[39m\r[1/3] Pending  \027[2m[0/3] Passed\027[22m  \027[31m[2/3] Failed\027[39m\r\027[2m[0/3] Pending\027[22m  \027[2m[0/3] Passed\027[22m  \027[31m[3/3] Failed\027[39m
 
-\027[1m\027[31m  \226\128\162 exceptions in tests \226\128\186 test framework handling of exceptions \226\128\186 normal failure
-\027[39m\027[22m    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).toEqual(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 exceptions in tests \226\128\186 test framework handling of exceptions \226\128\186 normal failure\027[39m\027[22m
+    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).toEqual(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
     
     Expected value to equal:
       \027[32m\"bar\"\027[39m

--- a/src/rely/test/lib/__snapshots__/TestRunner.813890c0.0.snapshot
+++ b/src/rely/test/lib/__snapshots__/TestRunner.813890c0.0.snapshot
@@ -2,8 +2,8 @@ TestRunner › mixed tests
 \027[97mmixed tests \226\128\186 Inner describe 1\027[39m
 \r[3/3] Pending  \027[2m[0/3] Passed\027[22m  \027[2m[0/3] Failed\027[22m\r[2/3] Pending  \027[2m[1/3] Passed\027[22m  \027[2m[0/3] Failed\027[22m\r[1/3] Pending  \027[2m[1/3] Passed\027[22m  \027[31m[1/3] Failed\027[39m\r\027[2m[0/3] Pending\027[22m  \027[2m[2/3] Passed\027[22m  \027[31m[1/3] Failed\027[39m
 
-\027[1m\027[31m  \226\128\162 mixed tests \226\128\186 Inner describe 1 \226\128\186 Inner test 2
-\027[39m\027[22m    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).toEqual(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
+\027[1m\027[31m  \226\128\162 mixed tests \226\128\186 Inner describe 1 \226\128\186 Inner test 2\027[39m\027[22m
+    \027[2mexpect.string(\027[22m\027[31mreceived\027[39m\027[2m).toEqual(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
     
     Expected value to equal:
       \027[32m\"bar\"\027[39m

--- a/src/rely/test/lib/dune
+++ b/src/rely/test/lib/dune
@@ -4,5 +4,5 @@
    (public_name rely-test.lib)
    ; the linkall flag is used to ensure that all tests are compiled and properly registered with the TestFramework
    (ocamlopt_flags -linkall -g)
-   (libraries  rely.lib )
+   (libraries rely.lib )
 )


### PR DESCRIPTION
Unfortunately file context for test failure isn't working in the Rely tests, however it works for Pastel for some reason (even though the dune files seem to be configured the same) so we didn't have test cases/I tried to add some but still ran into file context for test failure not working in the Rely test lib.

before:
![image](https://user-images.githubusercontent.com/5252755/49974154-d4291800-feec-11e8-82d8-1a44cf4bd25a.png)
after:
![image](https://user-images.githubusercontent.com/5252755/49974159-d7bc9f00-feec-11e8-916e-d3f4e986a3c7.png)
