### PR TITLE
remove call to List.hd to avoid possible exceptions

### DIFF
--- a/src/rely/StackTrace.re
+++ b/src/rely/StackTrace.re
@@ -39,7 +39,11 @@ module Make = (Config: Config) => {
   let getTopLocation = optSlots =>
     switch (optSlots) {
     | None => None
-    | Some(slots) => Slot.location(List.hd(slots))
+    | Some(slots) =>
+      switch (slots) {
+      | [hd, ...rest] => Slot.location(hd)
+      | [] => None
+      }
     };
 
   let getCallstack = () => get_callstack(maxStacklength);


### PR DESCRIPTION
Noticed some exceptions bubbling up while playing around with more consistent failure stack traces, traced it to here.