### PR TITLE
float matchers

### DIFF
--- a/src/rely/matchers/DefaultMatchers.re
+++ b/src/rely/matchers/DefaultMatchers.re
@@ -8,6 +8,7 @@ open StringMatchers;
 open BoolMatchers;
 open SnapshotMatchers;
 open IntMatchers;
+open FloatMatchers;
 open FnMatchers;
 open MatcherTypes;
 
@@ -17,6 +18,7 @@ type matchers('ext) = {
   lines: list(string) => stringMatchersWithNot,
   bool: bool => boolMatchersWithNot,
   int: int => intMatchersWithNot,
+  float: float => floatMatchersWithNot,
   fn: 'a. (unit => 'a) => fnMatchersWithNot,
   ext: 'ext
 };
@@ -34,6 +36,7 @@ let makeDefaultMatchers = (utils, snapshotMatcher, makeMatchers) => {
   },
   bool: b => BoolMatchers.makeMatchers(".bool", utils, b),
   int: i => IntMatchers.makeMatchers(".int", utils, i),
+  float: f => FloatMatchers.makeMatchers(".float", utils, f),
   fn: f => FnMatchers.makeMatchers(".fn", utils, f),
   ext: makeMatchers(utils)
 };

--- a/src/rely/matchers/DefaultMatchers.re
+++ b/src/rely/matchers/DefaultMatchers.re
@@ -20,7 +20,7 @@ type matchers('ext) = {
   int: int => intMatchersWithNot,
   float: float => floatMatchersWithNot,
   fn: 'a. (unit => 'a) => fnMatchersWithNot,
-  ext: 'ext
+  ext: 'ext,
 };
 
 let makeDefaultMatchers = (utils, snapshotMatcher, makeMatchers) => {
@@ -38,5 +38,5 @@ let makeDefaultMatchers = (utils, snapshotMatcher, makeMatchers) => {
   int: i => IntMatchers.makeMatchers(".int", utils, i),
   float: f => FloatMatchers.makeMatchers(".float", utils, f),
   fn: f => FnMatchers.makeMatchers(".fn", utils, f),
-  ext: makeMatchers(utils)
+  ext: makeMatchers(utils),
 };

--- a/src/rely/matchers/FloatMatchers.re
+++ b/src/rely/matchers/FloatMatchers.re
@@ -25,12 +25,12 @@ let makeMatchers = (accessorPath, {createMatcher}) => {
         ) => {
         let (digits, expected) = expectedThunk();
         let actual = actualThunk();
-        let precision = (10.0 ** float_of_int(-digits)) /. 2.0;
+        let precision = 10.0 ** float_of_int(- digits) /. 2.0;
 
         let actualEqualsExpected = abs_float(actual -. expected) < precision;
 
         let pass =
-          (actualEqualsExpected && !isNot) || (!actualEqualsExpected && isNot);
+          actualEqualsExpected && !isNot || !actualEqualsExpected && isNot;
         if (!pass) {
           let message =
             String.concat(
@@ -61,7 +61,8 @@ let makeMatchers = (accessorPath, {createMatcher}) => {
       });
 
     let makeFloatMatchers = isNot => {
-      toBeCloseTo: (~digits=2, expected) => toBeCloseTo(isNot, () => actual, () => (digits, expected)),
+      toBeCloseTo: (~digits=2, expected) =>
+        toBeCloseTo(isNot, () => actual, () => (digits, expected)),
     };
 
     let floatMatchers = makeFloatMatchers(false);

--- a/src/rely/matchers/FloatMatchers.re
+++ b/src/rely/matchers/FloatMatchers.re
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+open MatcherTypes;
+
+type floatMatchers = {toBeCloseTo: (~digits: int=?, float) => unit};
+type floatMatchersWithNot = {
+  toBeCloseTo: (~digits: int=?, float) => unit,
+  not: floatMatchers,
+};
+
+let passMessageThunk = () => "";
+
+let makeMatchers = (accessorPath, {createMatcher}) => {
+  let createFloatMatchers = actual => {
+    let toBeCloseTo = isNot =>
+      createMatcher(
+        (
+          {matcherHint, formatReceived, formatExpected},
+          actualThunk,
+          expectedThunk,
+        ) => {
+        let (digits, expected) = expectedThunk();
+        let actual = actualThunk();
+        let precision = (10.0 ** float_of_int(-digits)) /. 2.0;
+
+        let actualEqualsExpected = abs_float(actual -. expected) < precision;
+
+        let pass =
+          (actualEqualsExpected && !isNot) || (!actualEqualsExpected && isNot);
+        if (!pass) {
+          let message =
+            String.concat(
+              "",
+              [
+                matcherHint(
+                  ~expectType=accessorPath,
+                  ~matcherName=".toBeCloseTo",
+                  ~isNot,
+                  ~expected="expected, precision",
+                  (),
+                ),
+                "\n\n",
+                "Precision: ",
+                formatExpected(string_of_int(digits)) ++ "-digit",
+                "\n",
+                "Expected: ",
+                formatExpected(string_of_float(expected)),
+                "\n",
+                "Received: ",
+                formatReceived(string_of_float(actual)),
+              ],
+            );
+          (() => message, pass);
+        } else {
+          (passMessageThunk, pass);
+        };
+      });
+
+    let makeFloatMatchers = isNot => {
+      toBeCloseTo: (~digits=2, expected) => toBeCloseTo(isNot, () => actual, () => (digits, expected)),
+    };
+
+    let floatMatchers = makeFloatMatchers(false);
+    {not: makeFloatMatchers(true), toBeCloseTo: floatMatchers.toBeCloseTo};
+  };
+  createFloatMatchers;
+};

--- a/tests/__snapshots__/FloatMatchers.56a40b03.0.snapshot
+++ b/tests/__snapshots__/FloatMatchers.56a40b03.0.snapshot
@@ -1,0 +1,7 @@
+FloatMatchers › failure output .toBeCloseTo
+Running 1 test suite
+\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m \027[97mfailure output .toBeCloseTo\027[39m\027[72D\027[K\027[32m\027[1m\027[7m PASS \027[27m\027[22m\027[39m \027[97mfailure output .toBeCloseTo\027[39m
+
+\027[97m\027[1mTest Suites: \027[22m\027[39m0 failed, \027[32m\027[1m1 passed\027[22m\027[39m, 1 total
+\027[97m\027[1mTests:       \027[22m\027[39m0 failed, \027[32m\027[1m2 passed\027[22m\027[39m, 2 total
+

--- a/tests/__snapshots__/FloatMatchers.db4be1fd.0.snapshot
+++ b/tests/__snapshots__/FloatMatchers.db4be1fd.0.snapshot
@@ -1,0 +1,71 @@
+FloatMatchers › failure output .not.toBeCloseTo
+Running 1 test suite
+\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m \027[97mfailure output .not.toBeCloseTo\027[39m\027[76D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m \027[97mfailure output .not.toBeCloseTo\027[39m
+\027[1m\027[31m  \226\128\162 failure output .not.toBeCloseTo \226\128\186 0. should not be close to 0. with precision 0\027[39m\027[22m
+
+    \027[2mexpect.float(\027[22m\027[31mreceived\027[39m\027[2m).\027[22mnot\027[2m.toBeCloseTo(\027[22m\027[32mexpected, precision\027[39m\027[2m)\027[22m
+    
+    Precision: \027[32m0\027[39m-digit
+    Expected: \027[32m0.\027[39m
+    Received: \027[31m0.\027[39m
+
+\027[1m\027[31m  \226\128\162 failure output .not.toBeCloseTo \226\128\186 1. should not be close to 0.96 with precision 1\027[39m\027[22m
+
+    \027[2mexpect.float(\027[22m\027[31mreceived\027[39m\027[2m).\027[22mnot\027[2m.toBeCloseTo(\027[22m\027[32mexpected, precision\027[39m\027[2m)\027[22m
+    
+    Precision: \027[32m1\027[39m-digit
+    Expected: \027[32m0.96\027[39m
+    Received: \027[31m1.\027[39m
+
+\027[1m\027[31m  \226\128\162 failure output .not.toBeCloseTo \226\128\186 1. should not be close to 0.996 with precision 2\027[39m\027[22m
+
+    \027[2mexpect.float(\027[22m\027[31mreceived\027[39m\027[2m).\027[22mnot\027[2m.toBeCloseTo(\027[22m\027[32mexpected, precision\027[39m\027[2m)\027[22m
+    
+    Precision: \027[32m2\027[39m-digit
+    Expected: \027[32m0.996\027[39m
+    Received: \027[31m1.\027[39m
+
+\027[1m\027[31m  \226\128\162 failure output .not.toBeCloseTo \226\128\186 1. should not be close to 0.9996 with precision 3\027[39m\027[22m
+
+    \027[2mexpect.float(\027[22m\027[31mreceived\027[39m\027[2m).\027[22mnot\027[2m.toBeCloseTo(\027[22m\027[32mexpected, precision\027[39m\027[2m)\027[22m
+    
+    Precision: \027[32m3\027[39m-digit
+    Expected: \027[32m0.9996\027[39m
+    Received: \027[31m1.\027[39m
+
+\027[1m\027[31m  \226\128\162 failure output .not.toBeCloseTo \226\128\186 1. should not be close to 0.9995 with precision 3\027[39m\027[22m
+
+    \027[2mexpect.float(\027[22m\027[31mreceived\027[39m\027[2m).\027[22mnot\027[2m.toBeCloseTo(\027[22m\027[32mexpected, precision\027[39m\027[2m)\027[22m
+    
+    Precision: \027[32m3\027[39m-digit
+    Expected: \027[32m0.9995\027[39m
+    Received: \027[31m1.\027[39m
+
+\027[1m\027[31m  \226\128\162 failure output .not.toBeCloseTo \226\128\186 0. should not be close to 0.1 with precision 0\027[39m\027[22m
+
+    \027[2mexpect.float(\027[22m\027[31mreceived\027[39m\027[2m).\027[22mnot\027[2m.toBeCloseTo(\027[22m\027[32mexpected, precision\027[39m\027[2m)\027[22m
+    
+    Precision: \027[32m0\027[39m-digit
+    Expected: \027[32m0.1\027[39m
+    Received: \027[31m0.\027[39m
+
+\027[1m\027[31m  \226\128\162 failure output .not.toBeCloseTo \226\128\186 0. should not be close to 0.0001 with precision 3\027[39m\027[22m
+
+    \027[2mexpect.float(\027[22m\027[31mreceived\027[39m\027[2m).\027[22mnot\027[2m.toBeCloseTo(\027[22m\027[32mexpected, precision\027[39m\027[2m)\027[22m
+    
+    Precision: \027[32m3\027[39m-digit
+    Expected: \027[32m0.0001\027[39m
+    Received: \027[31m0.\027[39m
+
+\027[1m\027[31m  \226\128\162 failure output .not.toBeCloseTo \226\128\186 0. should not be close to 4e-06 with precision 5\027[39m\027[22m
+
+    \027[2mexpect.float(\027[22m\027[31mreceived\027[39m\027[2m).\027[22mnot\027[2m.toBeCloseTo(\027[22m\027[32mexpected, precision\027[39m\027[2m)\027[22m
+    
+    Precision: \027[32m5\027[39m-digit
+    Expected: \027[32m4e-06\027[39m
+    Received: \027[31m0.\027[39m
+
+
+\027[97m\027[1mTest Suites: \027[22m\027[39m\027[31m\027[1m1 failed\027[22m\027[39m, 0 passed, 1 total
+\027[97m\027[1mTests:       \027[22m\027[39m\027[31m\027[1m8 failed\027[22m\027[39m, 0 passed, 8 total
+

--- a/tests/__tests__/rely/FloatMatchers_test.re
+++ b/tests/__tests__/rely/FloatMatchers_test.re
@@ -26,63 +26,74 @@ describe("FloatMatchers", describeUtils => {
        )
      );
 
-    let customPrecisionTestCases = [
-        (0.0, 0.0, 0),
-        (1.0, 0.96, 1),
-        (1.0, 0.996, 2),
-        (1.0, 0.9996, 3),
-        (1.0, 0.9995, 3),
-        (0.0, 0.1, 0),
-        (0.0, 0.0001, 3),
-        (0.0, 0.000004, 5)
-    ];
+  let customPrecisionTestCases = [
+    (0.0, 0.0, 0),
+    (1.0, 0.96, 1),
+    (1.0, 0.996, 2),
+    (1.0, 0.9996, 3),
+    (1.0, 0.9995, 3),
+    (0.0, 0.1, 0),
+    (0.0, 0.0001, 3),
+    (0.0, 0.000004, 5),
+  ];
 
+  customPrecisionTestCases
+  |> List.iter(((f1, f2, precision)) =>
+       test(
+         string_of_float(f1)
+         ++ " should be close to "
+         ++ string_of_float(f2)
+         ++ " with precision "
+         ++ string_of_int(precision),
+         ({expect}) =>
+         expect.float(f1).toBeCloseTo(~digits=precision, f2)
+       )
+     );
+
+  let notToBeCloseToCases = [(0.0, 1.0, 0), (1.0, 0.95, 1)];
+
+  notToBeCloseToCases
+  |> List.iter(((f1, f2, precision)) =>
+       test(
+         string_of_float(f1)
+         ++ " should not be close to "
+         ++ string_of_float(f2)
+         ++ " with precision "
+         ++ string_of_int(precision),
+         ({expect}) =>
+         expect.float(f1).not.toBeCloseTo(~digits=precision, f2)
+       )
+     );
+
+  testRunnerOutputSnapshotTest(
+    "failure output .not.toBeCloseTo", describeUtils, ({test}) =>
     customPrecisionTestCases
-    |> List.iter(((f1, f2, precision)) => test(
-        string_of_float(f1) ++ " should be close to " ++ string_of_float(f2) ++ " with precision " ++ string_of_int(precision),
-        ({expect}) =>
-            expect.float(f1).toBeCloseTo(~digits=precision, f2)
-        )
-    );
+    |> List.iter(((f1, f2, precision)) =>
+         test(
+           string_of_float(f1)
+           ++ " should not be close to "
+           ++ string_of_float(f2)
+           ++ " with precision "
+           ++ string_of_int(precision),
+           ({expect}) =>
+           expect.float(f1).not.toBeCloseTo(~digits=precision, f2)
+         )
+       )
+  );
 
-    let notToBeCloseToCases = [
-        (0.0, 1.0, 0),
-        (1.0, 0.95, 1),
-    ];
-
+  testRunnerOutputSnapshotTest(
+    "failure output .toBeCloseTo", describeUtils, ({test}) =>
     notToBeCloseToCases
-    |> List.iter(((f1, f2, precision)) => test(
-        string_of_float(f1) ++ " should not be close to " ++ string_of_float(f2) ++ " with precision " ++ string_of_int(precision),
-        ({expect}) =>
-            expect.float(f1).not.toBeCloseTo(~digits=precision, f2)
-        )
-    );
-
-    testRunnerOutputSnapshotTest(
-        "failure output .not.toBeCloseTo",
-        describeUtils,
-        ({test}) => {
-            customPrecisionTestCases
-            |> List.iter(((f1, f2, precision)) => test(
-                string_of_float(f1) ++ " should not be close to " ++ string_of_float(f2) ++ " with precision " ++ string_of_int(precision),
-                ({expect}) =>
-                    expect.float(f1).not.toBeCloseTo(~digits=precision, f2)
-                )
-            );
-        }
-    );
-
-    testRunnerOutputSnapshotTest(
-        "failure output .toBeCloseTo",
-        describeUtils,
-        ({test}) => {
-            notToBeCloseToCases
-            |> List.iter(((f1, f2, precision)) => test(
-                string_of_float(f1) ++ " should be close to " ++ string_of_float(f2) ++ " with precision " ++ string_of_int(precision),
-                ({expect}) =>
-                    expect.float(f1).not.toBeCloseTo(~digits=precision, f2)
-                )
-            );
-        }
-    );
+    |> List.iter(((f1, f2, precision)) =>
+         test(
+           string_of_float(f1)
+           ++ " should be close to "
+           ++ string_of_float(f2)
+           ++ " with precision "
+           ++ string_of_int(precision),
+           ({expect}) =>
+           expect.float(f1).not.toBeCloseTo(~digits=precision, f2)
+         )
+       )
+  );
 });

--- a/tests/__tests__/rely/FloatMatchers_test.re
+++ b/tests/__tests__/rely/FloatMatchers_test.re
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+open TestFramework;
+open TestRunnerOutputSnapshotTest;
+
+describe("FloatMatchers", describeUtils => {
+  let test = describeUtils.test;
+  let defaultPrecisionTestCases = [
+    (0.0, 0.0),
+    (0.0, 0.001),
+    (1.23, 1.229),
+    (1.23, 1.226),
+    (1.23, 1.225),
+    (1.23, 1.234),
+  ];
+  defaultPrecisionTestCases
+  |> List.iter(((f1, f2)) =>
+       test(
+         string_of_float(f1) ++ " should be close to " ++ string_of_float(f2),
+         ({expect}) =>
+         expect.float(f1).toBeCloseTo(f2)
+       )
+     );
+
+    let customPrecisionTestCases = [
+        (0.0, 0.0, 0),
+        (1.0, 0.96, 1),
+        (1.0, 0.996, 2),
+        (1.0, 0.9996, 3),
+        (1.0, 0.9995, 3),
+        (0.0, 0.1, 0),
+        (0.0, 0.0001, 3),
+        (0.0, 0.000004, 5)
+    ];
+
+    customPrecisionTestCases
+    |> List.iter(((f1, f2, precision)) => test(
+        string_of_float(f1) ++ " should be close to " ++ string_of_float(f2) ++ " with precision " ++ string_of_int(precision),
+        ({expect}) =>
+            expect.float(f1).toBeCloseTo(~digits=precision, f2)
+        )
+    );
+
+    let notToBeCloseToCases = [
+        (0.0, 1.0, 0),
+        (1.0, 0.95, 1),
+    ];
+
+    notToBeCloseToCases
+    |> List.iter(((f1, f2, precision)) => test(
+        string_of_float(f1) ++ " should not be close to " ++ string_of_float(f2) ++ " with precision " ++ string_of_int(precision),
+        ({expect}) =>
+            expect.float(f1).not.toBeCloseTo(~digits=precision, f2)
+        )
+    );
+
+    testRunnerOutputSnapshotTest(
+        "failure output .not.toBeCloseTo",
+        describeUtils,
+        ({test}) => {
+            customPrecisionTestCases
+            |> List.iter(((f1, f2, precision)) => test(
+                string_of_float(f1) ++ " should not be close to " ++ string_of_float(f2) ++ " with precision " ++ string_of_int(precision),
+                ({expect}) =>
+                    expect.float(f1).not.toBeCloseTo(~digits=precision, f2)
+                )
+            );
+        }
+    );
+
+    testRunnerOutputSnapshotTest(
+        "failure output .toBeCloseTo",
+        describeUtils,
+        ({test}) => {
+            notToBeCloseToCases
+            |> List.iter(((f1, f2, precision)) => test(
+                string_of_float(f1) ++ " should be close to " ++ string_of_float(f2) ++ " with precision " ++ string_of_int(precision),
+                ({expect}) =>
+                    expect.float(f1).not.toBeCloseTo(~digits=precision, f2)
+                )
+            );
+        }
+    );
+});


### PR DESCRIPTION
Add float matchers. Same implementation/API as jest/the internal FB jest wrapper

![image](https://user-images.githubusercontent.com/5252755/50316025-d26dd000-0469-11e9-8274-e6278603b529.png)

Targeting not-matcher-hint branch for snapshot compatibility