### PR TITLE
TestSkip

### DIFF
--- a/src/rely/Rely.rei
+++ b/src/rely/Rely.rei
@@ -8,13 +8,18 @@ module Test: {
   type testUtils('ext) = {expect: DefaultMatchers.matchers('ext)};
   type testFn('ext) = (string, testUtils('ext) => unit) => unit;
 };
+
 module Describe: {
   type describeUtils('ext) = {
     describe: describeFn('ext),
     test: Test.testFn('ext),
+    testSkip: Test.testFn('ext),
   }
   and describeFn('ext) = (string, describeUtils('ext) => unit) => unit;
 };
+
+module Reporter = Reporter;
+module TestResult = TestResult;
 
 module RunConfig: {
   type printer = {
@@ -27,6 +32,7 @@ module RunConfig: {
   let initialize: unit => t;
   let updateSnapshots: (bool, t) => t;
   let printer_internal_do_not_use: (printer, t) => t;
+  let internal_reporters_api_do_not_use: (Reporter.t, t) => t;
   let onTestFrameworkFailure: (unit => unit, t) => t;
 };
 

--- a/src/rely/RunConfig.re
+++ b/src/rely/RunConfig.re
@@ -48,6 +48,11 @@ module RunConfig = {
     ],
   };
 
+  let internal_reporters_api_do_not_use = (reporter: Reporter.t, config) => {
+    ...config,
+    reporters: [reporter],
+  };
+
   let onTestFrameworkFailure = (onTestFrameworkFailure, config) => {
     ...config,
     onTestFrameworkFailure,

--- a/src/rely/TestResult.re
+++ b/src/rely/TestResult.re
@@ -128,11 +128,11 @@ module AggregatedResult = {
 
   let addTestSuiteResult =
       (testSuiteResult: TestSuiteResult.t, aggregatedResult) => {
-    let wasSuiteSkipped =
+    let didSuiteSkip =
       testSuiteResult.numSkippedTests
       == List.length(testSuiteResult.testResults);
     let didSuiteFail = testSuiteResult.numFailedTests > 0;
-    let didSuitePass = !didSuiteFail && !wasSuiteSkipped;
+    let didSuitePass = !didSuiteFail && !didSuiteSkip;
     {
       numFailedTests:
         aggregatedResult.numFailedTests + testSuiteResult.numFailedTests,
@@ -146,7 +146,7 @@ module AggregatedResult = {
       numSkippedTests:
         aggregatedResult.numSkippedTests + testSuiteResult.numSkippedTests,
       numSkippedTestSuites:
-        aggregatedResult.numSkippedTestSuites + (wasSuiteSkipped ? 1 : 0),
+        aggregatedResult.numSkippedTestSuites + (didSuiteSkip ? 1 : 0),
       numTotalTests:
         aggregatedResult.numTotalTests
         + testSuiteResult.numPassedTests

--- a/src/rely/TestResult.re
+++ b/src/rely/TestResult.re
@@ -8,6 +8,7 @@ open Common.Collections;
 
 type status =
   | Passed
+  | Skipped
   | Failed(string, option(Printexc.location), string)
   | Exception(exn, option(Printexc.location), string);
 
@@ -48,6 +49,7 @@ module TestSuiteResult = {
   type t = {
     numFailedTests: int,
     numPassedTests: int,
+    numSkippedTests: int,
     testResults: list(testResult),
     displayName: string,
   };
@@ -58,12 +60,14 @@ module TestSuiteResult = {
 
     let numFailedTests = ref(0);
     let numPassedTests = ref(0);
+    let numSkippedTests = ref(0);
     let aggregateTestResults = ref(testResults);
 
     List.iter(
       r => {
         numFailedTests := numFailedTests^ + r.numFailedTests;
         numPassedTests := numPassedTests^ + r.numPassedTests;
+        numSkippedTests := numSkippedTests^ + r.numSkippedTests;
         aggregateTestResults := aggregateTestResults^ @ r.testResults;
       },
       childResults,
@@ -75,12 +79,14 @@ module TestSuiteResult = {
         | Passed => incr(numPassedTests)
         | Failed(_, _, _)
         | Exception(_, _, _) => incr(numFailedTests)
+        | Skipped => incr(numSkippedTests)
         },
       testResults,
     );
     {
       numFailedTests: numFailedTests^,
       numPassedTests: numPassedTests^,
+      numSkippedTests: numSkippedTests^,
       testResults: aggregateTestResults^,
       displayName: path |> TestPath.describeToString,
     };
@@ -94,6 +100,8 @@ module AggregatedResult = {
     numPassedTests: int,
     numPassedTestSuites: int,
     numPendingTestSuites: int,
+    numSkippedTests: int,
+    numSkippedTestSuites: int,
     numTotalTests: int,
     numTotalTestSuites: int,
     snapshotSummary: option(snapshotSummary),
@@ -108,6 +116,8 @@ module AggregatedResult = {
     numPassedTests: 0,
     numPassedTestSuites: 0,
     numPendingTestSuites: numTestSuites,
+    numSkippedTests: 0,
+    numSkippedTestSuites: 0,
     numTotalTests: 0,
     numTotalTestSuites: numTestSuites,
     snapshotSummary: None,
@@ -118,21 +128,30 @@ module AggregatedResult = {
 
   let addTestSuiteResult =
       (testSuiteResult: TestSuiteResult.t, aggregatedResult) => {
-    let didSuitePass = testSuiteResult.numFailedTests == 0;
+    let wasSuiteSkipped =
+      testSuiteResult.numSkippedTests
+      == List.length(testSuiteResult.testResults);
+    let didSuiteFail = testSuiteResult.numFailedTests > 0;
+    let didSuitePass = !didSuiteFail && !wasSuiteSkipped;
     {
       numFailedTests:
         aggregatedResult.numFailedTests + testSuiteResult.numFailedTests,
       numFailedTestSuites:
-        aggregatedResult.numFailedTestSuites + (didSuitePass ? 0 : 1),
+        aggregatedResult.numFailedTestSuites + (didSuiteFail ? 1 : 0),
       numPassedTests:
         aggregatedResult.numPassedTests + testSuiteResult.numPassedTests,
       numPassedTestSuites:
         aggregatedResult.numPassedTestSuites + (didSuitePass ? 1 : 0),
       numPendingTestSuites: aggregatedResult.numPendingTestSuites - 1,
+      numSkippedTests:
+        aggregatedResult.numSkippedTests + testSuiteResult.numSkippedTests,
+      numSkippedTestSuites:
+        aggregatedResult.numSkippedTestSuites + (wasSuiteSkipped ? 1 : 0),
       numTotalTests:
         aggregatedResult.numTotalTests
         + testSuiteResult.numPassedTests
-        + testSuiteResult.numFailedTests,
+        + testSuiteResult.numFailedTests
+        + testSuiteResult.numSkippedTests,
       numTotalTestSuites: aggregatedResult.numTotalTestSuites,
       testSuiteResults: aggregatedResult.testSuiteResults @ [testSuiteResult],
       snapshotSummary: aggregatedResult.snapshotSummary,

--- a/tests/__tests__/rely/AggregateResult_test.re
+++ b/tests/__tests__/rely/AggregateResult_test.re
@@ -1,0 +1,407 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+open TestFramework;
+
+type singleSuiteInput = {
+  name: string,
+  numPassingTests: int,
+  numFailingTests: int,
+  numSkippedTests: int,
+};
+
+type multipleSuiteInput = {
+  name: string,
+  testSuites: list(TestSuite.t),
+};
+
+type singleSuiteExpectedOutput = {
+  numPassedTests: int,
+  numFailedTests: int,
+  numSkippedTests: int,
+  numPassedTestSuites: int,
+  numPendingTestSuites: int,
+  numTotalTests: int,
+  numTotalTestSuites: int,
+  numSkippedTestSuites: int,
+  numFailedTestSuites: int,
+};
+
+describe("Rely AggregateResult", ({describe, test}) => {
+  describe("Single suite cases", ({test}) => {
+    let singleSuiteInput = (passing, failing, skipped) => {
+      let name =
+        String.concat(
+          ", ",
+          [
+            string_of_int(passing) ++ " passing tests",
+            string_of_int(failing) ++ " failing tests",
+            string_of_int(skipped) ++ " skipped tests",
+          ],
+        );
+      {
+        name,
+        numPassingTests: passing,
+        numFailingTests: failing,
+        numSkippedTests: skipped,
+      };
+    };
+    let singleSuiteTestCases = [
+      (
+        {
+          name: "single skipped test",
+          numPassingTests: 0,
+          numFailingTests: 0,
+          numSkippedTests: 1,
+        },
+        {
+          numPassedTestSuites: 0,
+          numPendingTestSuites: 0,
+          numTotalTests: 1,
+          numTotalTestSuites: 1,
+          numSkippedTestSuites: 1,
+          numFailedTestSuites: 0,
+          numPassedTests: 0,
+          numFailedTests: 0,
+          numSkippedTests: 1,
+        },
+      ),
+      (
+        {
+          name: "single passing test",
+          numPassingTests: 1,
+          numFailingTests: 0,
+          numSkippedTests: 0,
+        },
+        {
+          numPassedTestSuites: 1,
+          numPendingTestSuites: 0,
+          numTotalTests: 1,
+          numTotalTestSuites: 1,
+          numSkippedTestSuites: 0,
+          numFailedTestSuites: 0,
+          numPassedTests: 1,
+          numFailedTests: 0,
+          numSkippedTests: 0,
+        },
+      ),
+      (
+        {
+          name: "single failing test",
+          numPassingTests: 0,
+          numFailingTests: 1,
+          numSkippedTests: 0,
+        },
+        {
+          numPassedTestSuites: 0,
+          numPendingTestSuites: 0,
+          numTotalTests: 1,
+          numTotalTestSuites: 1,
+          numSkippedTestSuites: 0,
+          numFailedTestSuites: 1,
+          numPassedTests: 0,
+          numFailedTests: 1,
+          numSkippedTests: 0,
+        },
+      ),
+      (
+        singleSuiteInput(1, 10, 100),
+        {
+          numPassedTestSuites: 0,
+          numPendingTestSuites: 0,
+          numTotalTests: 111,
+          numTotalTestSuites: 1,
+          numSkippedTestSuites: 0,
+          numFailedTestSuites: 1,
+          numPassedTests: 1,
+          numFailedTests: 10,
+          numSkippedTests: 100,
+        },
+      ),
+      (
+        singleSuiteInput(1, 100, 10),
+        {
+          numPassedTestSuites: 0,
+          numPendingTestSuites: 0,
+          numTotalTests: 111,
+          numTotalTestSuites: 1,
+          numSkippedTestSuites: 0,
+          numFailedTestSuites: 1,
+          numPassedTests: 1,
+          numFailedTests: 100,
+          numSkippedTests: 10,
+        },
+      ),
+      (
+        singleSuiteInput(10, 1, 100),
+        {
+          numPassedTestSuites: 0,
+          numPendingTestSuites: 0,
+          numTotalTests: 111,
+          numTotalTestSuites: 1,
+          numSkippedTestSuites: 0,
+          numFailedTestSuites: 1,
+          numPassedTests: 10,
+          numFailedTests: 1,
+          numSkippedTests: 100,
+        },
+      ),
+      (
+        singleSuiteInput(10, 100, 1),
+        {
+          numPassedTestSuites: 0,
+          numPendingTestSuites: 0,
+          numTotalTests: 111,
+          numTotalTestSuites: 1,
+          numSkippedTestSuites: 0,
+          numFailedTestSuites: 1,
+          numPassedTests: 10,
+          numFailedTests: 100,
+          numSkippedTests: 1,
+        },
+      ),
+      (
+        singleSuiteInput(100, 1, 10),
+        {
+          numPassedTestSuites: 0,
+          numPendingTestSuites: 0,
+          numTotalTests: 111,
+          numTotalTestSuites: 1,
+          numSkippedTestSuites: 0,
+          numFailedTestSuites: 1,
+          numPassedTests: 100,
+          numFailedTests: 1,
+          numSkippedTests: 10,
+        },
+      ),
+      (
+        singleSuiteInput(100, 10, 1),
+        {
+          numPassedTestSuites: 0,
+          numPendingTestSuites: 0,
+          numTotalTests: 111,
+          numTotalTestSuites: 1,
+          numSkippedTestSuites: 0,
+          numFailedTestSuites: 1,
+          numPassedTests: 100,
+          numFailedTests: 10,
+          numSkippedTests: 1,
+        },
+      ),
+      (
+        singleSuiteInput(100, 0, 1),
+        {
+          numPassedTestSuites: 1,
+          numPendingTestSuites: 0,
+          numTotalTests: 101,
+          numTotalTestSuites: 1,
+          numSkippedTestSuites: 0,
+          numFailedTestSuites: 0,
+          numPassedTests: 100,
+          numFailedTests: 0,
+          numSkippedTests: 1,
+        },
+      ),
+    ];
+    let testSingleSuite = ((input: singleSuiteInput, expectedOutput)) =>
+      test(
+        input.name,
+        ({expect}) => {
+          open Rely.TestResult.AggregatedResult;
+          let aggregatedResult =
+            ref({
+              numFailedTests: 0,
+              numFailedTestSuites: 0,
+              numPassedTests: 0,
+              numPassedTestSuites: 0,
+              numPendingTestSuites: 0,
+              numSkippedTests: 0,
+              numSkippedTestSuites: 0,
+              numTotalTests: 0,
+              numTotalTestSuites: 0,
+              snapshotSummary: None,
+              testSuiteResults: [],
+            });
+
+          let testSuites = [
+            TestSuite.(
+              init(input.name)
+              |> withSkippedTests(input.numSkippedTests)
+              |> withPassingTests(input.numPassingTests)
+              |> withFailingTests(input.numFailingTests)
+            ),
+          ];
+          module Reporter =
+            TestReporter.Make({});
+          Reporter.onRunComplete(res => aggregatedResult := res);
+
+          TestSuiteRunner.run(testSuites, Reporter.reporter);
+          let actualOutput = {
+            numPassedTestSuites: aggregatedResult^.numPassedTestSuites,
+            numPendingTestSuites: aggregatedResult^.numPendingTestSuites,
+            numTotalTests: aggregatedResult^.numTotalTests,
+            numTotalTestSuites: aggregatedResult^.numTotalTestSuites,
+            numSkippedTestSuites: aggregatedResult^.numSkippedTestSuites,
+            numFailedTestSuites: aggregatedResult^.numFailedTestSuites,
+            numPassedTests: aggregatedResult^.numPassedTests,
+            numFailedTests: aggregatedResult^.numFailedTests,
+            numSkippedTests: aggregatedResult^.numSkippedTests,
+          };
+
+          expect.bool(actualOutput == expectedOutput).toBeTrue();
+        },
+      );
+    singleSuiteTestCases |> List.iter(testSingleSuite);
+  });
+
+  describe("Multiple suite cases", ({test}) => {
+    let singletonPassingTestSuite =
+      TestSuite.(init("passing") |> withPassingTests(1));
+    let singletonFailingTestSuite =
+      TestSuite.(init("failing") |> withFailingTests(1));
+    let singletonSkippedTestSuite =
+      TestSuite.(init("skipped") |> withSkippedTests(1));
+
+    let repeatHelper = (el, n, l) =>
+      switch (n) {
+      | n when n <= 0 => l
+      | n => l @ [el]
+      };
+    let repeat = (el, n) => repeatHelper(el, n, []);
+
+    let singletonSuiteTestCase = (passing, failing, skipped) => {
+      let name =
+        String.concat(
+          ", ",
+          [
+            string_of_int(passing) ++ " passing test suites",
+            string_of_int(failing) ++ " failing test suites",
+            string_of_int(skipped) ++ " skipped test suites",
+          ],
+        );
+      let testSuites =
+        repeat(singletonPassingTestSuite, passing)
+        @ repeat(singletonFailingTestSuite, failing)
+        @ repeat(singletonSkippedTestSuite, skipped);
+      {name, testSuites};
+    };
+
+    let testCases = [
+      (
+        {testSuites: [], name: "no test suites"},
+        {
+          numPassedTests: 0,
+          numFailedTests: 0,
+          numSkippedTests: 0,
+          numPassedTestSuites: 0,
+          numPendingTestSuites: 0,
+          numTotalTests: 0,
+          numTotalTestSuites: 0,
+          numSkippedTestSuites: 0,
+          numFailedTestSuites: 0,
+        },
+      ),
+      (
+        singletonSuiteTestCase(1, 0, 1),
+        {
+          numPassedTests: 1,
+          numFailedTests: 0,
+          numSkippedTests: 1,
+          numPassedTestSuites: 1,
+          numPendingTestSuites: 0,
+          numTotalTests: 2,
+          numTotalTestSuites: 2,
+          numSkippedTestSuites: 1,
+          numFailedTestSuites: 0,
+        },
+      ),
+      (
+        singletonSuiteTestCase(1, 1, 0),
+        {
+          numPassedTests: 1,
+          numFailedTests: 1,
+          numSkippedTests: 0,
+          numPassedTestSuites: 1,
+          numPendingTestSuites: 0,
+          numTotalTests: 2,
+          numTotalTestSuites: 2,
+          numSkippedTestSuites: 0,
+          numFailedTestSuites: 1,
+        },
+      ),
+      (
+        singletonSuiteTestCase(0, 1, 1),
+        {
+          numPassedTests: 0,
+          numFailedTests: 1,
+          numSkippedTests: 1,
+          numPassedTestSuites: 0,
+          numPendingTestSuites: 0,
+          numTotalTests: 2,
+          numTotalTestSuites: 2,
+          numSkippedTestSuites: 1,
+          numFailedTestSuites: 1,
+        },
+      ),
+      (
+        singletonSuiteTestCase(1, 1, 1),
+        {
+          numPassedTests: 1,
+          numFailedTests: 1,
+          numSkippedTests: 1,
+          numPassedTestSuites: 1,
+          numPendingTestSuites: 0,
+          numTotalTests: 3,
+          numTotalTestSuites: 3,
+          numSkippedTestSuites: 1,
+          numFailedTestSuites: 1,
+        },
+      ),
+    ];
+
+    let runTestCases = ((input, expectedOutput)) =>
+      test(
+        input.name,
+        ({expect}) => {
+          open Rely.TestResult.AggregatedResult;
+          let aggregatedResult =
+            ref({
+              numFailedTests: 0,
+              numFailedTestSuites: 0,
+              numPassedTests: 0,
+              numPassedTestSuites: 0,
+              numPendingTestSuites: 0,
+              numSkippedTests: 0,
+              numSkippedTestSuites: 0,
+              numTotalTests: 0,
+              numTotalTestSuites: 0,
+              snapshotSummary: None,
+              testSuiteResults: [],
+            });
+
+          module Reporter =
+            TestReporter.Make({});
+          Reporter.onRunComplete(res => aggregatedResult := res);
+
+          TestSuiteRunner.run(input.testSuites, Reporter.reporter);
+          let actualOutput = {
+            numPassedTestSuites: aggregatedResult^.numPassedTestSuites,
+            numPendingTestSuites: aggregatedResult^.numPendingTestSuites,
+            numTotalTests: aggregatedResult^.numTotalTests,
+            numTotalTestSuites: aggregatedResult^.numTotalTestSuites,
+            numSkippedTestSuites: aggregatedResult^.numSkippedTestSuites,
+            numFailedTestSuites: aggregatedResult^.numFailedTestSuites,
+            numPassedTests: aggregatedResult^.numPassedTests,
+            numFailedTests: aggregatedResult^.numFailedTests,
+            numSkippedTests: aggregatedResult^.numSkippedTests,
+          };
+
+          expect.bool(actualOutput == expectedOutput).toBeTrue();
+        },
+      );
+    testCases |> List.iter(runTestCases);
+  });
+});

--- a/tests/__tests__/rely/CustomMatchers_test.re
+++ b/tests/__tests__/rely/CustomMatchers_test.re
@@ -10,358 +10,356 @@ open Rely.MatcherTypes;
 
 let basePrinter = Console.ObjectPrinter.base;
 
- module User = {
-   type universe =
-     | Facebook
-     | Instagram
-     | Oculus
-     | Unknown;
-   type t('a) = {
-     name: string,
-     universe,
-     age: int,
-     data: 'a,
-   };
-   let universeToString = universe =>
-     switch (universe) {
-     | Facebook => "Facebook"
-     | Instagram => "Instagram"
-     | Oculus => "Oculus"
-     | Unknown => "Unknown"
-     };
-   /*
-    * Custom matchers and related logic should be separated into a separate
-    * Test module for the structure.
-    */
-   module Test = {
-     /*
-      * Define all the relevant structures. Use of `.not` must be manually
-      * defined, like in this example.
-      */
-     type matchers('a) = {
-       inFacebook: unit => unit,
-       inInstagram: unit => unit,
-       inOculus: unit => unit,
-       toHaveData: 'a => unit,
-     };
-     type matchersWithNot('a) = {
-       not: matchers('a),
-       inFacebook: unit => unit,
-       inInstagram: unit => unit,
-       inOculus: unit => unit,
-       toHaveData: 'a => unit,
-       toHaveAge: (~olderThan: int, ~youngerThan: int) => unit,
-     };
-     /*
-      * This is the type of `.ext`, (short for extensions) that will eventually
-      * get exposed via `expect.ext` in tests.
-      */
-     type ext = {user: 'a. t('a) => matchersWithNot('a)};
-     /*
-      * This is a function that will get access to some utilities defined in
-      * FB.Test, it will use the utilities to create register matchers and
-      * then return the extension object, `.ext`.
-      */
-     let matchers = ({createMatcher}) => {
-       let noError = () => "";
-       /*
-        * IMPORTANT: Due to how the types are inferred matchers need to be
-        * created within this function, after the first "argument" is passed
-        * to the matcher. Otherwise you may get weird errors about types
-        * being less general than required, or that types can't be inferred.
-        */
-       let user = user => {
+module User = {
+  type universe =
+    | Facebook
+    | Instagram
+    | Oculus
+    | Unknown;
+  type t('a) = {
+    name: string,
+    universe,
+    age: int,
+    data: 'a,
+  };
+  let universeToString = universe =>
+    switch (universe) {
+    | Facebook => "Facebook"
+    | Instagram => "Instagram"
+    | Oculus => "Oculus"
+    | Unknown => "Unknown"
+    };
+  /*
+   * Custom matchers and related logic should be separated into a separate
+   * Test module for the structure.
+   */
+  module Test = {
+    /*
+     * Define all the relevant structures. Use of `.not` must be manually
+     * defined, like in this example.
+     */
+    type matchers('a) = {
+      inFacebook: unit => unit,
+      inInstagram: unit => unit,
+      inOculus: unit => unit,
+      toHaveData: 'a => unit,
+    };
+    type matchersWithNot('a) = {
+      not: matchers('a),
+      inFacebook: unit => unit,
+      inInstagram: unit => unit,
+      inOculus: unit => unit,
+      toHaveData: 'a => unit,
+      toHaveAge: (~olderThan: int, ~youngerThan: int) => unit,
+    };
+    /*
+     * This is the type of `.ext`, (short for extensions) that will eventually
+     * get exposed via `expect.ext` in tests.
+     */
+    type ext = {user: 'a. t('a) => matchersWithNot('a)};
+    /*
+     * This is a function that will get access to some utilities defined in
+     * FB.Test, it will use the utilities to create register matchers and
+     * then return the extension object, `.ext`.
+     */
+    let matchers = ({createMatcher}) => {
+      let noError = () => "";
+      /*
+       * IMPORTANT: Due to how the types are inferred matchers need to be
+       * created within this function, after the first "argument" is passed
+       * to the matcher. Otherwise you may get weird errors about types
+       * being less general than required, or that types can't be inferred.
+       */
+      let user = user => {
         let dataToString = basePrinter.polymorphicPrint(basePrinter);
-         /* We will generalize the universe matchers */
-         let createUniverseMatcher = (~isNot, expectedUniverse) => {
-           let expectedUniverseString = universeToString(expectedUniverse);
-           createMatcher((_, actualThunk, _) => {
-               /*
-                * The actual and expected values are all wrapped in thunks,
-                * functions that accept no arguments and return a value. This
-                * allows matchers to be more general and include things like named
-                * arguments, we just place a burden on the matchers that they
-                * must package and unpackage the arguments via thunks.
-                */
-               let actual = actualThunk();
-               let result =
-                 if (isNot) {
-                   /* We expect the universes to not be equal */
-                   if (actual.universe === expectedUniverse) {
-                     (
-                       () =>
-                         "Expected user to not be in the "
-                         ++ expectedUniverseString
-                         ++ " universe",
-                       false,
-                     );
-                   } else {
-                     (noError, true);
-                   };
-                 } else if
-                   /* We expect the universes to be equal */
-                   (actual.universe !== expectedUniverse) {
-                   (
-                     () =>
-                       "Expected user to be in the "
-                       ++ expectedUniverseString
-                       ++ " universe, but user was in the "
-                       ++ universeToString(actual.universe)
-                       ++ " universe",
-                     false,
-                   );
-                 } else {
-                   (noError, true);
-                 };
-               result;
-             },
-           );
-         };
-         let notInFacebook = createUniverseMatcher(~isNot=true, Facebook);
-         let notInInstagram = createUniverseMatcher(~isNot=true, Instagram);
-         let notInOculus = createUniverseMatcher(~isNot=true, Oculus);
-         let inFacebook = createUniverseMatcher(~isNot=false, Facebook);
-         let inInstagram = createUniverseMatcher(~isNot=false, Instagram);
-         let inOculus = createUniverseMatcher(~isNot=false, Oculus);
-         /* Generalize the data matcher */
-         let createDataMatcher = (~isNot) => {
-           createMatcher((_, actualThunk, expectedThunk) => {
-             let actual = actualThunk();
-             let expected = expectedThunk();
-             let result =
-               if (isNot) {
-                 /* Error case, data should not equal what was given. */
-                 if (actual.data == expected) {
-                   (
-                     () =>
-                       "Expected user not to have the data:\n  "
-                       ++ dataToString(expected),
-                     false,
-                   );
-                 } else {
-                   (noError, true);
-                 };
-               } else {
-                 ();
-                 /* Error case, data should be equal to what was given. */
-                 if (actual.data != expected) {
-                   (
-                     () =>
-                       "Expected user to have the data:\n  "
-                       ++ dataToString(expected)
-                       ++ "\nBut data was\n  "
-                       ++ dataToString(actual.data),
-                     false,
-                   );
-                 } else {
-                   (noError, true);
-                 };
-               };
-             result;
-           });
-         };
-         let notToHaveData = createDataMatcher(~isNot=true);
-         let toHaveData = createDataMatcher(~isNot=false);
-         let toHaveAge =
-           createMatcher((_, actualThunk, expectedThunk) => {
-             let user = actualThunk();
-             /*
-              * This is an example of using thunks to unpackage the named
-              * arguments for `toHaveAge`. This tuple is tied exactly to the
-              * structure that is build below. It doesn't have to be a tuple, it
-              * could be any single value. If this were more complex a record
-              * might be more appropriate.
-              */
-             let (olderThan, youngerThan) = expectedThunk();
-             let result =
-               if (user.age < olderThan) {
-                 (
-                   () =>
-                     "Expected user to be older than:\n  "
-                     ++ string_of_int(olderThan)
-                     ++ "\nBut user was\n  "
-                     ++ string_of_int(user.age),
-                   false,
-                 );
-               } else if (user.age > youngerThan) {
-                 (
-                   () =>
-                     "Expected user to be younger than:\n  "
-                     ++ string_of_int(youngerThan)
-                     ++ "\nBut user was\n  "
-                     ++ string_of_int(user.age),
-                   false,
-                 );
-               } else {
-                 (noError, true);
-               };
-             result;
-           });
-         /*
-          * Now we build the actual extensions structure. Here we pass in
-          * thunks to the result of our createMatcher calls above. This is how
-          * we package up actual and expected values in a general way.
-          */
-         let matchers = {
-           not: {
-             inFacebook: () => notInFacebook(() => user, () => ()),
-             inInstagram: () => notInInstagram(() => user, () => ()),
-             inOculus: () => notInOculus(() => user, () => ()),
-             toHaveData: expected => notToHaveData(() => user, () => expected),
-           },
-           inFacebook: () => inFacebook(() => user, () => ()),
-           inInstagram: () => inInstagram(() => user, () => ()),
-           inOculus: () => inOculus(() => user, () => ()),
-           toHaveData: expected => toHaveData(() => user, () => expected),
-           /*
-            * This is where we accept the named arguments and then package them
-            * into a thunk that can be unpackaged later on.
-            */
-           toHaveAge: (~olderThan, ~youngerThan) =>
-             toHaveAge(() => user, () => (olderThan, youngerThan)),
-         };
-         matchers;
-       };
-       let ext = {user: user};
-       ext;
-     };
-   };
- };
+        /* We will generalize the universe matchers */
+        let createUniverseMatcher = (~isNot, expectedUniverse) => {
+          let expectedUniverseString = universeToString(expectedUniverse);
+          createMatcher((_, actualThunk, _) => {
+            /*
+             * The actual and expected values are all wrapped in thunks,
+             * functions that accept no arguments and return a value. This
+             * allows matchers to be more general and include things like named
+             * arguments, we just place a burden on the matchers that they
+             * must package and unpackage the arguments via thunks.
+             */
+            let actual = actualThunk();
+            let result =
+              if (isNot) {
+                /* We expect the universes to not be equal */
+                if (actual.universe === expectedUniverse) {
+                  (
+                    () =>
+                      "Expected user to not be in the "
+                      ++ expectedUniverseString
+                      ++ " universe",
+                    false,
+                  );
+                } else {
+                  (noError, true);
+                };
+              } else if
+                /* We expect the universes to be equal */
+                (actual.universe !== expectedUniverse) {
+                (
+                  () =>
+                    "Expected user to be in the "
+                    ++ expectedUniverseString
+                    ++ " universe, but user was in the "
+                    ++ universeToString(actual.universe)
+                    ++ " universe",
+                  false,
+                );
+              } else {
+                (noError, true);
+              };
+            result;
+          });
+        };
+        let notInFacebook = createUniverseMatcher(~isNot=true, Facebook);
+        let notInInstagram = createUniverseMatcher(~isNot=true, Instagram);
+        let notInOculus = createUniverseMatcher(~isNot=true, Oculus);
+        let inFacebook = createUniverseMatcher(~isNot=false, Facebook);
+        let inInstagram = createUniverseMatcher(~isNot=false, Instagram);
+        let inOculus = createUniverseMatcher(~isNot=false, Oculus);
+        /* Generalize the data matcher */
+        let createDataMatcher = (~isNot) =>
+          createMatcher((_, actualThunk, expectedThunk) => {
+            let actual = actualThunk();
+            let expected = expectedThunk();
+            let result =
+              if (isNot) {
+                /* Error case, data should not equal what was given. */
+                if (actual.data == expected) {
+                  (
+                    () =>
+                      "Expected user not to have the data:\n  "
+                      ++ dataToString(expected),
+                    false,
+                  );
+                } else {
+                  (noError, true);
+                };
+              } else {
+                ();
+                /* Error case, data should be equal to what was given. */
+                if (actual.data != expected) {
+                  (
+                    () =>
+                      "Expected user to have the data:\n  "
+                      ++ dataToString(expected)
+                      ++ "\nBut data was\n  "
+                      ++ dataToString(actual.data),
+                    false,
+                  );
+                } else {
+                  (noError, true);
+                };
+              };
+            result;
+          });
+        let notToHaveData = createDataMatcher(~isNot=true);
+        let toHaveData = createDataMatcher(~isNot=false);
+        let toHaveAge =
+          createMatcher((_, actualThunk, expectedThunk) => {
+            let user = actualThunk();
+            /*
+             * This is an example of using thunks to unpackage the named
+             * arguments for `toHaveAge`. This tuple is tied exactly to the
+             * structure that is build below. It doesn't have to be a tuple, it
+             * could be any single value. If this were more complex a record
+             * might be more appropriate.
+             */
+            let (olderThan, youngerThan) = expectedThunk();
+            let result =
+              if (user.age < olderThan) {
+                (
+                  () =>
+                    "Expected user to be older than:\n  "
+                    ++ string_of_int(olderThan)
+                    ++ "\nBut user was\n  "
+                    ++ string_of_int(user.age),
+                  false,
+                );
+              } else if (user.age > youngerThan) {
+                (
+                  () =>
+                    "Expected user to be younger than:\n  "
+                    ++ string_of_int(youngerThan)
+                    ++ "\nBut user was\n  "
+                    ++ string_of_int(user.age),
+                  false,
+                );
+              } else {
+                (noError, true);
+              };
+            result;
+          });
+        /*
+         * Now we build the actual extensions structure. Here we pass in
+         * thunks to the result of our createMatcher calls above. This is how
+         * we package up actual and expected values in a general way.
+         */
+        let matchers = {
+          not: {
+            inFacebook: () => notInFacebook(() => user, () => ()),
+            inInstagram: () => notInInstagram(() => user, () => ()),
+            inOculus: () => notInOculus(() => user, () => ()),
+            toHaveData: expected => notToHaveData(() => user, () => expected),
+          },
+          inFacebook: () => inFacebook(() => user, () => ()),
+          inInstagram: () => inInstagram(() => user, () => ()),
+          inOculus: () => inOculus(() => user, () => ()),
+          toHaveData: expected => toHaveData(() => user, () => expected),
+          /*
+           * This is where we accept the named arguments and then package them
+           * into a thunk that can be unpackaged later on.
+           */
+          toHaveAge: (~olderThan, ~youngerThan) =>
+            toHaveAge(() => user, () => (olderThan, youngerThan)),
+        };
+        matchers;
+      };
+      let ext = {user: user};
+      ext;
+    };
+  };
+};
 
- /*
-  * This is typically where the normal test code would start. The structure and
-  * matchers would be defined externally and reused across many test files.
-  */
- open User;
+/*
+ * This is typically where the normal test code would start. The structure and
+ * matchers would be defined externally and reused across many test files.
+ */
+open User;
 
- let describe = extendDescribe(User.Test.matchers);
+let describe = extendDescribe(User.Test.matchers);
 
- /* Alice is a Facebook user with string data. */
- let alice = {
-   name: "Alice",
-   universe: Facebook,
-   age: 25,
-   data: "some random string data",
- };
+/* Alice is a Facebook user with string data. */
+let alice = {
+  name: "Alice",
+  universe: Facebook,
+  age: 25,
+  data: "some random string data",
+};
 
- /* Bob is an Oculus user with int data. */
- let bob = {name: "Bob", universe: Oculus, age: 30, data: 42};
+/* Bob is an Oculus user with int data. */
+let bob = {name: "Bob", universe: Oculus, age: 30, data: 42};
 
- describe("Custom Matchers", ({test}) => {
-   test("Alice tests", ({expect}) => {
-     expect.ext.user(alice).inFacebook();
-     expect.ext.user(alice).not.inInstagram();
-     expect.ext.user(alice).not.inOculus();
-     expect.ext.user(alice).toHaveData("some random string data");
-     expect.ext.user(alice).not.toHaveData("the wrong data");
-     expect.ext.user(alice).toHaveAge(~olderThan=18, ~youngerThan=65);
-     /* A non-custom test could be */
-     expect.string(alice.data).toEqual("some random string data");
-   });
-   test("Bob tests", ({expect}) => {
-     expect.ext.user(bob).not.inFacebook();
-     expect.ext.user(bob).not.inInstagram();
-     expect.ext.user(bob).inOculus();
-     expect.ext.user(bob).toHaveData(42);
-     expect.ext.user(bob).not.toHaveData(100);
-     expect.ext.user(bob).toHaveAge(~olderThan=18, ~youngerThan=65);
-     /* A non-custom test could be */
-     expect.int(bob.data).toBe(42);
-   });
-   test("Alice invalid tests", ({expect}) => {
-     expect.ext.user(alice).inFacebook();
-     expect.ext.user(alice).not.inOculus();
-     /* This test fails at compile time, Alice has string not int data. */
-     /* expect.ext.user(alice).toHaveData(1); */
-     /* These tests fails at run time with helpful error messages. */
-     /* expect.ext.user(alice).not.inFacebook(); */
-     /* expect.ext.user(alice).inOculus(); */
-     /* expect.ext.user(alice).toHaveData("the wrong data"); */
-     /* expect.ext.user(alice).toHaveAge(~olderThan=50, ~youngerThan=65); */
-     ();
-   });
-   test("Bob invalid tests", ({expect}) => {
-     expect.ext.user(bob).not.inFacebook();
-     expect.ext.user(bob).inOculus();
-     /* This test fails at compile time, Bob has int not string data. */
-     /* expect.ext.user(bob).toHaveData("string data"); */
-     /* These tests fails at run time with helpful error messages. */
-     /* expect.ext.user(bob).inFacebook(); */
-     /* expect.ext.user(bob).not.inOculus(); */
-     /* expect.ext.user(bob).toHaveData(100); */
-     /* expect.ext.user(bob).toHaveAge(~olderThan=18, ~youngerThan=22); */
-     ();
-   });
- });
+describe("Custom Matchers", ({test}) => {
+  test("Alice tests", ({expect}) => {
+    expect.ext.user(alice).inFacebook();
+    expect.ext.user(alice).not.inInstagram();
+    expect.ext.user(alice).not.inOculus();
+    expect.ext.user(alice).toHaveData("some random string data");
+    expect.ext.user(alice).not.toHaveData("the wrong data");
+    expect.ext.user(alice).toHaveAge(~olderThan=18, ~youngerThan=65);
+    /* A non-custom test could be */
+    expect.string(alice.data).toEqual("some random string data");
+  });
+  test("Bob tests", ({expect}) => {
+    expect.ext.user(bob).not.inFacebook();
+    expect.ext.user(bob).not.inInstagram();
+    expect.ext.user(bob).inOculus();
+    expect.ext.user(bob).toHaveData(42);
+    expect.ext.user(bob).not.toHaveData(100);
+    expect.ext.user(bob).toHaveAge(~olderThan=18, ~youngerThan=65);
+    /* A non-custom test could be */
+    expect.int(bob.data).toBe(42);
+  });
+  test("Alice invalid tests", ({expect}) => {
+    expect.ext.user(alice).inFacebook();
+    expect.ext.user(alice).not.inOculus();
+    /* This test fails at compile time, Alice has string not int data. */
+    /* expect.ext.user(alice).toHaveData(1); */
+    /* These tests fails at run time with helpful error messages. */
+    /* expect.ext.user(alice).not.inFacebook(); */
+    /* expect.ext.user(alice).inOculus(); */
+    /* expect.ext.user(alice).toHaveData("the wrong data"); */
+    /* expect.ext.user(alice).toHaveAge(~olderThan=50, ~youngerThan=65); */
+    ();
+  });
+  test("Bob invalid tests", ({expect}) => {
+    expect.ext.user(bob).not.inFacebook();
+    expect.ext.user(bob).inOculus();
+    /* This test fails at compile time, Bob has int not string data. */
+    /* expect.ext.user(bob).toHaveData("string data"); */
+    /* These tests fails at run time with helpful error messages. */
+    /* expect.ext.user(bob).inFacebook(); */
+    /* expect.ext.user(bob).not.inOculus(); */
+    /* expect.ext.user(bob).toHaveData(100); */
+    /* expect.ext.user(bob).toHaveAge(~olderThan=18, ~youngerThan=22); */
+    ();
+  });
+});
 
- /*
-  * Let's pretend like there is another custom set of matchers for "Accounts"
-  * rather than users. How can we compose the matchers and use both?
-  */
- module Account = {
-   module Test = {
-     /*
-      * We will just steal the same types so we don't have to implement more
-      * matchers. This could be an entirely different set of matchers.
-      */
-     type ext = {account: 'a. User.t('a) => User.Test.matchersWithNot('a)};
-     let matchers = utils => {
-       let userExt = User.Test.matchers(utils);
-       let ext = {account: userExt.user};
-       ext;
-     };
-   };
- };
+/*
+ * Let's pretend like there is another custom set of matchers for "Accounts"
+ * rather than users. How can we compose the matchers and use both?
+ */
+module Account = {
+  module Test = {
+    /*
+     * We will just steal the same types so we don't have to implement more
+     * matchers. This could be an entirely different set of matchers.
+     */
+    type ext = {account: 'a. User.t('a) => User.Test.matchersWithNot('a)};
+    let matchers = utils => {
+      let userExt = User.Test.matchers(utils);
+      let ext = {account: userExt.user};
+      ext;
+    };
+  };
+};
 
- /*
-  * We can switch over to using the Account matchers, and prevent the usage of
-  * the User matchers. This is typically recommended and sufficient. It's not
-  * necessary to combine the custom matchers and use them within the same
-  * describe block.
-  */
- let describe = extendDescribe(Account.Test.matchers);
+/*
+ * We can switch over to using the Account matchers, and prevent the usage of
+ * the User matchers. This is typically recommended and sufficient. It's not
+ * necessary to combine the custom matchers and use them within the same
+ * describe block.
+ */
+let describe = extendDescribe(Account.Test.matchers);
 
- describe("Separate type of Custom Matchers", ({test}) => {
-   test("Alice tests", ({expect}) => {
-     expect.ext.account(alice).inFacebook();
-     expect.ext.account(alice).not.inOculus();
-     /* We can use account, but not user anymore: */
-     /* expect.ext.user(alice).inFacebook(); */
-     ();
-   });
-   ();
- });
+describe("Separate type of Custom Matchers", ({test}) => {
+  test("Alice tests", ({expect}) => {
+    expect.ext.account(alice).inFacebook();
+    expect.ext.account(alice).not.inOculus();
+    /* We can use account, but not user anymore: */
+    /* expect.ext.user(alice).inFacebook(); */
+    ();
+  });
+  ();
+});
 
- /*
-  * If you really need to combine matchers you can do so like this. It does
-  * require duplicating the types of the other defined matchers.
-  *
-  * If there are sets of custom matchers that are frequently used together, it's
-  * okay to define them in the same place even if the structures are logically
-  * unique. Then this combining step can be avoided.
-  */
- module Combined = {
-   type ext = {
-     account: 'a. User.t('a) => User.Test.matchersWithNot('a),
-     user: 'a. User.t('a) => User.Test.matchersWithNot('a),
-   };
-   let matchers = utils => {
-     let accountExt = Account.Test.matchers(utils);
-     let userExt = User.Test.matchers(utils);
-     let ext = {account: accountExt.account, user: userExt.user};
-     ext;
-   };
- };
+/*
+ * If you really need to combine matchers you can do so like this. It does
+ * require duplicating the types of the other defined matchers.
+ *
+ * If there are sets of custom matchers that are frequently used together, it's
+ * okay to define them in the same place even if the structures are logically
+ * unique. Then this combining step can be avoided.
+ */
+module Combined = {
+  type ext = {
+    account: 'a. User.t('a) => User.Test.matchersWithNot('a),
+    user: 'a. User.t('a) => User.Test.matchersWithNot('a),
+  };
+  let matchers = utils => {
+    let accountExt = Account.Test.matchers(utils);
+    let userExt = User.Test.matchers(utils);
+    let ext = {account: accountExt.account, user: userExt.user};
+    ext;
+  };
+};
 
- /* Use the combined matchers */
- let describe = extendDescribe(Combined.matchers);
+/* Use the combined matchers */
+let describe = extendDescribe(Combined.matchers);
 
- describe("Combined Custom Matchers", ({test}) => {
-   test("Alice tests", ({expect}) => {
-     /* Now we can use both account and user! */
-     expect.ext.account(alice).inFacebook();
-     expect.ext.account(alice).not.inOculus();
-     expect.ext.user(alice).toHaveData("some random string data");
-   });
-   ();
- });
+describe("Combined Custom Matchers", ({test}) => {
+  test("Alice tests", ({expect}) => {
+    /* Now we can use both account and user! */
+    expect.ext.account(alice).inFacebook();
+    expect.ext.account(alice).not.inOculus();
+    expect.ext.user(alice).toHaveData("some random string data");
+  });
+  ();
+});

--- a/tests/__tests__/rely/TestReporter.re
+++ b/tests/__tests__/rely/TestReporter.re
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+open Rely.Reporter;
+
+module type TestReporter = {let reporter: Rely.Reporter.t;};
+
+module Make = (()) => {
+  let reporterInternal =
+    ref({
+      onTestSuiteStart: _ => (),
+      onTestSuiteResult: (_, _, _) => (),
+      onRunStart: _ => (),
+      onRunComplete: _ => (),
+    });
+
+  let wasOnRunStartCalled = ref(false);
+  let wasOnRunCompleteCalled = ref(false);
+  let numOnTestSuiteStartCalls = ref(0);
+  let numOnTestSuiteResultCalls = ref(0);
+
+  let onTestSuiteStart = callback =>
+    reporterInternal := {...reporterInternal^, onTestSuiteStart: callback};
+
+  let onTestSuiteResult = callback =>
+    reporterInternal := {...reporterInternal^, onTestSuiteResult: callback};
+
+  let onRunStart = callback =>
+    reporterInternal := {...reporterInternal^, onRunStart: callback};
+
+  let onRunComplete = callback =>
+    reporterInternal := {...reporterInternal^, onRunComplete: callback};
+
+  let reporter = {
+    onTestSuiteStart: testSuite => {
+      incr(numOnTestSuiteStartCalls);
+      reporterInternal^.onTestSuiteStart(testSuite);
+    },
+    onTestSuiteResult: (testSuite, aggregatedResult, testSuiteResult) => {
+      incr(numOnTestSuiteResultCalls);
+      reporterInternal^.onTestSuiteResult(
+        testSuite,
+        aggregatedResult,
+        testSuiteResult,
+      );
+    },
+    onRunStart: runInfo => {
+      wasOnRunStartCalled := true;
+      reporterInternal^.onRunStart(runInfo);
+    },
+    onRunComplete: aggregatedResult => {
+      wasOnRunCompleteCalled := true;
+      reporterInternal^.onRunComplete(aggregatedResult);
+    },
+  };
+};

--- a/tests/__tests__/rely/TestSuite.re
+++ b/tests/__tests__/rely/TestSuite.re
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+type t = {
+  numFailingTests: int,
+  numPassingTests: int,
+  numSkippedTests: int,
+  nestedSuites: list(t),
+  name: string,
+};
+
+let init = name => {
+  numFailingTests: 0,
+  numPassingTests: 0,
+  numSkippedTests: 0,
+  nestedSuites: [],
+  name,
+};
+
+let withNestedTestSuite: (~child: t, t) => t =
+  (~child, parent) => {
+    ...parent,
+    nestedSuites: parent.nestedSuites @ [child],
+  };
+
+let withFailingTests = (numFailingTests, suite) => {
+  ...suite,
+  numFailingTests,
+};
+let withPassingTests = (numPassingTests, suite) => {
+  ...suite,
+  numPassingTests,
+};
+
+let withSkippedTests = (numSkippedTests, suite) => {
+  ...suite,
+  numSkippedTests,
+};
+let rec toFunction = config => {
+  let failingTests = (test: Rely.Test.testFn(unit)) =>
+    for (i in 1 to config.numFailingTests) {
+      test("failing test " ++ string_of_int(i), ({expect}) =>
+        expect.bool(true).toBeFalse()
+      );
+    };
+
+  let passingTests = (test: Rely.Test.testFn(unit)) =>
+    for (i in 1 to config.numPassingTests) {
+      test("passing test " ++ string_of_int(i), ({expect}) =>
+        expect.bool(true).toBeTrue()
+      );
+    };
+
+  let skippedTests = (testSkip: Rely.Test.testFn(unit)) =>
+    for (i in 1 to config.numSkippedTests) {
+      testSkip("skipped test " ++ string_of_int(i), ({expect}) =>
+        expect.bool(true).toBeTrue()
+      );
+    };
+
+  let nestedSuites = (describe: Rely.Describe.describeFn(unit)) =>
+    config.nestedSuites |> List.iter(suite => toFunction(suite, describe));
+
+  let fn = (describe: Rely.Describe.describeFn(unit)) =>
+    describe(
+      config.name,
+      ({describe, test, testSkip}) => {
+        failingTests(test);
+        passingTests(test);
+        skippedTests(testSkip);
+        nestedSuites(describe);
+      },
+    );
+  fn;
+};

--- a/tests/__tests__/rely/TestSuite.rei
+++ b/tests/__tests__/rely/TestSuite.rei
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+type t;
+let init: string => t;
+let withNestedTestSuite: (~child: t, t) => t;
+let withFailingTests: (int, t) => t;
+let withPassingTests: (int, t) => t;
+let withSkippedTests: (int, t) => t;
+let toFunction: (t, Rely.Describe.describeFn(unit)) => unit;

--- a/tests/__tests__/rely/TestSuiteRunner.re
+++ b/tests/__tests__/rely/TestSuiteRunner.re
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+module MakeTestFramework = (()) : Rely.TestFramework =>
+  Rely.Make({
+    let config =
+      Rely.TestFrameworkConfig.initialize({
+        snapshotDir: "unused",
+        projectDir: "",
+      });
+  });
+
+let run = (testSuites: list(TestSuite.t), reporter: Rely.Reporter.t) => {
+  module TestFramework =
+    MakeTestFramework({});
+
+  testSuites
+  |> List.map(TestSuite.toFunction)
+  |> List.iter(ts => ts(TestFramework.describe));
+
+  TestFramework.run(
+    Rely.RunConfig.(
+      initialize()
+      |> internal_reporters_api_do_not_use(reporter)
+      |> onTestFrameworkFailure(() => ())
+    ),
+  );
+};

--- a/tests/__tests__/rely/TestSuiteRunner.rei
+++ b/tests/__tests__/rely/TestSuiteRunner.rei
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+let run: (list(TestSuite.t), Rely.Reporter.t) => unit;


### PR DESCRIPTION
Add TestSkip method, tests for AggregateResults. We could easily implement describeSkip as well for skipping test suites if we so desired.