### PR TITLE
describe skip

### DIFF
--- a/src/rely/Rely.rei
+++ b/src/rely/Rely.rei
@@ -17,6 +17,7 @@ module Test: {
 module Describe: {
   type describeUtils('ext) = {
     describe: describeFn('ext),
+    describeSkip: describeFn('ext),
     test: Test.testFn('ext),
     testSkip: Test.testFn('ext),
   }
@@ -78,6 +79,7 @@ module MatcherTypes: {
 
 module type TestFramework = {
   let describe: Describe.describeFn(unit);
+  let describeSkip: Describe.describeFn('a);
   let extendDescribe:
     MatcherTypes.matchersExtensionFn('ext) => Describe.describeFn('ext);
   let run: RunConfig.t => unit;

--- a/tests/__tests__/rely/TestSuite.rei
+++ b/tests/__tests__/rely/TestSuite.rei
@@ -10,4 +10,5 @@ let withNestedTestSuite: (~child: t, t) => t;
 let withFailingTests: (int, t) => t;
 let withPassingTests: (int, t) => t;
 let withSkippedTests: (int, t) => t;
-let toFunction: (t, Rely.Describe.describeFn(unit)) => unit;
+let toFunction: (t, ~describe: Rely.Describe.describeFn(unit), ~describeSkip: Rely.Describe.describeFn(unit)) => unit;
+let skipSuite: (t) => t;

--- a/tests/__tests__/rely/TestSuiteRunner.re
+++ b/tests/__tests__/rely/TestSuiteRunner.re
@@ -19,7 +19,10 @@ let run = (testSuites: list(TestSuite.t), reporter: Rely.Reporter.t) => {
 
   testSuites
   |> List.map(TestSuite.toFunction)
-  |> List.iter(ts => ts(TestFramework.describe));
+  |> List.iter(ts => ts(
+    ~describe=TestFramework.describe,
+    ~describeSkip=TestFramework.describeSkip,
+  ));
 
   TestFramework.run(
     Rely.RunConfig.(
@@ -42,7 +45,12 @@ let runWithCustomTime = (getTime, testSuites, reporter) => {
 
   testSuites
   |> List.map(TestSuite.toFunction)
-  |> List.iter(ts => ts(TestFramework.describe));
+  |> List.iter(ts =>
+       ts(
+         ~describe=TestFramework.describe,
+         ~describeSkip=TestFramework.describeSkip,
+       )
+     );
 
   TestFramework.run(
     Rely.RunConfig.(


### PR DESCRIPTION
Describe skip feature. Ended up using obj.magic in the top level describeSkip implementation to give a good API (the code that uses it is never actually called by design), curious to see if you guys have a cleaner solution that doesn't require a lot of refactoring.