### PR TITLE
[RFC] Make reporters API public

### DIFF
--- a/src/rely/Rely.re
+++ b/src/rely/Rely.re
@@ -18,7 +18,6 @@ module ListMatchers = ListMatchers;
 module MatcherTypes = MatcherTypes;
 module MatcherUtils = MatcherUtils;
 module Reporter = Reporter;
-module TestResult = TestResult;
 module Time = Time;
 
 module Test = {

--- a/src/rely/Rely.rei
+++ b/src/rely/Rely.rei
@@ -25,12 +25,6 @@ module Describe: {
 };
 
 module RunConfig: {
-  type printer = {
-    printString: string => unit,
-    printEndline: string => unit,
-    printNewline: unit => unit,
-    flush: out_channel => unit,
-  };
   type reporter =
     | Default
     | Custom(Reporter.t);
@@ -41,7 +35,6 @@ module RunConfig: {
   let onTestFrameworkFailure: (unit => unit, t) => t;
   let updateSnapshots: (bool, t) => t;
   let withReporters: (list(reporter), t) => t;
-  let printer_internal_do_not_use: (printer, t) => t;
 };
 
 module MatcherUtils: {

--- a/src/rely/Rely.rei
+++ b/src/rely/Rely.rei
@@ -7,6 +7,7 @@
 module ArrayMatchers = ArrayMatchers;
 module CollectionMatchers = CollectionMatchers;
 module ListMatchers = ListMatchers;
+module Reporter = Reporter;
 module Time = Time;
 
 module Test: {
@@ -23,9 +24,6 @@ module Describe: {
   and describeFn('ext) = (string, describeUtils('ext) => unit) => unit;
 };
 
-module Reporter = Reporter;
-module TestResult = TestResult;
-
 module RunConfig: {
   type printer = {
     printString: string => unit,
@@ -33,12 +31,17 @@ module RunConfig: {
     printNewline: unit => unit,
     flush: out_channel => unit,
   };
+  type reporter =
+    | Default
+    | Custom(Reporter.t);
+
   type t;
+
   let initialize: unit => t;
-  let updateSnapshots: (bool, t) => t;
-  let printer_internal_do_not_use: (printer, t) => t;
-  let internal_reporters_api_do_not_use: (Reporter.t, t) => t;
   let onTestFrameworkFailure: (unit => unit, t) => t;
+  let updateSnapshots: (bool, t) => t;
+  let withReporters: (list(reporter), t) => t;
+  let printer_internal_do_not_use: (printer, t) => t;
 };
 
 module MatcherUtils: {

--- a/src/rely/Reporter.re
+++ b/src/rely/Reporter.re
@@ -14,9 +14,13 @@ type relyRunInfo = {
   testSuites: list(testSuite)
 };
 
+type aggregatedResult = AggregatedResult.t;
+type testSuiteResult = TestSuiteResult.t;
+type testResult = TestResult.testResult;
+
 type t = {
   onTestSuiteStart: testSuite => unit,
-  onTestSuiteResult: (testSuite, AggregatedResult.t, TestSuiteResult.t) => unit,
+  onTestSuiteResult: (testSuite, aggregatedResult, testSuiteResult) => unit,
   onRunStart: (relyRunInfo) => unit,
-  onRunComplete: AggregatedResult.t => unit,
+  onRunComplete: aggregatedResult => unit,
 };

--- a/src/rely/RunConfig.re
+++ b/src/rely/RunConfig.re
@@ -38,20 +38,6 @@ module RunConfig = {
   let updateSnapshots: (bool, t) => t =
     (updateSnapshots, config) => {...config, updateSnapshots};
 
-  /* When external use becomes a priority, this should be handled by a test reporters API, for now this
-     is just used in testing the test runner itself to prevent writing to standard out*/
-  let printer_internal_do_not_use = (printer: printer, config) => {
-    ...config,
-    reporters: [
-      TerminalReporter.createTerminalReporter({
-        printString: printer.printString,
-        printEndline: printer.printEndline,
-        printNewline: printer.printNewline,
-        flush: printer.flush,
-      }),
-    ],
-  };
-
   let withReporters = (reporters: list(reporter), config) => {
     let reporters =
       reporters

--- a/src/rely/RunConfig.re
+++ b/src/rely/RunConfig.re
@@ -31,6 +31,10 @@ module RunConfig = {
     ],
   };
 
+  type reporter =
+    | Default
+    | Custom(Reporter.t);
+
   let updateSnapshots: (bool, t) => t =
     (updateSnapshots, config) => {...config, updateSnapshots};
 
@@ -48,9 +52,22 @@ module RunConfig = {
     ],
   };
 
-  let internal_reporters_api_do_not_use = (reporter: Reporter.t, config) => {
-    ...config,
-    reporters: [reporter],
+  let withReporters = (reporters: list(reporter), config) => {
+    let reporters =
+      reporters
+      |> List.map(wrappedReporter =>
+           switch (wrappedReporter) {
+           | Default =>
+             TerminalReporter.createTerminalReporter({
+               printEndline: print_endline,
+               printNewline: print_newline,
+               printString: print_string,
+               flush,
+             })
+           | Custom(reporter) => reporter
+           }
+         );
+    {...config, reporters};
   };
 
   let onTestFrameworkFailure = (onTestFrameworkFailure, config) => {

--- a/src/rely/Snapshot.re
+++ b/src/rely/Snapshot.re
@@ -6,7 +6,7 @@
  */;
 open SnapshotIO;
 open Common.Collections;
-open TestResult;
+open TestResult.AggregatedResult;
 
 type state = {
   unusedSnapshotSet: MStringSet.t,

--- a/src/rely/Snapshot.rei
+++ b/src/rely/Snapshot.rei
@@ -13,7 +13,7 @@ module Make:
     let initializeState:
       (~snapshotDir: string, ~updateSnapshots: bool) => state;
     let markSnapshotsAsCheckedForTest: (string, state) => state;
-    let getSnapshotStatus: state => TestResult.snapshotSummary;
+    let getSnapshotStatus: state => TestResult.AggregatedResult.snapshotSummary;
     let removeUnusedSnapshots: state => unit;
     let markSnapshotUsed: (string, state) => state;
     let markSnapshotUpdated: (string, state) => state;

--- a/src/rely/TestResult.re
+++ b/src/rely/TestResult.re
@@ -37,12 +37,6 @@ type describeResult = {
   startTime: option(Time.t),
 };
 
-type snapshotSummary = {
-  numCreatedSnapshots: int,
-  numRemovedSnapshots: int,
-  numUpdatedSnapshots: int,
-};
-
 module TestSuiteResult = {
   type t = {
     numFailedTests: int,
@@ -96,6 +90,12 @@ module TestSuiteResult = {
 };
 
 module AggregatedResult = {
+  type snapshotSummary = {
+    numCreatedSnapshots: int,
+    numRemovedSnapshots: int,
+    numUpdatedSnapshots: int,
+  };
+
   type t = {
     numFailedTests: int,
     numFailedTestSuites: int,

--- a/tests/__tests__/rely/AggregateResult_test.re
+++ b/tests/__tests__/rely/AggregateResult_test.re
@@ -212,7 +212,7 @@ describe("Rely AggregateResult", ({describe, test}) => {
       test(
         input.name,
         ({expect}) => {
-          open Rely.TestResult.AggregatedResult;
+          open Rely.Reporter;
           let aggregatedResult = ref(None);
 
           let testSuites = [
@@ -361,7 +361,7 @@ describe("Rely AggregateResult", ({describe, test}) => {
       test(
         input.name,
         ({expect}) => {
-          open Rely.TestResult.AggregatedResult;
+          open Rely.Reporter;
           let aggregatedResult = ref(None);
 
           module Reporter =

--- a/tests/__tests__/rely/TestRunnerMultipleDescribe_test.re
+++ b/tests/__tests__/rely/TestRunnerMultipleDescribe_test.re
@@ -54,12 +54,7 @@ describe("Multiple TestFramework.describes", ({test}) => {
         InnerTestFramework.run(
           Rely.RunConfig.(
             initialize()
-            |> printer_internal_do_not_use({
-                 printEndline: _ => (),
-                 printString: _ => (),
-                 printNewline: _ => (),
-                 flush: _ => (),
-               })
+            |> withReporters([])
             |> onTestFrameworkFailure(() => onFrameworkFailureCalled := true)
           ),
         );

--- a/tests/__tests__/rely/TestSuiteRunner.re
+++ b/tests/__tests__/rely/TestSuiteRunner.re
@@ -24,7 +24,7 @@ let run = (testSuites: list(TestSuite.t), reporter: Rely.Reporter.t) => {
   TestFramework.run(
     Rely.RunConfig.(
       initialize()
-      |> internal_reporters_api_do_not_use(reporter)
+      |> withReporters([Custom(reporter)])
       |> onTestFrameworkFailure(() => ())
     ),
   );
@@ -47,7 +47,7 @@ let runWithCustomTime = (getTime, testSuites, reporter) => {
   TestFramework.run(
     Rely.RunConfig.(
       initialize()
-      |> internal_reporters_api_do_not_use(reporter)
+      |> withReporters([Custom(reporter)])
       |> onTestFrameworkFailure(() => ())
     ),
   );

--- a/tests/__tests__/rely/TimingTest.re
+++ b/tests/__tests__/rely/TimingTest.re
@@ -1,6 +1,6 @@
 open TestFramework;
 open Rely.Time;
-open Rely.TestResult;
+open Rely.Reporter;
 
 exception OnRunCompleteNotCalled;
 
@@ -31,7 +31,7 @@ describe("Rely timing data", ({describe, test}) => {
       | Some(aggregatedResult) =>
         let suiteStartBeforeSuiteEnd =
           aggregatedResult.testSuiteResults
-          |> List.map((r: Rely.TestResult.TestSuiteResult.t) =>
+          |> List.map((r: Rely.Reporter.testSuiteResult) =>
                switch (r.startTime, r.endTime) {
                | (Some(start), Some(endT)) => start < endT
                | _ => true
@@ -62,11 +62,11 @@ describe("Rely timing data", ({describe, test}) => {
       | Some(aggregatedResult) =>
         let timingsPopulated =
           aggregatedResult.testSuiteResults
-          |> List.map((r: Rely.TestResult.TestSuiteResult.t) =>
+          |> List.map((r: Rely.Reporter.testSuiteResult) =>
                r.testResults
              )
           |> List.flatten
-          |> List.map((r: Rely.TestResult.testResult) =>
+          |> List.map((r: Rely.Reporter.testResult) =>
                switch (r.duration) {
                /* >= 0 because sometimes it's too dang fast :p,
                 * can verify they aren't all zero with a Console.log, but it's
@@ -101,11 +101,11 @@ describe("Rely timing data", ({describe, test}) => {
       | Some(aggregatedResult) =>
         let timingsNotPopulated =
           aggregatedResult.testSuiteResults
-          |> List.map((r: Rely.TestResult.TestSuiteResult.t) =>
+          |> List.map((r: Rely.Reporter.testSuiteResult) =>
                r.testResults
              )
           |> List.flatten
-          |> List.map((r: Rely.TestResult.testResult) =>
+          |> List.map((r: Rely.Reporter.testResult) =>
                switch (r.duration) {
                | Some(duration) => false
                | None => true


### PR DESCRIPTION
See RunConfig.re and Rely.rei for the main changes. Basically custom reporters can be specified via a Custom constructor to RunConfig (and the default reporter is just called Default, I could see calling it terminal as well).

I played with a few solutions for exposing the test result types, I ended up aliasing the types we needed directly on the Reporter module and not exposing TestResult directly. I played with separating the public types from the intermediate types and conversion code, but wasn't super happy with how this ended up. I could see separating TestResult into three intermediate modules and requiring a limited signature in Reporter as well, but wanted to discuss here before commiting to that.

I want to say that this is a minor version, but we are no longer exposing the TestResult module on Rely.rei, which is a breaking change. That said it was only ever usable for reporters which were explicitly marked as internal soooo /shrug.