### PR TITLE
use Filename.dirname(__FILE__) for more resilient filtering

### DIFF
--- a/src/rely/Rely.re
+++ b/src/rely/Rely.re
@@ -69,7 +69,7 @@ module Make = (UserConfig: FrameworkConfig) => {
   module StackTrace =
     StackTrace.Make({
       let baseDir = UserConfig.config.projectDir;
-      let exclude = ["Rely.re", "matchers/"];
+      let exclude = [Filename.dirname(__FILE__)];
       let formatLink = Pastel.cyan;
       let formatText = Pastel.dim;
     });

--- a/src/rely/Rely.re
+++ b/src/rely/Rely.re
@@ -69,7 +69,7 @@ module Make = (UserConfig: FrameworkConfig) => {
   module StackTrace =
     StackTrace.Make({
       let baseDir = UserConfig.config.projectDir;
-      let exclude = [Filename.dirname(__FILE__)];
+      let exclude = [Filename.dirname(__FILE__) ++ Filename.dir_sep];
       let formatLink = Pastel.cyan;
       let formatText = Pastel.dim;
     });


### PR DESCRIPTION
We had a rename bug when we renamed TestRunner to Rely, this should prevent such things in the future and just automatically exclude all of the files in the Rely directory from stack traces which should prevent a category of bad user experience.