### PR TITLE
file-context-printer: Fix failing build due to missing dep.

### DIFF
--- a/file-context-printer.json
+++ b/file-context-printer.json
@@ -1,6 +1,6 @@
 {
   "name": "@reason-native/file-context-printer",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A utility for pretty printing source code",
   "repository": {
     "type": "git",
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "esy": {
-    "build": "refmterr dune build -p file-context-printer",
+    "build": "dune build -p file-context-printer",
     "install": "esy-installer file-context-printer.install"
   },
   "scripts": {


### PR DESCRIPTION
Summary:
The previous build command was using refmterr, but it doesn't
and can't depend on refmterr (cyclical dep).
We didn't catch this at release time because the monorepo
builds are a different setup from individual package builds.
@andreypopp's upcoming monorepo work will fix that.

Test Plan:

Reviewers:kad

CC: