### PR TITLE
Benderson/add timing data

### DIFF
--- a/src/rely/Clock.re
+++ b/src/rely/Clock.re
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+open Time;
+
+let getTime = () => Seconds(Unix.gettimeofday());

--- a/src/rely/Clock.rei
+++ b/src/rely/Clock.rei
@@ -4,4 +4,4 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
-let run: (list(TestSuite.t), Rely.Reporter.t) => unit;
+let getTime: unit => Time.t;

--- a/src/rely/Rely.rei
+++ b/src/rely/Rely.rei
@@ -4,9 +4,10 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
+module ArrayMatchers = ArrayMatchers;
 module CollectionMatchers = CollectionMatchers;
 module ListMatchers = ListMatchers;
-module ArrayMatchers = ArrayMatchers;
+module Time = Time;
 
 module Test: {
   type testUtils('ext) = {expect: DefaultMatchers.matchers('ext)};
@@ -88,6 +89,7 @@ type requiredConfiguration = TestFrameworkConfig.requiredConfiguration;
 module TestFrameworkConfig: {
   type t;
   let initialize: requiredConfiguration => t;
+  let internal_do_not_use_get_time: (unit => Time.t, t) => t;
 };
 
 module type FrameworkConfig = {let config: TestFrameworkConfig.t;};

--- a/src/rely/TerminalReporter.re
+++ b/src/rely/TerminalReporter.re
@@ -7,6 +7,7 @@
 open Common.Option.Infix;
 open TestResult;
 open TestResult.AggregatedResult;
+open Time;
 
 type terminalPrinter = {
   printString: string => unit,
@@ -203,8 +204,19 @@ let createRunSummary = (result: AggregatedResult.t) => {
         String.concat(", ", testSummaryParts),
       ],
     );
+  let Seconds(duration) = Time.subtract(Clock.getTime(), result.startTime);
+  let timeString =
+    duration *. 1000. > 1. ? Printf.sprintf("%.3fs", duration) : "< 1ms";
+  let timeSummary =
+    String.concat(
+      "",
+      [
+        <Pastel bold=true color=WhiteBright> "Time:        " </Pastel>,
+        timeString,
+      ],
+    );
 
-  String.concat("\n", [testSuiteSummary, testSummary]);
+  String.concat("\n", [testSuiteSummary, testSummary, timeSummary]);
 };
 
 let printSnapshotStatus = testResult =>

--- a/src/rely/TestFrameworkConfig.re
+++ b/src/rely/TestFrameworkConfig.re
@@ -4,6 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
+open Clock;
+
 type requiredConfiguration = {
   snapshotDir: string,
   projectDir: string,
@@ -13,11 +15,17 @@ module TestFrameworkConfig = {
   type t = {
     snapshotDir: string,
     projectDir: string,
+    getTime: unit => Time.t,
   };
+
+  type optionalConfiguration = {getTime: unit => Time.t};
 
   let initialize: requiredConfiguration => t =
     config => {
       snapshotDir: config.snapshotDir,
       projectDir: config.projectDir,
+      getTime: Clock.getTime,
     };
+
+  let internal_do_not_use_get_time = (fn, cfg: t) => {...cfg, getTime: fn};
 };

--- a/src/rely/Time.re
+++ b/src/rely/Time.re
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+type t =
+  /* An offset of the current time and 00:00:00 GMT, Jan. 1, 1970 in seconds*/
+  | Seconds(float);
+
+let subtract = (t1, t2) =>
+  switch (t1, t2) {
+  | (Seconds(s1), Seconds(s2)) => Seconds((-.)(s1, s2))
+  };

--- a/src/rely/Util.re
+++ b/src/rely/Util.re
@@ -4,6 +4,11 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
+type timingInfo = {
+  startTime: Time.t,
+  endTime: Time.t,
+};
+
 let withBacktrace = f => {
   let prevBacktraceStatus = Printexc.backtrace_status();
   Printexc.record_backtrace(true);
@@ -15,4 +20,11 @@ let withBacktrace = f => {
     };
   Printexc.record_backtrace(prevBacktraceStatus);
   value;
+};
+
+let time = (getTime, thunk) => {
+  let startTime = getTime();
+  thunk();
+  let endTime = getTime();
+  {startTime: startTime, endTime: endTime};
 };

--- a/tests/TestRunnerOutputSnapshotTest.re
+++ b/tests/TestRunnerOutputSnapshotTest.re
@@ -6,24 +6,38 @@
  */;
 open Rely.Describe;
 open Rely.Test;
+open Rely.Time;
 
 module type SnapshotDir = {let snapshotDir: string;};
 
 module MakeTestFramework = (SnapshotDir: SnapshotDir) : Rely.TestFramework =>
   Rely.Make({
     let config =
-      Rely.TestFrameworkConfig.initialize({
-        snapshotDir:
-          Filename.(
-            GetProjectRoot.get()
-            |> (dir => Filename.concat(dir, "tests"))
-            |> (
-              dir => Filename.concat(dir, "__snapshots_test_runner_output__")
-            )
-            |> (dir => Filename.concat(dir, SnapshotDir.snapshotDir))
-          ),
-        projectDir: "",
-      });
+      Rely.TestFrameworkConfig.(
+        initialize({
+          snapshotDir:
+            Filename.(
+              GetProjectRoot.get()
+              |> (dir => Filename.concat(dir, "tests"))
+              |> (
+                dir =>
+                  Filename.concat(dir, "__snapshots_test_runner_output__")
+              )
+              |> (dir => Filename.concat(dir, SnapshotDir.snapshotDir))
+            ),
+          projectDir: "",
+        })
+        /* evil hack, default reporter not currently exposed and time can't be
+         * passed to reporters, setting time in the future by a second (which is longer
+         * than any tests should take so that when the terminal reporter calculates
+         * how long tests took to run it gets a negative number which gets "rounded"
+         * to < 1 ms. Come either virtual modules/the next major version we can fix this,
+         * until then, I think this is the most reasonable option to ensure our
+         * snapshots are consistent */
+        |> internal_do_not_use_get_time(() =>
+             Seconds(Unix.gettimeofday() +. 1000.)
+           )
+      );
   });
 
 /**

--- a/tests/__snapshots__/FloatMatchers.56a40b03.0.snapshot
+++ b/tests/__snapshots__/FloatMatchers.56a40b03.0.snapshot
@@ -4,4 +4,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright>0 failed, <green><bold>1 passed</bold></green>, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright>0 failed, <green><bold>2 passed</bold></green>, 2 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/FloatMatchers.db4be1fd.0.snapshot
+++ b/tests/__snapshots__/FloatMatchers.db4be1fd.0.snapshot
@@ -68,4 +68,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>8 failed</bold></red>, 0 passed, 8 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/FnMatchers.2113922b.0.snapshot
+++ b/tests/__snapshots__/FnMatchers.2113922b.0.snapshot
@@ -36,4 +36,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>4 failed</bold></red>, 0 passed, 4 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/Rely_array_matchers_toBeEmpty.2af8e875.0.snapshot
+++ b/tests/__snapshots__/Rely_array_matchers_toBeEmpty.2af8e875.0.snapshot
@@ -10,4 +10,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/Rely_array_matchers_toBeEmpty.af057e34.0.snapshot
+++ b/tests/__snapshots__/Rely_array_matchers_toBeEmpty.af057e34.0.snapshot
@@ -10,4 +10,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/Rely_array_matchers_toContain.53f160c7.0.snapshot
+++ b/tests/__snapshots__/Rely_array_matchers_toContain.53f160c7.0.snapshot
@@ -33,4 +33,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>3 failed</bold></red>, 0 passed, 3 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/Rely_array_matchers_toContain.8cf884f5.0.snapshot
+++ b/tests/__snapshots__/Rely_array_matchers_toContain.8cf884f5.0.snapshot
@@ -44,4 +44,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>4 failed</bold></red>, 0 passed, 4 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/Rely_array_matchers_toContainEqual.cb9ef9bc.0.snapshot
+++ b/tests/__snapshots__/Rely_array_matchers_toContainEqual.cb9ef9bc.0.snapshot
@@ -42,4 +42,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>4 failed</bold></red>, 0 passed, 4 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/Rely_array_matchers_toContainEqual.decf80a6.0.snapshot
+++ b/tests/__snapshots__/Rely_array_matchers_toContainEqual.decf80a6.0.snapshot
@@ -22,4 +22,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>2 failed</bold></red>, 0 passed, 2 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/Rely_array_matchers_toEqual.01309343.0.snapshot
+++ b/tests/__snapshots__/Rely_array_matchers_toEqual.01309343.0.snapshot
@@ -58,4 +58,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>6 failed</bold></red>, 0 passed, 6 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/Rely_array_matchers_toEqual.c2e6ea6b.0.snapshot
+++ b/tests/__snapshots__/Rely_array_matchers_toEqual.c2e6ea6b.0.snapshot
@@ -31,4 +31,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>3 failed</bold></red>, 0 passed, 3 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/Rely_list_matchers_toBeEmpty.46fde8fb.0.snapshot
+++ b/tests/__snapshots__/Rely_list_matchers_toBeEmpty.46fde8fb.0.snapshot
@@ -10,4 +10,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/Rely_list_matchers_toBeEmpty.7d8c97ff.0.snapshot
+++ b/tests/__snapshots__/Rely_list_matchers_toBeEmpty.7d8c97ff.0.snapshot
@@ -10,4 +10,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/Rely_list_matchers_toContain.472b2cbb.0.snapshot
+++ b/tests/__snapshots__/Rely_list_matchers_toContain.472b2cbb.0.snapshot
@@ -44,4 +44,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>4 failed</bold></red>, 0 passed, 4 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/Rely_list_matchers_toContain.50c54e5f.0.snapshot
+++ b/tests/__snapshots__/Rely_list_matchers_toContain.50c54e5f.0.snapshot
@@ -33,4 +33,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>3 failed</bold></red>, 0 passed, 3 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/Rely_list_matchers_toContainEqual.2cb46764.0.snapshot
+++ b/tests/__snapshots__/Rely_list_matchers_toContainEqual.2cb46764.0.snapshot
@@ -42,4 +42,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>4 failed</bold></red>, 0 passed, 4 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/Rely_list_matchers_toContainEqual.45ad09a9.0.snapshot
+++ b/tests/__snapshots__/Rely_list_matchers_toContainEqual.45ad09a9.0.snapshot
@@ -22,4 +22,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>2 failed</bold></red>, 0 passed, 2 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/Rely_list_matchers_toEqual.0ac36f9e.0.snapshot
+++ b/tests/__snapshots__/Rely_list_matchers_toEqual.0ac36f9e.0.snapshot
@@ -58,4 +58,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>6 failed</bold></red>, 0 passed, 6 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/Rely_list_matchers_toEqual.1b8cb7fe.0.snapshot
+++ b/tests/__snapshots__/Rely_list_matchers_toEqual.1b8cb7fe.0.snapshot
@@ -31,4 +31,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>3 failed</bold></red>, 0 passed, 3 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/TestRunner.1e3e5d03.0.snapshot
+++ b/tests/__snapshots__/TestRunner.1e3e5d03.0.snapshot
@@ -110,4 +110,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>16 failed</bold></red>, 0 passed, 16 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/TestRunner.813890c0.0.snapshot
+++ b/tests/__snapshots__/TestRunner.813890c0.0.snapshot
@@ -16,4 +16,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright><red><bold>1 failed</bold></red>, 0 passed, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright><red><bold>1 failed</bold></red>, <green><bold>2 passed</bold></green>, 3 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/TestRunner.94379a08.0.snapshot
+++ b/tests/__snapshots__/TestRunner.94379a08.0.snapshot
@@ -4,4 +4,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright>0 failed, <green><bold>1 passed</bold></green>, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright>0 failed, <green><bold>7 passed</bold></green>, 7 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/TestRunner.9ae8523f.0.snapshot
+++ b/tests/__snapshots__/TestRunner.9ae8523f.0.snapshot
@@ -4,4 +4,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright>0 failed, <green><bold>1 passed</bold></green>, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright>0 failed, <green><bold>1 passed</bold></green>, 1 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__snapshots__/TestRunner.e9296ac9.0.snapshot
+++ b/tests/__snapshots__/TestRunner.e9296ac9.0.snapshot
@@ -4,4 +4,5 @@ Running 1 test suite
 
 <whiteBright><bold>Test Suites: </bold></whiteBright>0 failed, <green><bold>1 passed</bold></green>, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright>0 failed, <green><bold>2 passed</bold></green>, 2 total
+<whiteBright><bold>Time:        </bold></whiteBright>< 1ms
 

--- a/tests/__tests__/rely/AggregateResult_test.re
+++ b/tests/__tests__/rely/AggregateResult_test.re
@@ -30,6 +30,8 @@ type singleSuiteExpectedOutput = {
   numFailedTestSuites: int,
 };
 
+exception OnRunCompleteNotCalled;
+
 describe("Rely AggregateResult", ({describe, test}) => {
   describe("Single suite cases", ({test}) => {
     let singleSuiteInput = (passing, failing, skipped) => {
@@ -211,20 +213,7 @@ describe("Rely AggregateResult", ({describe, test}) => {
         input.name,
         ({expect}) => {
           open Rely.TestResult.AggregatedResult;
-          let aggregatedResult =
-            ref({
-              numFailedTests: 0,
-              numFailedTestSuites: 0,
-              numPassedTests: 0,
-              numPassedTestSuites: 0,
-              numPendingTestSuites: 0,
-              numSkippedTests: 0,
-              numSkippedTestSuites: 0,
-              numTotalTests: 0,
-              numTotalTestSuites: 0,
-              snapshotSummary: None,
-              testSuiteResults: [],
-            });
+          let aggregatedResult = ref(None);
 
           let testSuites = [
             TestSuite.(
@@ -236,22 +225,28 @@ describe("Rely AggregateResult", ({describe, test}) => {
           ];
           module Reporter =
             TestReporter.Make({});
-          Reporter.onRunComplete(res => aggregatedResult := res);
+          Reporter.onRunComplete(res => aggregatedResult := Some(res));
 
           TestSuiteRunner.run(testSuites, Reporter.reporter);
-          let actualOutput = {
-            numPassedTestSuites: aggregatedResult^.numPassedTestSuites,
-            numPendingTestSuites: aggregatedResult^.numPendingTestSuites,
-            numTotalTests: aggregatedResult^.numTotalTests,
-            numTotalTestSuites: aggregatedResult^.numTotalTestSuites,
-            numSkippedTestSuites: aggregatedResult^.numSkippedTestSuites,
-            numFailedTestSuites: aggregatedResult^.numFailedTestSuites,
-            numPassedTests: aggregatedResult^.numPassedTests,
-            numFailedTests: aggregatedResult^.numFailedTests,
-            numSkippedTests: aggregatedResult^.numSkippedTests,
-          };
 
-          expect.bool(actualOutput == expectedOutput).toBeTrue();
+          let _ =
+            switch (aggregatedResult^) {
+            | None => raise(OnRunCompleteNotCalled)
+            | Some(aggregatedResult) =>
+              let actualOutput = {
+                numPassedTestSuites: aggregatedResult.numPassedTestSuites,
+                numPendingTestSuites: aggregatedResult.numPendingTestSuites,
+                numTotalTests: aggregatedResult.numTotalTests,
+                numTotalTestSuites: aggregatedResult.numTotalTestSuites,
+                numSkippedTestSuites: aggregatedResult.numSkippedTestSuites,
+                numFailedTestSuites: aggregatedResult.numFailedTestSuites,
+                numPassedTests: aggregatedResult.numPassedTests,
+                numFailedTests: aggregatedResult.numFailedTests,
+                numSkippedTests: aggregatedResult.numSkippedTests,
+              };
+              expect.bool(actualOutput == expectedOutput).toBeTrue();
+            };
+          ();
         },
       );
     singleSuiteTestCases |> List.iter(testSingleSuite);
@@ -367,39 +362,32 @@ describe("Rely AggregateResult", ({describe, test}) => {
         input.name,
         ({expect}) => {
           open Rely.TestResult.AggregatedResult;
-          let aggregatedResult =
-            ref({
-              numFailedTests: 0,
-              numFailedTestSuites: 0,
-              numPassedTests: 0,
-              numPassedTestSuites: 0,
-              numPendingTestSuites: 0,
-              numSkippedTests: 0,
-              numSkippedTestSuites: 0,
-              numTotalTests: 0,
-              numTotalTestSuites: 0,
-              snapshotSummary: None,
-              testSuiteResults: [],
-            });
+          let aggregatedResult = ref(None);
 
           module Reporter =
             TestReporter.Make({});
-          Reporter.onRunComplete(res => aggregatedResult := res);
+          Reporter.onRunComplete(res => aggregatedResult := Some(res));
 
           TestSuiteRunner.run(input.testSuites, Reporter.reporter);
-          let actualOutput = {
-            numPassedTestSuites: aggregatedResult^.numPassedTestSuites,
-            numPendingTestSuites: aggregatedResult^.numPendingTestSuites,
-            numTotalTests: aggregatedResult^.numTotalTests,
-            numTotalTestSuites: aggregatedResult^.numTotalTestSuites,
-            numSkippedTestSuites: aggregatedResult^.numSkippedTestSuites,
-            numFailedTestSuites: aggregatedResult^.numFailedTestSuites,
-            numPassedTests: aggregatedResult^.numPassedTests,
-            numFailedTests: aggregatedResult^.numFailedTests,
-            numSkippedTests: aggregatedResult^.numSkippedTests,
-          };
 
-          expect.bool(actualOutput == expectedOutput).toBeTrue();
+          let _ =
+            switch (aggregatedResult^) {
+            | None => raise(OnRunCompleteNotCalled)
+            | Some(aggregatedResult) =>
+              let actualOutput = {
+                numPassedTestSuites: aggregatedResult.numPassedTestSuites,
+                numPendingTestSuites: aggregatedResult.numPendingTestSuites,
+                numTotalTests: aggregatedResult.numTotalTests,
+                numTotalTestSuites: aggregatedResult.numTotalTestSuites,
+                numSkippedTestSuites: aggregatedResult.numSkippedTestSuites,
+                numFailedTestSuites: aggregatedResult.numFailedTestSuites,
+                numPassedTests: aggregatedResult.numPassedTests,
+                numFailedTests: aggregatedResult.numFailedTests,
+                numSkippedTests: aggregatedResult.numSkippedTests,
+              };
+              expect.bool(actualOutput == expectedOutput).toBeTrue();
+            };
+          ();
         },
       );
     testCases |> List.iter(runTestCases);

--- a/tests/__tests__/rely/TestSuiteRunner.re
+++ b/tests/__tests__/rely/TestSuiteRunner.re
@@ -29,3 +29,26 @@ let run = (testSuites: list(TestSuite.t), reporter: Rely.Reporter.t) => {
     ),
   );
 };
+
+let runWithCustomTime = (getTime, testSuites, reporter) => {
+  module TestFramework =
+    Rely.Make({
+      let config =
+        Rely.TestFrameworkConfig.(
+          initialize({snapshotDir: "unused", projectDir: ""})
+          |> internal_do_not_use_get_time(getTime)
+        );
+    });
+
+  testSuites
+  |> List.map(TestSuite.toFunction)
+  |> List.iter(ts => ts(TestFramework.describe));
+
+  TestFramework.run(
+    Rely.RunConfig.(
+      initialize()
+      |> internal_reporters_api_do_not_use(reporter)
+      |> onTestFrameworkFailure(() => ())
+    ),
+  );
+};

--- a/tests/__tests__/rely/TimingTest.re
+++ b/tests/__tests__/rely/TimingTest.re
@@ -1,0 +1,143 @@
+open TestFramework;
+open Rely.Time;
+open Rely.TestResult;
+
+exception OnRunCompleteNotCalled;
+
+describe("Rely timing data", ({describe, test}) => {
+  test("test suite start times before end times", ({expect}) => {
+    module Reporter =
+      TestReporter.Make({});
+    let result = ref(None);
+    let testSuites = [
+      TestSuite.(
+        init("foo") |> withPassingTests(15) |> withFailingTests(10)
+      ),
+      TestSuite.(
+        init("bar") |> withPassingTests(15) |> withFailingTests(10)
+      ),
+      TestSuite.(
+        init("baz") |> withPassingTests(15) |> withFailingTests(10)
+      ),
+    ];
+
+    Reporter.onRunComplete(res => result := Some(res));
+
+    TestSuiteRunner.run(testSuites, Reporter.reporter);
+
+    let _ =
+      switch (result^) {
+      | None => raise(OnRunCompleteNotCalled)
+      | Some(aggregatedResult) =>
+        let suiteStartBeforeSuiteEnd =
+          aggregatedResult.testSuiteResults
+          |> List.map((r: Rely.TestResult.TestSuiteResult.t) =>
+               switch (r.startTime, r.endTime) {
+               | (Some(start), Some(endT)) => start < endT
+               | _ => true
+               }
+             )
+          |> List.fold_left((acc, r) => acc && r, true);
+        expect.bool(suiteStartBeforeSuiteEnd).toBeTrue();
+      };
+    ();
+  });
+  test("duration should be populated for run tests", ({expect}) => {
+    module Reporter =
+      TestReporter.Make({});
+    let result = ref(None);
+    let testSuites = [
+      TestSuite.(
+        init("foo") |> withPassingTests(15) |> withFailingTests(10)
+      ),
+    ];
+
+    Reporter.onRunComplete(res => result := Some(res));
+
+    TestSuiteRunner.run(testSuites, Reporter.reporter);
+
+    let _ =
+      switch (result^) {
+      | None => raise(OnRunCompleteNotCalled)
+      | Some(aggregatedResult) =>
+        let timingsPopulated =
+          aggregatedResult.testSuiteResults
+          |> List.map((r: Rely.TestResult.TestSuiteResult.t) =>
+               r.testResults
+             )
+          |> List.flatten
+          |> List.map((r: Rely.TestResult.testResult) =>
+               switch (r.duration) {
+               /* >= 0 because sometimes it's too dang fast :p,
+                * can verify they aren't all zero with a Console.log, but it's
+                * nondeterministic so there isn't an assertion to that effect
+                */
+               | Some(Seconds(duration)) => duration >= 0.
+               | None => false
+               }
+             )
+          |> List.fold_left((acc, r) => acc && r, true);
+        expect.bool(timingsPopulated).toBeTrue();
+      };
+    ();
+  });
+  test("duration should not be populated for skipped tests", ({expect}) => {
+    module Reporter =
+      TestReporter.Make({});
+    let result = ref(None);
+    let testSuites = [
+      TestSuite.(
+        init("foo") |> withSkippedTests(15)
+      ),
+    ];
+
+    Reporter.onRunComplete(res => result := Some(res));
+
+    TestSuiteRunner.run(testSuites, Reporter.reporter);
+
+    let _ =
+      switch (result^) {
+      | None => raise(OnRunCompleteNotCalled)
+      | Some(aggregatedResult) =>
+        let timingsNotPopulated =
+          aggregatedResult.testSuiteResults
+          |> List.map((r: Rely.TestResult.TestSuiteResult.t) =>
+               r.testResults
+             )
+          |> List.flatten
+          |> List.map((r: Rely.TestResult.testResult) =>
+               switch (r.duration) {
+               | Some(duration) => false
+               | None => true
+               }
+             )
+          |> List.fold_left((acc, r) => acc && r, true);
+        expect.bool(timingsNotPopulated).toBeTrue();
+      };
+    ();
+  });
+  test("startTime should be populated with initial value from clock", ({expect}) => {
+    module Reporter =
+      TestReporter.Make({});
+    let result = ref(None);
+    let testSuites = [
+      TestSuite.(
+        init("foo") |> withPassingTests(15) |> withFailingTests(10)
+      ),
+    ];
+
+    let startTime = 10.;
+    Reporter.onRunComplete(res => result := Some(res));
+
+    TestSuiteRunner.runWithCustomTime(() => Seconds(startTime), testSuites, Reporter.reporter);
+
+    let _ =
+      switch (result^) {
+      | None => raise(OnRunCompleteNotCalled)
+      | Some(aggregatedResult) =>
+        let Seconds(actualStartTime) = aggregatedResult.startTime;
+        expect.float(actualStartTime).toBeCloseTo(startTime);
+      };
+    ();
+  });
+});


### PR DESCRIPTION
Adds timing data for the overall run, individual test suite runs, and individual test runs.

Right now only the top level is exposed via the terminal reporter's output.

As a result, I believe the reporter API can now be solidified and made public (I think via a variant that is something like ```type reporter = | Terminal | Custom(reporterLifecycle)```)

Additionally doing this work it became clear that RunConfig (and several other modules) should be moved into the result of the Rely.Make functor. Unfortunately this would be a breaking change so I didn't do it now, however I think we will want to do it at some point so that configuration changes can better flow through.

![image](https://user-images.githubusercontent.com/5252755/52012278-08ea3200-248f-11e9-9de8-9e2b8946b6b5.png)
