### PR TITLE
Rely.mock and associated tests

### DIFF
--- a/src/rely/Mock.re
+++ b/src/rely/Mock.re
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+
+type result('a) =
+  | Return('a)
+  | Exception(exn);
+
+type t('a, 'b, 'c) = {
+  calls: ref(list('c)),
+  results: ref(list(result('b))),
+  fn: 'a,
+  originalImplementation: 'a,
+  implementation: ref('a),
+};
+
+let fn = mock => mock.fn;
+let getCalls = mock => mock.calls^;
+let getResults = mock => mock.results^;
+let wasCalled = mock =>
+  switch (mock.calls^) {
+  | [] => false
+  | [first, ...rest] => true
+  };
+let resetHistory = mock => {
+  mock.calls := [];
+  mock.results := [];
+};
+let resetImplementation = mock =>
+  mock.implementation := mock.originalImplementation;
+let reset = mock => {
+  resetHistory(mock);
+  resetImplementation(mock);
+};
+let changeImplementation = (fn, mock) => mock.implementation := fn;
+
+let mock1 = fn => {
+  let calls = ref([]);
+  let results = ref([]);
+  let implementation = ref(fn);
+  let wrappedFn = arg => {
+    calls := calls^ @ [arg];
+    switch (implementation^(arg)) {
+    | returnValue =>
+      results := results^ @ [Return(returnValue)];
+      returnValue;
+    | exception e =>
+      results := results^ @ [Exception(e)];
+      raise(e);
+    };
+  };
+  {fn: wrappedFn, originalImplementation: fn, calls, results, implementation};
+};
+
+let mock2 = fn => {
+  let calls = ref([]);
+  let results = ref([]);
+  let implementation = ref(fn);
+  let wrappedFn = (arg1, arg2) => {
+    calls := calls^ @ [(arg1, arg2)];
+    switch (implementation^(arg1, arg2)) {
+    | returnValue =>
+      results := results^ @ [Return(returnValue)];
+      returnValue;
+    | exception e =>
+      results := results^ @ [Exception(e)];
+      raise(e);
+    };
+  };
+  {fn: wrappedFn, originalImplementation: fn, calls, results, implementation};
+};
+
+let mock3 = fn => {
+  let calls = ref([]);
+  let results = ref([]);
+  let implementation = ref(fn);
+  let wrappedFn = (arg1, arg2, arg3) => {
+    calls := calls^ @ [(arg1, arg2, arg3)];
+    switch (implementation^(arg1, arg2, arg3)) {
+    | returnValue =>
+      results := results^ @ [Return(returnValue)];
+      returnValue;
+    | exception e =>
+      results := results^ @ [Exception(e)];
+      raise(e);
+    };
+  };
+  {fn: wrappedFn, originalImplementation: fn, calls, results, implementation};
+};
+let mock4 = fn => {
+  let calls = ref([]);
+  let results = ref([]);
+  let implementation = ref(fn);
+  let wrappedFn = (arg1, arg2, arg3, arg4) => {
+    calls := calls^ @ [(arg1, arg2, arg3, arg4)];
+    switch (implementation^(arg1, arg2, arg3, arg4)) {
+    | returnValue =>
+      results := results^ @ [Return(returnValue)];
+      returnValue;
+    | exception e =>
+      results := results^ @ [Exception(e)];
+      raise(e);
+    };
+  };
+  {fn: wrappedFn, originalImplementation: fn, calls, results, implementation};
+};
+let mock5 = fn => {
+  let calls = ref([]);
+  let results = ref([]);
+  let implementation = ref(fn);
+  let wrappedFn = (arg1, arg2, arg3, arg4, arg5) => {
+    calls := calls^ @ [(arg1, arg2, arg3, arg4, arg5)];
+    switch (implementation^(arg1, arg2, arg3, arg4, arg5)) {
+    | returnValue =>
+      results := results^ @ [Return(returnValue)];
+      returnValue;
+    | exception e =>
+      results := results^ @ [Exception(e)];
+      raise(e);
+    };
+  };
+  {fn: wrappedFn, originalImplementation: fn, calls, results, implementation};
+};
+
+let mock6 = fn => {
+  let calls = ref([]);
+  let results = ref([]);
+  let implementation = ref(fn);
+  let wrappedFn = (arg1, arg2, arg3, arg4, arg5, arg6) => {
+    calls := calls^ @ [(arg1, arg2, arg3, arg4, arg5, arg6)];
+    switch (implementation^(arg1, arg2, arg3, arg4, arg5, arg6)) {
+    | returnValue =>
+      results := results^ @ [Return(returnValue)];
+      returnValue;
+    | exception e =>
+      results := results^ @ [Exception(e)];
+      raise(e);
+    };
+  };
+  {fn: wrappedFn, originalImplementation: fn, calls, results, implementation};
+};
+let mock7 = fn => {
+  let calls = ref([]);
+  let results = ref([]);
+  let implementation = ref(fn);
+  let wrappedFn = (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => {
+    calls := calls^ @ [(arg1, arg2, arg3, arg4, arg5, arg6, arg7)];
+    switch (implementation^(arg1, arg2, arg3, arg4, arg5, arg6, arg7)) {
+    | returnValue =>
+      results := results^ @ [Return(returnValue)];
+      returnValue;
+    | exception e =>
+      results := results^ @ [Exception(e)];
+      raise(e);
+    };
+  };
+  {fn: wrappedFn, originalImplementation: fn, calls, results, implementation};
+};

--- a/src/rely/Mock.re
+++ b/src/rely/Mock.re
@@ -4,158 +4,286 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
+let maxNumStackFrames = 3;
 
-type result('a) =
-  | Return('a)
-  | Exception(exn);
+module type Mock = {
+  type t('fn, 'ret, 'tupledArgs);
+  type result('a) =
+    | Return('a)
+    | Exception(exn, option(Printexc.location), string);
 
-type t('a, 'b, 'c) = {
-  calls: ref(list('c)),
-  results: ref(list(result('b))),
-  fn: 'a,
-  originalImplementation: 'a,
-  implementation: ref('a),
-};
+  let fn: t('fn, 'ret, 'tupledArgs) => 'fn;
+  let getCalls: t('fn, 'ret, 'tupledArgs) => list('tupledArgs);
+  let getResults: t('fn, 'ret, 'tupledArgs) => list(result('ret));
+  /** Resets the internal tracking information about calls and results */
+  let resetHistory: t('fn, 'ret, 'tupledArgs) => unit;
+  /** resets the mock implementation to the implementation originally provided */
+  let resetImplementation: t('fn, 'ret, 'tupledArgs) => unit;
+  /** resets both the internal tracking information about calls and results as
+* as well as restores the mock implementation to the original implementation */
+  let reset: t('fn, 'ret, 'tupledArgs) => unit;
+  let changeImplementation: ('fn, t('fn, 'ret, 'tupledArgs)) => unit;
 
-let fn = mock => mock.fn;
-let getCalls = mock => mock.calls^;
-let getResults = mock => mock.results^;
-let wasCalled = mock =>
-  switch (mock.calls^) {
-  | [] => false
-  | [first, ...rest] => true
-  };
-let resetHistory = mock => {
-  mock.calls := [];
-  mock.results := [];
-};
-let resetImplementation = mock =>
-  mock.implementation := mock.originalImplementation;
-let reset = mock => {
-  resetHistory(mock);
-  resetImplementation(mock);
-};
-let changeImplementation = (fn, mock) => mock.implementation := fn;
-
-let mock1 = fn => {
-  let calls = ref([]);
-  let results = ref([]);
-  let implementation = ref(fn);
-  let wrappedFn = arg => {
-    calls := calls^ @ [arg];
-    switch (implementation^(arg)) {
-    | returnValue =>
-      results := results^ @ [Return(returnValue)];
-      returnValue;
-    | exception e =>
-      results := results^ @ [Exception(e)];
-      raise(e);
-    };
-  };
-  {fn: wrappedFn, originalImplementation: fn, calls, results, implementation};
-};
-
-let mock2 = fn => {
-  let calls = ref([]);
-  let results = ref([]);
-  let implementation = ref(fn);
-  let wrappedFn = (arg1, arg2) => {
-    calls := calls^ @ [(arg1, arg2)];
-    switch (implementation^(arg1, arg2)) {
-    | returnValue =>
-      results := results^ @ [Return(returnValue)];
-      returnValue;
-    | exception e =>
-      results := results^ @ [Exception(e)];
-      raise(e);
-    };
-  };
-  {fn: wrappedFn, originalImplementation: fn, calls, results, implementation};
+  let mock1: ('args => 'ret) => t('args => 'ret, 'ret, 'args);
+  let mock2:
+    (('arg1, 'arg2) => 'ret) =>
+    t(('arg1, 'arg2) => 'ret, 'ret, ('arg1, 'arg2));
+  let mock3:
+    (('arg1, 'arg2, 'arg3) => 'ret) =>
+    t(('arg1, 'arg2, 'arg3) => 'ret, 'ret, ('arg1, 'arg2, 'arg3));
+  let mock4:
+    (('arg1, 'arg2, 'arg3, 'arg4) => 'ret) =>
+    t(
+      ('arg1, 'arg2, 'arg3, 'arg4) => 'ret,
+      'ret,
+      ('arg1, 'arg2, 'arg3, 'arg4),
+    );
+  let mock5:
+    (('arg1, 'arg2, 'arg3, 'arg4, 'arg5) => 'ret) =>
+    t(
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5) => 'ret,
+      'ret,
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5),
+    );
+  let mock6:
+    (('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6) => 'ret) =>
+    t(
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6) => 'ret,
+      'ret,
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6),
+    );
+  let mock7:
+    (('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6, 'arg7) => 'ret) =>
+    t(
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6, 'arg7) => 'ret,
+      'ret,
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6, 'arg7),
+    );
 };
 
-let mock3 = fn => {
-  let calls = ref([]);
-  let results = ref([]);
-  let implementation = ref(fn);
-  let wrappedFn = (arg1, arg2, arg3) => {
-    calls := calls^ @ [(arg1, arg2, arg3)];
-    switch (implementation^(arg1, arg2, arg3)) {
-    | returnValue =>
-      results := results^ @ [Return(returnValue)];
-      returnValue;
-    | exception e =>
-      results := results^ @ [Exception(e)];
-      raise(e);
-    };
-  };
-  {fn: wrappedFn, originalImplementation: fn, calls, results, implementation};
-};
-let mock4 = fn => {
-  let calls = ref([]);
-  let results = ref([]);
-  let implementation = ref(fn);
-  let wrappedFn = (arg1, arg2, arg3, arg4) => {
-    calls := calls^ @ [(arg1, arg2, arg3, arg4)];
-    switch (implementation^(arg1, arg2, arg3, arg4)) {
-    | returnValue =>
-      results := results^ @ [Return(returnValue)];
-      returnValue;
-    | exception e =>
-      results := results^ @ [Exception(e)];
-      raise(e);
-    };
-  };
-  {fn: wrappedFn, originalImplementation: fn, calls, results, implementation};
-};
-let mock5 = fn => {
-  let calls = ref([]);
-  let results = ref([]);
-  let implementation = ref(fn);
-  let wrappedFn = (arg1, arg2, arg3, arg4, arg5) => {
-    calls := calls^ @ [(arg1, arg2, arg3, arg4, arg5)];
-    switch (implementation^(arg1, arg2, arg3, arg4, arg5)) {
-    | returnValue =>
-      results := results^ @ [Return(returnValue)];
-      returnValue;
-    | exception e =>
-      results := results^ @ [Exception(e)];
-      raise(e);
-    };
-  };
-  {fn: wrappedFn, originalImplementation: fn, calls, results, implementation};
-};
+module Make = (StackTrace: StackTrace.StackTrace) => {
+  type result('a) =
+    | Return('a)
+    | Exception(exn, option(Printexc.location), string);
 
-let mock6 = fn => {
-  let calls = ref([]);
-  let results = ref([]);
-  let implementation = ref(fn);
-  let wrappedFn = (arg1, arg2, arg3, arg4, arg5, arg6) => {
-    calls := calls^ @ [(arg1, arg2, arg3, arg4, arg5, arg6)];
-    switch (implementation^(arg1, arg2, arg3, arg4, arg5, arg6)) {
-    | returnValue =>
-      results := results^ @ [Return(returnValue)];
-      returnValue;
-    | exception e =>
-      results := results^ @ [Exception(e)];
-      raise(e);
+  type t('a, 'b, 'c) = {
+    calls: ref(list('c)),
+    results: ref(list(result('b))),
+    fn: 'a,
+    originalImplementation: 'a,
+    implementation: ref('a),
+  };
+
+  let fn = mock => mock.fn;
+  let getCalls = mock => mock.calls^;
+  let getResults = mock => mock.results^;
+  let wasCalled = mock =>
+    switch (mock.calls^) {
+    | [] => false
+    | [first, ...rest] => true
+    };
+  let resetHistory = mock => {
+    mock.calls := [];
+    mock.results := [];
+  };
+  let resetImplementation = mock =>
+    mock.implementation := mock.originalImplementation;
+  let reset = mock => {
+    resetHistory(mock);
+    resetImplementation(mock);
+  };
+  let changeImplementation = (fn, mock) => mock.implementation := fn;
+
+  let mock1 = fn => {
+    let calls = ref([]);
+    let results = ref([]);
+    let implementation = ref(fn);
+    let wrappedFn = arg => {
+      calls := calls^ @ [arg];
+      switch (implementation^(arg)) {
+      | returnValue =>
+        results := results^ @ [Return(returnValue)];
+        returnValue;
+      | exception e =>
+        let exceptionTrace = StackTrace.getExceptionStackTrace();
+        let location = StackTrace.getTopLocation(exceptionTrace);
+        let stackTrace =
+          StackTrace.stackTraceToString(exceptionTrace, maxNumStackFrames);
+        results := results^ @ [Exception(e, location, stackTrace)];
+        raise(e);
+      };
+    };
+    {
+      fn: wrappedFn,
+      originalImplementation: fn,
+      calls,
+      results,
+      implementation,
     };
   };
-  {fn: wrappedFn, originalImplementation: fn, calls, results, implementation};
-};
-let mock7 = fn => {
-  let calls = ref([]);
-  let results = ref([]);
-  let implementation = ref(fn);
-  let wrappedFn = (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => {
-    calls := calls^ @ [(arg1, arg2, arg3, arg4, arg5, arg6, arg7)];
-    switch (implementation^(arg1, arg2, arg3, arg4, arg5, arg6, arg7)) {
-    | returnValue =>
-      results := results^ @ [Return(returnValue)];
-      returnValue;
-    | exception e =>
-      results := results^ @ [Exception(e)];
-      raise(e);
+
+  let mock2 = fn => {
+    let calls = ref([]);
+    let results = ref([]);
+    let implementation = ref(fn);
+    let wrappedFn = (arg1, arg2) => {
+      calls := calls^ @ [(arg1, arg2)];
+      switch (implementation^(arg1, arg2)) {
+      | returnValue =>
+        results := results^ @ [Return(returnValue)];
+        returnValue;
+      | exception e =>
+        let exceptionTrace = StackTrace.getExceptionStackTrace();
+        let location = StackTrace.getTopLocation(exceptionTrace);
+        let stackTrace =
+          StackTrace.stackTraceToString(exceptionTrace, maxNumStackFrames);
+        results := results^ @ [Exception(e, location, stackTrace)];
+        raise(e);
+      };
+    };
+    {
+      fn: wrappedFn,
+      originalImplementation: fn,
+      calls,
+      results,
+      implementation,
     };
   };
-  {fn: wrappedFn, originalImplementation: fn, calls, results, implementation};
+
+  let mock3 = fn => {
+    let calls = ref([]);
+    let results = ref([]);
+    let implementation = ref(fn);
+    let wrappedFn = (arg1, arg2, arg3) => {
+      calls := calls^ @ [(arg1, arg2, arg3)];
+      switch (implementation^(arg1, arg2, arg3)) {
+      | returnValue =>
+        results := results^ @ [Return(returnValue)];
+        returnValue;
+      | exception e =>
+        let exceptionTrace = StackTrace.getExceptionStackTrace();
+        let location = StackTrace.getTopLocation(exceptionTrace);
+        let stackTrace =
+          StackTrace.stackTraceToString(exceptionTrace, maxNumStackFrames);
+        results := results^ @ [Exception(e, location, stackTrace)];
+        raise(e);
+      };
+    };
+    {
+      fn: wrappedFn,
+      originalImplementation: fn,
+      calls,
+      results,
+      implementation,
+    };
+  };
+  let mock4 = fn => {
+    let calls = ref([]);
+    let results = ref([]);
+    let implementation = ref(fn);
+    let wrappedFn = (arg1, arg2, arg3, arg4) => {
+      calls := calls^ @ [(arg1, arg2, arg3, arg4)];
+      switch (implementation^(arg1, arg2, arg3, arg4)) {
+      | returnValue =>
+        results := results^ @ [Return(returnValue)];
+        returnValue;
+      | exception e =>
+        let exceptionTrace = StackTrace.getExceptionStackTrace();
+        let location = StackTrace.getTopLocation(exceptionTrace);
+        let stackTrace =
+          StackTrace.stackTraceToString(exceptionTrace, maxNumStackFrames);
+        results := results^ @ [Exception(e, location, stackTrace)];
+        raise(e);
+      };
+    };
+    {
+      fn: wrappedFn,
+      originalImplementation: fn,
+      calls,
+      results,
+      implementation,
+    };
+  };
+  let mock5 = fn => {
+    let calls = ref([]);
+    let results = ref([]);
+    let implementation = ref(fn);
+    let wrappedFn = (arg1, arg2, arg3, arg4, arg5) => {
+      calls := calls^ @ [(arg1, arg2, arg3, arg4, arg5)];
+      switch (implementation^(arg1, arg2, arg3, arg4, arg5)) {
+      | returnValue =>
+        results := results^ @ [Return(returnValue)];
+        returnValue;
+      | exception e =>
+        let exceptionTrace = StackTrace.getExceptionStackTrace();
+        let location = StackTrace.getTopLocation(exceptionTrace);
+        let stackTrace =
+          StackTrace.stackTraceToString(exceptionTrace, maxNumStackFrames);
+        results := results^ @ [Exception(e, location, stackTrace)];
+        raise(e);
+      };
+    };
+    {
+      fn: wrappedFn,
+      originalImplementation: fn,
+      calls,
+      results,
+      implementation,
+    };
+  };
+
+  let mock6 = fn => {
+    let calls = ref([]);
+    let results = ref([]);
+    let implementation = ref(fn);
+    let wrappedFn = (arg1, arg2, arg3, arg4, arg5, arg6) => {
+      calls := calls^ @ [(arg1, arg2, arg3, arg4, arg5, arg6)];
+      switch (implementation^(arg1, arg2, arg3, arg4, arg5, arg6)) {
+      | returnValue =>
+        results := results^ @ [Return(returnValue)];
+        returnValue;
+      | exception e =>
+        let exceptionTrace = StackTrace.getExceptionStackTrace();
+        let location = StackTrace.getTopLocation(exceptionTrace);
+        let stackTrace =
+          StackTrace.stackTraceToString(exceptionTrace, maxNumStackFrames);
+        results := results^ @ [Exception(e, location, stackTrace)];
+        raise(e);
+      };
+    };
+    {
+      fn: wrappedFn,
+      originalImplementation: fn,
+      calls,
+      results,
+      implementation,
+    };
+  };
+  let mock7 = fn => {
+    let calls = ref([]);
+    let results = ref([]);
+    let implementation = ref(fn);
+    let wrappedFn = (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => {
+      calls := calls^ @ [(arg1, arg2, arg3, arg4, arg5, arg6, arg7)];
+      switch (implementation^(arg1, arg2, arg3, arg4, arg5, arg6, arg7)) {
+      | returnValue =>
+        results := results^ @ [Return(returnValue)];
+        returnValue;
+      | exception e =>
+        let exceptionTrace = StackTrace.getExceptionStackTrace();
+        let location = StackTrace.getTopLocation(exceptionTrace);
+        let stackTrace =
+          StackTrace.stackTraceToString(exceptionTrace, maxNumStackFrames);
+        results := results^ @ [Exception(e, location, stackTrace)];
+        raise(e);
+      };
+    };
+    {
+      fn: wrappedFn,
+      originalImplementation: fn,
+      calls,
+      results,
+      implementation,
+    };
+  };
 };

--- a/src/rely/Mock.rei
+++ b/src/rely/Mock.rei
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+
+type t('fn, 'ret, 'tupledArgs);
+type result('a) =
+  | Return('a)
+  | Exception(exn);
+
+let fn: t('fn, 'ret, 'tupledArgs) => 'fn;
+let getCalls: t('fn, 'ret, 'tupledArgs) => list('tupledArgs);
+let getResults: t('fn, 'ret, 'tupledArgs) => list(result('ret));
+/** Resets the internal tracking information about calls and results */
+let resetHistory: t('fn, 'ret, 'tupledArgs) => unit;
+/** resets the mock implementation to the implementation originally provided */
+let resetImplementation: t('fn, 'ret, 'tupledArgs) => unit;
+/** resets both the internal tracking information about calls and results as
+  * as well as restores the mock implementation to the original implementation */
+let reset: t('fn, 'ret, 'tupledArgs) => unit;
+let changeImplementation: ('fn, t('fn, 'ret, 'tupledArgs)) => unit;
+
+let mock1: ('args => 'ret) => t('args => 'ret, 'ret, 'args);
+let mock2:
+  (('arg1, 'arg2) => 'ret) => t(('arg1, 'arg2) => 'ret, 'ret, ('arg1, 'arg2));
+let mock3:
+  (('arg1, 'arg2, 'arg3) => 'ret) =>
+  t(('arg1, 'arg2, 'arg3) => 'ret, 'ret, ('arg1, 'arg2, 'arg3));
+let mock4:
+  (('arg1, 'arg2, 'arg3, 'arg4) => 'ret) =>
+  t(('arg1, 'arg2, 'arg3, 'arg4) => 'ret, 'ret, ('arg1, 'arg2, 'arg3, 'arg4));
+let mock5:
+  (('arg1, 'arg2, 'arg3, 'arg4, 'arg5) => 'ret) =>
+  t(
+    ('arg1, 'arg2, 'arg3, 'arg4, 'arg5) => 'ret,
+    'ret,
+    ('arg1, 'arg2, 'arg3, 'arg4, 'arg5),
+  );
+let mock6:
+  (('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6) => 'ret) =>
+  t(
+    ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6) => 'ret,
+    'ret,
+    ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6),
+  );
+let mock7:
+  (('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6, 'arg7) => 'ret) =>
+  t(
+    ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6, 'arg7) => 'ret,
+    'ret,
+    ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6, 'arg7),
+  );

--- a/src/rely/Mock.rei
+++ b/src/rely/Mock.rei
@@ -4,51 +4,59 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
+module type Mock = {
+  type t('fn, 'ret, 'tupledArgs);
+  type result('a) =
+    | Return('a)
+    | Exception(exn, option(Printexc.location), string);
 
-type t('fn, 'ret, 'tupledArgs);
-type result('a) =
-  | Return('a)
-  | Exception(exn);
+  let fn: t('fn, 'ret, 'tupledArgs) => 'fn;
+  let getCalls: t('fn, 'ret, 'tupledArgs) => list('tupledArgs);
+  let getResults: t('fn, 'ret, 'tupledArgs) => list(result('ret));
+  /** Resets the internal tracking information about calls and results */
+  let resetHistory: t('fn, 'ret, 'tupledArgs) => unit;
+  /** resets the mock implementation to the implementation originally provided */
+  let resetImplementation: t('fn, 'ret, 'tupledArgs) => unit;
+  /** resets both the internal tracking information about calls and results as
+* as well as restores the mock implementation to the original implementation */
+  let reset: t('fn, 'ret, 'tupledArgs) => unit;
+  let changeImplementation: ('fn, t('fn, 'ret, 'tupledArgs)) => unit;
 
-let fn: t('fn, 'ret, 'tupledArgs) => 'fn;
-let getCalls: t('fn, 'ret, 'tupledArgs) => list('tupledArgs);
-let getResults: t('fn, 'ret, 'tupledArgs) => list(result('ret));
-/** Resets the internal tracking information about calls and results */
-let resetHistory: t('fn, 'ret, 'tupledArgs) => unit;
-/** resets the mock implementation to the implementation originally provided */
-let resetImplementation: t('fn, 'ret, 'tupledArgs) => unit;
-/** resets both the internal tracking information about calls and results as
-  * as well as restores the mock implementation to the original implementation */
-let reset: t('fn, 'ret, 'tupledArgs) => unit;
-let changeImplementation: ('fn, t('fn, 'ret, 'tupledArgs)) => unit;
+  let mock1: ('args => 'ret) => t('args => 'ret, 'ret, 'args);
+  let mock2:
+    (('arg1, 'arg2) => 'ret) =>
+    t(('arg1, 'arg2) => 'ret, 'ret, ('arg1, 'arg2));
+  let mock3:
+    (('arg1, 'arg2, 'arg3) => 'ret) =>
+    t(('arg1, 'arg2, 'arg3) => 'ret, 'ret, ('arg1, 'arg2, 'arg3));
+  let mock4:
+    (('arg1, 'arg2, 'arg3, 'arg4) => 'ret) =>
+    t(
+      ('arg1, 'arg2, 'arg3, 'arg4) => 'ret,
+      'ret,
+      ('arg1, 'arg2, 'arg3, 'arg4),
+    );
+  let mock5:
+    (('arg1, 'arg2, 'arg3, 'arg4, 'arg5) => 'ret) =>
+    t(
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5) => 'ret,
+      'ret,
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5),
+    );
+  let mock6:
+    (('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6) => 'ret) =>
+    t(
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6) => 'ret,
+      'ret,
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6),
+    );
+  let mock7:
+    (('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6, 'arg7) => 'ret) =>
+    t(
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6, 'arg7) => 'ret,
+      'ret,
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6, 'arg7),
+    );
+};
 
-let mock1: ('args => 'ret) => t('args => 'ret, 'ret, 'args);
-let mock2:
-  (('arg1, 'arg2) => 'ret) => t(('arg1, 'arg2) => 'ret, 'ret, ('arg1, 'arg2));
-let mock3:
-  (('arg1, 'arg2, 'arg3) => 'ret) =>
-  t(('arg1, 'arg2, 'arg3) => 'ret, 'ret, ('arg1, 'arg2, 'arg3));
-let mock4:
-  (('arg1, 'arg2, 'arg3, 'arg4) => 'ret) =>
-  t(('arg1, 'arg2, 'arg3, 'arg4) => 'ret, 'ret, ('arg1, 'arg2, 'arg3, 'arg4));
-let mock5:
-  (('arg1, 'arg2, 'arg3, 'arg4, 'arg5) => 'ret) =>
-  t(
-    ('arg1, 'arg2, 'arg3, 'arg4, 'arg5) => 'ret,
-    'ret,
-    ('arg1, 'arg2, 'arg3, 'arg4, 'arg5),
-  );
-let mock6:
-  (('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6) => 'ret) =>
-  t(
-    ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6) => 'ret,
-    'ret,
-    ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6),
-  );
-let mock7:
-  (('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6, 'arg7) => 'ret) =>
-  t(
-    ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6, 'arg7) => 'ret,
-    'ret,
-    ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6, 'arg7),
-  );
+module Make: (StackTrace: StackTrace.StackTrace) => Mock;

--- a/src/rely/Mock.rei
+++ b/src/rely/Mock.rei
@@ -4,7 +4,14 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
+let defaultNumMaxCalls: int;
+
+module type MockConfig = {
+  let maxNumCalls: int;
+}
+
 module type Mock = {
+  exception ExceededMaxNumberOfAllowableCalls(string);
   type t('fn, 'ret, 'tupledArgs);
   type result('a) =
     | Return('a)
@@ -59,4 +66,4 @@ module type Mock = {
     );
 };
 
-module Make: (StackTrace: StackTrace.StackTrace) => Mock;
+module Make: (StackTrace: StackTrace.StackTrace, MockConfig: MockConfig) => Mock;

--- a/src/rely/Rely.re
+++ b/src/rely/Rely.re
@@ -86,7 +86,13 @@ module Make = (UserConfig: FrameworkConfig) => {
       let formatLink = Pastel.cyan;
       let formatText = Pastel.dim;
     });
-  module Mock = Mock.Make(StackTrace);
+  module Mock =
+    Mock.Make(
+      StackTrace,
+      {
+        let maxNumCalls = UserConfig.config.maxNumMockCalls;
+      },
+    );
 
   let escape = (s: string): string => {
     let lines = Str.split(Str.regexp("\n"), s);

--- a/src/rely/Rely.re
+++ b/src/rely/Rely.re
@@ -17,6 +17,7 @@ module CollectionMatchers = CollectionMatchers;
 module ListMatchers = ListMatchers;
 module MatcherTypes = MatcherTypes;
 module MatcherUtils = MatcherUtils;
+module Mock = Mock;
 module Reporter = Reporter;
 module TestResult = TestResult;
 module Time = Time;

--- a/src/rely/Rely.rei
+++ b/src/rely/Rely.rei
@@ -7,7 +7,6 @@
 module ArrayMatchers = ArrayMatchers;
 module CollectionMatchers = CollectionMatchers;
 module ListMatchers = ListMatchers;
-module Mock = Mock;
 module Reporter = Reporter;
 module TestResult = TestResult;
 module Time = Time;
@@ -25,7 +24,6 @@ module Describe: {
   }
   and describeFn('ext) = (string, describeUtils('ext) => unit) => unit;
 };
-
 
 module RunConfig: {
   type printer = {
@@ -78,6 +76,7 @@ module MatcherTypes: {
 };
 
 module type TestFramework = {
+  module Mock: Mock.Mock;
   let describe: Describe.describeFn(unit);
   let extendDescribe:
     MatcherTypes.matchersExtensionFn('ext) => Describe.describeFn('ext);

--- a/src/rely/Rely.rei
+++ b/src/rely/Rely.rei
@@ -89,6 +89,7 @@ type requiredConfiguration = TestFrameworkConfig.requiredConfiguration;
 module TestFrameworkConfig: {
   type t;
   let initialize: requiredConfiguration => t;
+  let withMaxNumberOfMockCalls: (int, t) => t;
   let internal_do_not_use_get_time: (unit => Time.t, t) => t;
 };
 

--- a/src/rely/Rely.rei
+++ b/src/rely/Rely.rei
@@ -7,6 +7,9 @@
 module ArrayMatchers = ArrayMatchers;
 module CollectionMatchers = CollectionMatchers;
 module ListMatchers = ListMatchers;
+module Mock = Mock;
+module Reporter = Reporter;
+module TestResult = TestResult;
 module Time = Time;
 
 module Test: {
@@ -23,8 +26,6 @@ module Describe: {
   and describeFn('ext) = (string, describeUtils('ext) => unit) => unit;
 };
 
-module Reporter = Reporter;
-module TestResult = TestResult;
 
 module RunConfig: {
   type printer = {

--- a/src/rely/StackTrace.rei
+++ b/src/rely/StackTrace.rei
@@ -5,19 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */;
 module type StackTrace = {
-    type t;
-    let getStackTrace: unit => t;
-    let getExceptionStackTrace: unit => t;
-    let stackTraceToString: (t, int) => string;
-    let getTopLocation: t => option(Printexc.location);
-    let formatLocation: (Printexc.location, bool) => string;
-  };
+  type t;
+  let getStackTrace: unit => t;
+  let getExceptionStackTrace: unit => t;
+  let stackTraceToString: (t, int) => string;
+  let getTopLocation: t => option(Printexc.location);
+  let formatLocation: (Printexc.location, bool) => string;
+};
 
-  module type Config = {
-    let exclude: list(string);
-    let baseDir: string;
-    let formatLink: string => string;
-    let formatText: string => string;
-  };
+module type Config = {
+  let exclude: list(string);
+  let baseDir: string;
+  let formatLink: string => string;
+  let formatText: string => string;
+};
 
-  module Make: (Config: Config) => StackTrace;
+module Make: (Config: Config) => StackTrace;

--- a/src/rely/TestFrameworkConfig.re
+++ b/src/rely/TestFrameworkConfig.re
@@ -15,6 +15,7 @@ module TestFrameworkConfig = {
   type t = {
     snapshotDir: string,
     projectDir: string,
+    maxNumMockCalls: int,
     getTime: unit => Time.t,
   };
 
@@ -25,7 +26,12 @@ module TestFrameworkConfig = {
       snapshotDir: config.snapshotDir,
       projectDir: config.projectDir,
       getTime: Clock.getTime,
+      maxNumMockCalls: Mock.defaultNumMaxCalls,
     };
 
   let internal_do_not_use_get_time = (fn, cfg: t) => {...cfg, getTime: fn};
+  let withMaxNumberOfMockCalls = (num: int, cfg: t) => {
+    ...cfg,
+    maxNumMockCalls: num,
+  };
 };

--- a/tests/__tests__/rely/Mock_test.re
+++ b/tests/__tests__/rely/Mock_test.re
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 open TestFramework;
-open Rely;
 
 module type MockTestCase = {
   type fnType;
@@ -64,9 +63,16 @@ module MakeTestSuite = (TestCase: MockTestCase) => {
           MockException,
         );
 
-        expect.list(Mock.getResults(mock)).toEqual([
-          Mock.Exception(MockException),
-        ]);
+        let exceptions =
+          Mock.getResults(mock)
+          |> List.map(r =>
+               switch (r) {
+               | Mock.Exception(e, _, _) => Some(e)
+               | _ => None
+               }
+             );
+
+        expect.list(exceptions).toEqual([Some(MockException)]);
         expect.list(Mock.getCalls(mock)).toEqual([args]);
       });
 

--- a/tests/__tests__/rely/Mock_test.re
+++ b/tests/__tests__/rely/Mock_test.re
@@ -1,0 +1,253 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+open TestFramework;
+open Rely;
+
+module type MockTestCase = {
+  type fnType;
+  type returnType;
+  type tupledArgs;
+  exception MockException;
+  let create: fnType => Mock.t(fnType, returnType, tupledArgs);
+  let call: (fnType, tupledArgs) => returnType;
+  let implementation1: fnType;
+  let implementation2: fnType;
+  let exceptionImplemtation: fnType;
+  let args: tupledArgs;
+  let testCaseName: string;
+};
+
+module MakeTestSuite = (TestCase: MockTestCase) => {
+  open TestCase;
+
+  describe(
+    testCaseName,
+    ({test}) => {
+      test("calls and results should initially be empty", ({expect}) => {
+        let mock = create(implementation1);
+
+        expect.list(mock |> Mock.getCalls).toBeEmpty();
+        expect.list(mock |> Mock.getResults).toBeEmpty();
+      });
+      let runCallAndReturnValueTestCase = numCalls =>
+        test(
+          "calls and return values should be stored "
+          ++ string_of_int(numCalls)
+          ++ " calls",
+          ({expect}) => {
+            let mock = create(implementation1);
+            let expectedCalls = ref([]);
+            let expectedResults = ref([]);
+
+            for (i in 1 to numCalls) {
+              let result = Mock.Return(call(Mock.fn(mock), args));
+              expectedCalls := expectedCalls^ @ [args];
+              expectedResults := expectedResults^ @ [result];
+            };
+
+            expect.list(mock |> Mock.getCalls).toEqual(expectedCalls^);
+            expect.list(mock |> Mock.getResults).toEqual(expectedResults^);
+          },
+        );
+      let _ = [0, 1, 2, 3] |> List.map(runCallAndReturnValueTestCase);
+
+      test(
+        "exceptions in implementation should be recorded in results and rethrown",
+        ({expect}) => {
+        let mock = create(exceptionImplemtation);
+
+        expect.fn(() => call(Mock.fn(mock), args)).toThrowException(
+          MockException,
+        );
+
+        expect.list(Mock.getResults(mock)).toEqual([
+          Mock.Exception(MockException),
+        ]);
+        expect.list(Mock.getCalls(mock)).toEqual([args]);
+      });
+
+      test("reset history should reset calls and results", ({expect}) => {
+        let mock = create(implementation1);
+
+        let _ = call(Mock.fn(mock), args);
+        mock |> Mock.resetHistory;
+
+        expect.list(mock |> Mock.getCalls).toBeEmpty();
+        expect.list(mock |> Mock.getResults).toBeEmpty();
+      });
+
+      test(
+        "should return the same value as the provided implementation",
+        ({expect}) => {
+        let mock = create(implementation1);
+        let implementationResult = call(implementation1, args);
+
+        let mockResult = call(Mock.fn(mock), args);
+
+        expect.bool(mockResult == implementationResult).toBeTrue();
+      });
+
+      test(
+        "changeImplementation should cause Mock.fn to return same value as the new implementation",
+        ({expect}) => {
+          let mock = create(implementation1);
+          let implementation1Result = call(implementation1, args);
+          let implementation2Result = call(implementation2, args);
+
+          mock |> Mock.changeImplementation(implementation2);
+          let mockResult = call(Mock.fn(mock), args);
+
+          /* additionally requiring implementation 1 and 2 to return different
+           * things, otherwise this test is silly */
+          expect.bool(implementation1Result == implementation2Result).
+            toBeFalse();
+          expect.bool(mockResult == implementation2Result).toBeTrue();
+        },
+      );
+
+      test(
+        "resetImplementation should cause Mock.fn to return same value as the original implementation",
+        ({expect}) => {
+          let mock = create(implementation1);
+          let expectedResult = call(implementation1, args);
+
+          mock |> Mock.changeImplementation(implementation2);
+          mock |> Mock.changeImplementation(exceptionImplemtation);
+          mock |> Mock.resetImplementation;
+
+          let mockResult = call(Mock.fn(mock), args);
+
+          expect.bool(mockResult == expectedResult).toBeTrue();
+        },
+      );
+
+      test(
+        "reset should reset calls, returns, the implementation", ({expect}) => {
+        let mock = create(implementation1);
+
+        mock |> Mock.changeImplementation(implementation2);
+        let _ = call(Mock.fn(mock), args);
+        Mock.reset(mock);
+
+        expect.list(Mock.getCalls(mock)).toBeEmpty();
+        expect.list(Mock.getResults(mock)).toBeEmpty();
+        let result = call(Mock.fn(mock), args);
+        let expectedResult = call(implementation1, args);
+        expect.bool(result == expectedResult).toBeTrue();
+      });
+    },
+  );
+};
+
+module Mock1Tests =
+  MakeTestSuite({
+    type fnType = int => int;
+    type returnType = int;
+    type tupledArgs = int;
+    exception MockException;
+    let create = Mock.mock1;
+    let call = (fn, arg) => fn(arg);
+    let implementation1 = a => a;
+    let implementation2 = a => 1 + a;
+    let exceptionImplemtation = a => raise(MockException);
+    let args = 0;
+    let testCaseName = "Rely.mock1";
+  });
+
+module Mock2Tests =
+  MakeTestSuite({
+    type fnType = (int, int) => int;
+    type returnType = int;
+    type tupledArgs = (int, int);
+    exception MockException;
+    let create = Mock.mock2;
+    let call = (fn, (arg1, arg2)) => fn(arg1, arg2);
+    let implementation1 = (a, b) => a;
+    let implementation2 = (a, b) => b;
+    let exceptionImplemtation = (a, b) => raise(MockException);
+    let args = (1, 0);
+    let testCaseName = "Rely.mock2";
+  });
+
+module Mock3Tests =
+  MakeTestSuite({
+    type fnType = (int, int, int) => int;
+    type returnType = int;
+    type tupledArgs = (int, int, int);
+    exception MockException;
+    let create = Mock.mock3;
+    let call = (fn, (arg1, arg2, arg3)) => fn(arg1, arg2, arg3);
+    let implementation1 = (a, b, c) => a;
+    let implementation2 = (a, b, c) => b;
+    let exceptionImplemtation = (a, b, c) => raise(MockException);
+    let args = (1, 0, (-1));
+    let testCaseName = "Rely.mock3";
+  });
+
+module Mock4Tests =
+  MakeTestSuite({
+    type fnType = (int, int, int, int) => int;
+    type returnType = int;
+    type tupledArgs = (int, int, int, int);
+    exception MockException;
+    let create = Mock.mock4;
+    let call = (fn, (arg1, arg2, arg3, arg4)) => fn(arg1, arg2, arg3, arg4);
+    let implementation1 = (a, b, c, d) => a;
+    let implementation2 = (a, b, c, d) => b;
+    let exceptionImplemtation = (a, b, c, d) => raise(MockException);
+    let args = (1, 0, (-1), 42);
+    let testCaseName = "Rely.mock4";
+  });
+
+module Mock5Tests =
+  MakeTestSuite({
+    type fnType = (int, int, int, int, int) => int;
+    type returnType = int;
+    type tupledArgs = (int, int, int, int, int);
+    exception MockException;
+    let create = Mock.mock5;
+    let call = (fn, (arg1, arg2, arg3, arg4, arg5)) =>
+      fn(arg1, arg2, arg3, arg4, arg5);
+    let implementation1 = (a, b, c, d, e) => a;
+    let implementation2 = (a, b, c, d, e) => b;
+    let exceptionImplemtation = (a, b, c, d, e) => raise(MockException);
+    let args = (1, 0, (-1), 42, (-42));
+    let testCaseName = "Rely.mock5";
+  });
+
+module Mock6Tests =
+  MakeTestSuite({
+    type fnType = (int, int, int, int, int, int) => int;
+    type returnType = int;
+    type tupledArgs = (int, int, int, int, int, int);
+    exception MockException;
+    let create = Mock.mock6;
+    let call = (fn, (arg1, arg2, arg3, arg4, arg5, arg6)) =>
+      fn(arg1, arg2, arg3, arg4, arg5, arg6);
+    let implementation1 = (a, b, c, d, e, f) => a;
+    let implementation2 = (a, b, c, d, e, f) => b;
+    let exceptionImplemtation = (a, b, c, d, e, f) => raise(MockException);
+    let args = (1, 0, (-1), 42, (-42), 6);
+    let testCaseName = "Rely.mock6";
+  });
+
+module Mock7Tests =
+  MakeTestSuite({
+    type fnType = (int, int, int, int, int, int, int) => int;
+    type returnType = int;
+    type tupledArgs = (int, int, int, int, int, int, int);
+    exception MockException;
+    let create = Mock.mock7;
+    let call = (fn, (arg1, arg2, arg3, arg4, arg5, arg6, arg7)) =>
+      fn(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+    let implementation1 = (a, b, c, d, e, f, g) => a;
+    let implementation2 = (a, b, c, d, e, f, g) => b;
+    let exceptionImplemtation = (a, b, c, d, e, f, g) =>
+      raise(MockException);
+    let args = (1, 0, (-1), 42, (-42), 6, (-6));
+    let testCaseName = "Rely.mock7";
+  });

--- a/tests/__tests__/rely/Mock_test.re
+++ b/tests/__tests__/rely/Mock_test.re
@@ -145,6 +145,21 @@ module MakeTestSuite = (TestCase: MockTestCase) => {
         let expectedResult = call(implementation1, args);
         expect.bool(result == expectedResult).toBeTrue();
       });
+
+      /** This test is relatively expensive, it could be made more performant
+        * by instantiating a new TestFramework and configuring the limit to be
+        * much lower. However currently for Mock1-7 it is only adding a total of
+        * about 70ms, so I am leaving it as is for now.
+        */
+      test("excessive calls should trigger an exception", ({expect}) => {
+        let mock = create(implementation1);
+        let fn = Mock.fn(mock);
+        expect.fn(() => {
+          for(i in 1 to 15000) {
+            let _ = call(fn, args);
+          }
+        }).toThrow();
+      })
     },
   );
 };


### PR DESCRIPTION
Rely.mock feature. Currently working on matchers as well, but keeping the PRs separate.

See Mock.rei for the interface. It is expected that consumers will use expect.mock matchers rather than manual inspection of the results of getCalls and getResults.