### PR TITLE
Benderson/not matcher hint formatting fix

### DIFF
--- a/src/rely/matchers/MatcherUtils.re
+++ b/src/rely/matchers/MatcherUtils.re
@@ -69,9 +69,9 @@ let matcherHint =
       [
         Pastel.dim(String.concat("", ["expect", expectType, "("])),
         receivedColor(received),
-        Pastel.dim(
-          String.concat("", [")", isNot ? ".not" : "", matcherName, "("]),
-        ),
+        isNot ?
+          Pastel.dim(").") ++ "not" ++ Pastel.dim(matcherName ++ "(") :
+          Pastel.dim(String.concat("", [")", matcherName, "("])),
         expectedColor(expected),
         Pastel.dim(")"),
       ],

--- a/tests/__snapshots__/TestRunner.1e3e5d03.0.snapshot
+++ b/tests/__snapshots__/TestRunner.1e3e5d03.0.snapshot
@@ -55,7 +55,7 @@ Running 1 test suite
 
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.not.toBe(false)\027[39m\027[22m
 
-    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).not.toBe(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
+    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).\027[22mnot\027[2m.toBe(\027[22m\027[32mexpected\027[39m\027[2m)\027[22m
     
     Expected: \027[32mfalse\027[39m
     Received: \027[31mfalse\027[39m
@@ -68,7 +68,7 @@ Running 1 test suite
 
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.not.toBeTrue\027[39m\027[22m
 
-    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).not.toBeTrue(\027[22m\027[2m)\027[22m
+    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).\027[22mnot\027[2m.toBeTrue(\027[22m\027[2m)\027[22m
     
     Received: \027[31mtrue\027[39m
 
@@ -80,7 +80,7 @@ Running 1 test suite
 
 \027[1m\027[31m  \226\128\162 failing tests \226\128\186 expect.bool.not.toBeFalse\027[39m\027[22m
 
-    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).not.toBeFalse(\027[22m\027[2m)\027[22m
+    \027[2mexpect.bool(\027[22m\027[31mreceived\027[39m\027[2m).\027[22mnot\027[2m.toBeFalse(\027[22m\027[2m)\027[22m
     
     Received: \027[31mfalse\027[39m
 


### PR DESCRIPTION
Jest doesn't dim "not" in their failure messages, we were, this fixes that

after
![image](https://user-images.githubusercontent.com/5252755/50315764-e36a1180-0468-11e9-8079-3b6786cbccc0.png)

Targeting custom-matchers for compatibility with snapshot changes (and too lazy to do some rebasing to target the reporters branch instead)
