### PR TITLE
Benderson/mock matchers

### DIFF
--- a/src/rely/Mock.re
+++ b/src/rely/Mock.re
@@ -6,13 +6,21 @@
  */;
 let maxNumStackFrames = 3;
 let defaultNumMaxCalls = 10000;
+type result('a) =
+  | Return('a)
+  | Exception(exn, option(Printexc.location), string);
 
-module type Mock = {
+type t('fn, 'ret, 'tupledArgs) = {
+  calls: ref(list('tupledArgs)),
+  results: ref(list(result('ret))),
+  fn: 'fn,
+  originalImplementation: 'fn,
+  implementation: ref('fn),
+  numCalls: ref(int),
+};
+
+module type Sig = {
   exception ExceededMaxNumberOfAllowableCalls(string);
-  type t('fn, 'ret, 'tupledArgs);
-  type result('a) =
-    | Return('a)
-    | Exception(exn, option(Printexc.location), string);
 
   let fn: t('fn, 'ret, 'tupledArgs) => 'fn;
   let getCalls: t('fn, 'ret, 'tupledArgs) => list('tupledArgs);
@@ -67,18 +75,6 @@ module type MockConfig = {let maxNumCalls: int;};
 
 module Make = (StackTrace: StackTrace.StackTrace, MockConfig: MockConfig) => {
   exception ExceededMaxNumberOfAllowableCalls(string);
-  type result('a) =
-    | Return('a)
-    | Exception(exn, option(Printexc.location), string);
-
-  type t('a, 'b, 'c) = {
-    calls: ref(list('c)),
-    results: ref(list(result('b))),
-    fn: 'a,
-    originalImplementation: 'a,
-    implementation: ref('a),
-    numCalls: ref(int),
-  };
 
   let fn = mock => mock.fn;
   let getCalls = mock => mock.calls^;

--- a/src/rely/Mock.rei
+++ b/src/rely/Mock.rei
@@ -5,18 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */;
 let defaultNumMaxCalls: int;
+type t('fn, 'ret, 'tupledArgs);
+type result('a) =
+  | Return('a)
+  | Exception(exn, option(Printexc.location), string);
 
-module type MockConfig = {
-  let maxNumCalls: int;
-}
+module type MockConfig = {let maxNumCalls: int;};
 
-module type Mock = {
+module type Sig = {
   exception ExceededMaxNumberOfAllowableCalls(string);
-  type t('fn, 'ret, 'tupledArgs);
-  type result('a) =
-    | Return('a)
-    | Exception(exn, option(Printexc.location), string);
-
   let fn: t('fn, 'ret, 'tupledArgs) => 'fn;
   let getCalls: t('fn, 'ret, 'tupledArgs) => list('tupledArgs);
   let getResults: t('fn, 'ret, 'tupledArgs) => list(result('ret));
@@ -66,4 +63,5 @@ module type Mock = {
     );
 };
 
-module Make: (StackTrace: StackTrace.StackTrace, MockConfig: MockConfig) => Mock;
+module Make:
+  (StackTrace: StackTrace.StackTrace, MockConfig: MockConfig) => Sig;

--- a/src/rely/Rely.re
+++ b/src/rely/Rely.re
@@ -61,7 +61,7 @@ type runDescribeFn('ext) =
   describeResult;
 
 module type TestFramework = {
-  module Mock: Mock.Mock;
+  module Mock: Mock.Sig;
   let describe: Describe.describeFn(unit);
   let extendDescribe:
     MatcherTypes.matchersExtensionFn('ext) => Describe.describeFn('ext);
@@ -92,7 +92,7 @@ module Make = (UserConfig: FrameworkConfig) => {
         let maxNumCalls = UserConfig.config.maxNumMockCalls;
       },
     );
-
+  module DefaultMatchers = DefaultMatchers.Make(Mock);
   let escape = (s: string): string => {
     let lines = Str.split(Str.regexp("\n"), s);
     let lines = List.map(line => String.escaped(line), lines);

--- a/src/rely/Rely.rei
+++ b/src/rely/Rely.rei
@@ -9,6 +9,7 @@ module CollectionMatchers = CollectionMatchers;
 module ListMatchers = ListMatchers;
 module Reporter = Reporter;
 module Time = Time;
+module Mock = Mock;
 
 module Test: {
   type testUtils('ext) = {expect: DefaultMatchers.matchers('ext)};
@@ -73,7 +74,7 @@ module MatcherTypes: {
 };
 
 module type TestFramework = {
-  module Mock: Mock.Mock;
+  module Mock: Mock.Sig;
   let describe: Describe.describeFn(unit);
   let extendDescribe:
     MatcherTypes.matchersExtensionFn('ext) => Describe.describeFn('ext);

--- a/src/rely/matchers/CollectionMatchers.re
+++ b/src/rely/matchers/CollectionMatchers.re
@@ -9,7 +9,6 @@ open EqualityValidator;
 open MatcherTypes;
 
 type equalsFn('a) = ('a, 'a) => bool;
-type predicate('a) = 'a => bool;
 
 module type Collection = {
   type t('a);

--- a/src/rely/matchers/DefaultMatchers.re
+++ b/src/rely/matchers/DefaultMatchers.re
@@ -24,32 +24,36 @@ type matchers('ext) = {
   fn: 'a. (unit => 'a) => fnMatchersWithNot,
   list: 'a. list('a) => ListMatchers.matchersWithNot('a),
   array: 'a. array('a) => ArrayMatchers.matchersWithNot('a),
-  ext: 'ext,
   equal: 'a. EqualsMatcher.equalsMatcher('a),
   notEqual: 'a. EqualsMatcher.equalsMatcher('a),
   same: 'a. SameMatcher.sameMatcher('a),
   notSame: 'a. SameMatcher.sameMatcher('a),
+  mock: 'fn 'ret 'tupledArgs. Mock.t('fn, 'ret, 'tupledArgs) => MockMatchers.matchersWithNot('tupledArgs, 'ret),
+  ext: 'ext,
 };
 
-let makeDefaultMatchers = (utils, snapshotMatcher, makeMatchers) => {
-  string: s =>
-    StringMatchers.makeMatchers(".string", snapshotMatcher, utils, s),
-  file: filePath => {
-    let sActual = IO.readFile(filePath);
-    StringMatchers.makeMatchers(".file", snapshotMatcher, utils, sActual);
-  },
-  lines: lines => {
-    let sActual = String.concat("\n", lines);
-    StringMatchers.makeMatchers(".lines", snapshotMatcher, utils, sActual);
-  },
-  bool: b => BoolMatchers.makeMatchers(".bool", utils, b),
-  int: i => IntMatchers.makeMatchers(".int", utils, i),
-  float: f => FloatMatchers.makeMatchers(".float", utils, f),
-  fn: f => FnMatchers.makeMatchers(".fn", utils, f),
-  list: l => ListMatchers.makeMatchers(".list", utils, l),
-  array: a => ArrayMatchers.makeMatchers(".array", utils, a),
-  ext: makeMatchers(utils),
-  equal: (~equals=?, expected, actual) =>
+module Make = (Mock: Mock.Sig) => {
+  module MockMatchers = MockMatchers.Make(Mock);
+
+  let makeDefaultMatchers = (utils, snapshotMatcher, makeMatchers) => {
+    string: s =>
+      StringMatchers.makeMatchers(".string", snapshotMatcher, utils, s),
+    file: filePath => {
+      let sActual = IO.readFile(filePath);
+      StringMatchers.makeMatchers(".file", snapshotMatcher, utils, sActual);
+    },
+    lines: lines => {
+      let sActual = String.concat("\n", lines);
+      StringMatchers.makeMatchers(".lines", snapshotMatcher, utils, sActual);
+    },
+    bool: b => BoolMatchers.makeMatchers(".bool", utils, b),
+    int: i => IntMatchers.makeMatchers(".int", utils, i),
+    float: f => FloatMatchers.makeMatchers(".float", utils, f),
+    fn: f => FnMatchers.makeMatchers(".fn", utils, f),
+    list: l => ListMatchers.makeMatchers(".list", utils, l),
+    array: a => ArrayMatchers.makeMatchers(".array", utils, a),
+    mock: m => MockMatchers.makeMatchers(".mock", utils, m),
+    equal: (~equals=?, expected, actual) =>
     EqualsMatcher.makeEqualMatcher(
       ".equal",
       utils,
@@ -69,4 +73,7 @@ let makeDefaultMatchers = (utils, snapshotMatcher, makeMatchers) => {
     SameMatcher.makeSameMatcher(".same", utils, expected, actual),
   notSame: (expected, actual) =>
     SameMatcher.makeNotSameMatcher(".notSame", utils, expected, actual),
-};
+    ext: makeMatchers(utils)
+  };
+}
+

--- a/src/rely/matchers/MatcherUtils.re
+++ b/src/rely/matchers/MatcherUtils.re
@@ -113,6 +113,30 @@ let singleLevelMatcherHint =
   };
 };
 
+let numbers = [|
+  "zero",
+  "one",
+  "two",
+  "three",
+  "four",
+  "five",
+  "six",
+  "seven",
+  "eight",
+  "nine",
+  "ten",
+  "eleven",
+  "twelve",
+  "thirteen",
+|];
+
+let formatInt = n =>
+  if (0 <= n && n <= Array.length(numbers)) {
+    numbers[n];
+  } else {
+    string_of_int(n);
+  };
+
 let matcherUtils = {
   matcherHint,
   formatReceived,

--- a/src/rely/matchers/MatcherUtils.rei
+++ b/src/rely/matchers/MatcherUtils.rei
@@ -33,4 +33,6 @@ let singleLevelMatcherHint:
       unit,
     ) => string;
 
+let formatInt: int => string;
+
 let matcherUtils: t;

--- a/src/rely/matchers/MockMatchers.re
+++ b/src/rely/matchers/MockMatchers.re
@@ -66,7 +66,7 @@ module Make = (M: Mock.Sig) => {
     let printedExceptions =
       toPrint
       |> List.rev
-      |> List.map(ex => ex |> Printexc.to_string)
+      |> List.map(ex => ex |> Printexc.to_string |> formatException)
       |> String.concat(", ");
 
     switch (remainder) {

--- a/src/rely/matchers/MockMatchers.re
+++ b/src/rely/matchers/MockMatchers.re
@@ -1,0 +1,1038 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+open MatcherTypes;
+
+/** TODO we can do call/return validation around usage of == like in
+  * collection matchers and equals matcher. Not implemented because more
+  * complicated for tuples (see ObjectPrinter.re for a rough guideline)
+  */
+type equalsFn('a) = ('a, 'a) => bool;
+
+/*
+ * toThrowException is explicitly not included on "not" as the expected behavior
+ * is difficult to articulate. Jest will pass if it throws an exception other than the
+ * one it is not supposed to throw as well as if no exception is thrown. I assert that
+ * .not.toThrow is more intuitive and meets most use cases and as a result we should hold off
+ * on adding .not for specific exceptions until compelling use cases are brought forward
+ */
+type matchers('tupledArgs, 'ret) = {
+  toThrow: unit => unit,
+  toBeCalled: unit => unit,
+  toBeCalledTimes: int => unit,
+  toBeCalledWith: (~equals: equalsFn('tupledArgs)=?, 'tupledArgs) => unit,
+  lastCalledWith: (~equals: equalsFn('tupledArgs)=?, 'tupledArgs) => unit,
+  toReturnTimes: int => unit,
+  toReturnWith: (~equals: equalsFn('ret)=?, 'ret) => unit,
+  lastReturnedWith: (~equals: equalsFn('ret)=?, 'ret) => unit,
+};
+
+type matchersWithNot('tupledArgs, 'ret) = {
+  not: matchers('tupledArgs, 'ret),
+  toThrow: unit => unit,
+  toThrowException: exn => unit,
+  toBeCalled: unit => unit,
+  toBeCalledTimes: int => unit,
+  toBeCalledWith: (~equals: equalsFn('tupledArgs)=?, 'tupledArgs) => unit,
+  lastCalledWith: (~equals: equalsFn('tupledArgs)=?, 'tupledArgs) => unit,
+  toReturnTimes: int => unit,
+  toReturnWith: (~equals: equalsFn('ret)=?, 'ret) => unit,
+  lastReturnedWith: (~equals: equalsFn('ret)=?, 'ret) => unit,
+};
+
+let passMessageThunk = () => "";
+let defaultEqualityFn = (==);
+
+module Make = (M: Mock.Sig) => {
+  let formatExceptions = exceptions =>
+    switch (exceptions) {
+    | [singleton] => Printexc.to_string(singleton)
+    | other => PolymorphicPrint.print(other |> List.map(Printexc.to_string))
+    };
+  let split = (list, numToTake) => {
+    let rec splitInternal = (list, numToTake, acc) =>
+      switch (numToTake) {
+      | 0 => (acc, list)
+      | n =>
+        switch (list) {
+        | [] => (acc, [])
+        | [h, ...t] => splitInternal(t, numToTake - 1, [h, ...acc])
+        }
+      };
+    splitInternal(list, numToTake, []);
+  };
+
+  let formatCalls = (calls, formatCall) => {
+    let maxNumCalls = 3;
+    let (toPrint, remainder) = split(calls, maxNumCalls);
+    let printedCalls =
+      toPrint
+      |> List.rev
+      |> List.map(call => call |> PolymorphicPrint.print |> formatCall)
+      |> String.concat(", ");
+    switch (remainder) {
+    | [] => printedCalls
+    | l =>
+      switch (List.length(l)) {
+      | 1 => printedCalls ++ formatCall(" and one more call.")
+      | n =>
+        printedCalls
+        ++ formatCall(" and " ++ MatcherUtils.formatInt(n) ++ " more calls.")
+      }
+    };
+  };
+
+  let formatReturns = (returns, formatReturn) => {
+    let maxNumCalls = 3;
+    let (toPrint, remainder) = split(returns, maxNumCalls);
+    let printedRets =
+      toPrint
+      |> List.rev
+      |> List.map(call => call |> PolymorphicPrint.print |> formatReturn)
+      |> String.concat(", ");
+    switch (remainder) {
+    | [] => printedRets
+    | l =>
+      switch (List.length(l)) {
+      | 1 => printedRets ++ formatReturn(" and one more value.")
+      | n =>
+        printedRets
+        ++ formatReturn(
+             " and " ++ MatcherUtils.formatInt(n) ++ " more values.",
+           )
+      }
+    };
+  };
+
+  let numTimesString = num =>
+    MatcherUtils.formatInt(num) ++ (num == 1 ? " time" : " times");
+  let getReturns = mock =>
+    M.getResults(mock)
+    |> List.fold_left(
+         (acc, r) =>
+           switch (r) {
+           | Mock.Return(v) => [v, ...acc]
+           | Exception(_, _, _) => acc
+           },
+         [],
+       );
+
+  let makeMatchers = (accessorPath, {createMatcher}) => {
+    let createMockMatchers = mock => {
+      let toThrow =
+        createMatcher(
+          ({matcherHint, formatReceived, formatExpected}, actualThunk, _) => {
+          let mock = actualThunk();
+          let results = M.getResults(mock);
+          let exceptions =
+            results
+            |> List.filter(r =>
+                 switch (r) {
+                 | Mock.Exception(_, _, _) => true
+                 | Return(_) => false
+                 }
+               );
+
+          switch (exceptions) {
+          | [h, ...t] => (passMessageThunk, true)
+          | [] =>
+            let message =
+              String.concat(
+                "",
+                [
+                  matcherHint(
+                    ~matcherName=".toThrow",
+                    ~isNot=false,
+                    ~expectType=accessorPath,
+                    ~expected="",
+                    ~received="mock",
+                    (),
+                  ),
+                  "\n\n",
+                  "Expected the function to throw an error.\n",
+                  "But it didn't throw anything.",
+                ],
+              );
+            ((() => message), false);
+          };
+        });
+
+      let notToThrow =
+        createMatcher(
+          (
+            {matcherHint, formatReceived, indent, formatExpected},
+            actualThunk,
+            _,
+          ) => {
+          let mock = actualThunk();
+          let results = M.getResults(mock);
+          let exceptions =
+            results
+            |> List.map(r =>
+                 switch (r) {
+                 | Mock.Exception(e, _, _) => Some(e)
+                 | Return(_) => None
+                 }
+               )
+            |> List.fold_left(
+                 (acc, opt) =>
+                   switch (opt) {
+                   | Some(err) => [err, ...acc]
+                   | None => acc
+                   },
+                 [],
+               );
+
+          switch (exceptions) {
+          | [] => (passMessageThunk, true)
+          | arr =>
+            let message =
+              String.concat(
+                "",
+                [
+                  matcherHint(
+                    ~matcherName="toThrow",
+                    ~isNot=true,
+                    ~expectType=accessorPath,
+                    ~expected="",
+                    ~received="mock",
+                    (),
+                  ),
+                  "\n\n",
+                  "Expected the function not to throw an error.\n",
+                  "Instead, it threw: \n",
+                  indent(formatReceived(formatExceptions(arr))),
+                ],
+              );
+            ((() => message), false);
+          };
+        });
+
+      let toThrowException =
+        createMatcher(
+          (
+            {matcherHint, formatReceived, formatExpected, indent},
+            actualThunk,
+            expectedThunk,
+          ) => {
+          let mock = actualThunk();
+          let expectedException = expectedThunk();
+          let results = M.getResults(mock);
+          let exceptions =
+            results
+            |> List.map(r =>
+                 switch (r) {
+                 | Mock.Exception(e, _, _) => Some(e)
+                 | Return(_) => None
+                 }
+               )
+            |> List.fold_left(
+                 (acc, opt) =>
+                   switch (opt) {
+                   | Some(err) => [err, ...acc]
+                   | None => acc
+                   },
+                 [],
+               );
+          let threwExpectedException =
+            List.exists(e => e == expectedException, exceptions);
+
+          if (threwExpectedException) {
+            (passMessageThunk, true);
+          } else {
+            switch (exceptions) {
+            | [] =>
+              let message =
+                String.concat(
+                  "",
+                  [
+                    matcherHint(
+                      ~matcherName=".toThrowException",
+                      ~isNot=false,
+                      ~expectType=accessorPath,
+                      ~expected="exception",
+                      ~received="function",
+                      (),
+                    ),
+                    "\n\n",
+                    "Expected the function to throw an error matching:\n",
+                    indent(
+                      formatExpected(Printexc.to_string(expectedException)),
+                    ),
+                    "\n",
+                    "But it didn't throw anything.",
+                  ],
+                );
+              ((() => message), false);
+            | otherExceptions =>
+              let message =
+                String.concat(
+                  "",
+                  [
+                    matcherHint(
+                      ~matcherName=".toThrowException",
+                      ~isNot=false,
+                      ~expectType=accessorPath,
+                      ~expected="exception",
+                      ~received="function",
+                      (),
+                    ),
+                    "\n\n",
+                    "Expected the function to throw an error matching:\n",
+                    indent(
+                      formatExpected(Printexc.to_string(expectedException)),
+                    ),
+                    "\n",
+                    "Instead, it threw:\n",
+                    indent(
+                      formatReceived(formatExceptions(otherExceptions)),
+                    ),
+                  ],
+                );
+              ((() => message), false);
+            };
+          };
+        });
+
+      let toBeCalled = isNot =>
+        createMatcher(
+          (
+            {matcherHint, formatReceived, formatExpected, indent},
+            actualThunk,
+            expectedThunk,
+          ) => {
+          let mock = actualThunk();
+          let calls = M.getCalls(mock);
+          let wasCalled =
+            switch (calls) {
+            | [] => false
+            | [h, ...t] => true
+            };
+
+          switch (isNot, wasCalled) {
+          | (true, false)
+          | (false, true) => (passMessageThunk, true)
+          | (true, true) =>
+            let message =
+              String.concat(
+                "",
+                [
+                  matcherHint(
+                    ~expectType=accessorPath,
+                    ~isNot,
+                    ~matcherName=".toBeCalled",
+                    ~expected="",
+                    ~received="mock",
+                    (),
+                  ),
+                  "\n\n",
+                  "Expected the mock not be called, but it was called with:\n",
+                  indent(formatCalls(calls, formatReceived)),
+                ],
+              );
+            ((() => message), false);
+          | (false, false) =>
+            let message =
+              String.concat(
+                "",
+                [
+                  matcherHint(
+                    ~expectType=accessorPath,
+                    ~isNot,
+                    ~matcherName=".toBeCalled",
+                    ~expected="",
+                    ~received="mock",
+                    (),
+                  ),
+                  "\n\n",
+                  "Expected the mock to be called, but it was not called.",
+                ],
+              );
+            ((() => message), false);
+          };
+        });
+      let toBeCalledTimes = isNot =>
+        createMatcher(
+          (
+            {matcherHint, formatReceived, formatExpected, indent},
+            actualThunk,
+            expectedThunk,
+          ) => {
+          let mock = actualThunk();
+          let expectedNumCalls = expectedThunk();
+          let calls = M.getCalls(mock);
+          let actualNumCalls = List.length(calls);
+
+          let wasCalledCorrectNumberOfTimes =
+            expectedNumCalls == actualNumCalls;
+
+          switch (isNot, wasCalledCorrectNumberOfTimes) {
+          | (true, false)
+          | (false, true) => (passMessageThunk, true)
+          | (true, true) =>
+            let message =
+              String.concat(
+                "",
+                [
+                  matcherHint(
+                    ~expectType=accessorPath,
+                    ~isNot,
+                    ~matcherName=".toBeCalledTimes",
+                    ~received="mock",
+                    (),
+                  ),
+                  "\n\n",
+                  "Expected the mock not be called ",
+                  formatExpected(numTimesString(expectedNumCalls)),
+                  ", but it was called exactly ",
+                  formatReceived(numTimesString(actualNumCalls)),
+                  ".",
+                ],
+              );
+            ((() => message), false);
+          | (false, false) =>
+            switch (calls) {
+            | [] =>
+              let message =
+                String.concat(
+                  "",
+                  [
+                    matcherHint(
+                      ~expectType=accessorPath,
+                      ~isNot,
+                      ~matcherName=".toBeCalledTimes",
+                      ~received="mock",
+                      (),
+                    ),
+                    "\n\n",
+                    "Expected the mock to have been called ",
+                    formatExpected(numTimesString(expectedNumCalls)),
+                    ", but it was ",
+                    formatReceived("not called"),
+                    ".",
+                  ],
+                );
+              ((() => message), false);
+            | l =>
+              let message =
+                String.concat(
+                  "",
+                  [
+                    matcherHint(
+                      ~expectType=accessorPath,
+                      ~isNot,
+                      ~matcherName=".toBeCalledTimes",
+                      ~received="mock",
+                      (),
+                    ),
+                    "\n\n",
+                    "Expected the mock to have been called ",
+                    formatExpected(numTimesString(expectedNumCalls)),
+                    ", but it was called ",
+                    formatReceived(numTimesString(actualNumCalls)),
+                    ".",
+                  ],
+                );
+              ((() => message), false);
+            }
+          };
+        });
+      let toBeCalledWith = isNot =>
+        createMatcher(
+          (
+            {matcherHint, formatReceived, formatExpected, indent},
+            actualThunk,
+            expectedThunk,
+          ) => {
+          let mock = actualThunk();
+          let (equals, expectedArgs) = expectedThunk();
+
+          let calls = M.getCalls(mock);
+          let wasCalledWithExpected =
+            List.exists(args => equals(args, expectedArgs), calls);
+          let isUsingDefaultEquality = equals === defaultEqualityFn;
+
+          switch (isNot, wasCalledWithExpected) {
+          | (true, false)
+          | (false, true) => (passMessageThunk, true)
+          | (true, true) =>
+            let message =
+              String.concat(
+                "",
+                [
+                  matcherHint(
+                    ~expectType=accessorPath,
+                    ~isNot,
+                    ~matcherName=".toBeCalledWith",
+                    ~received="mock",
+                    ~options={
+                      comment:
+                        isUsingDefaultEquality ? Some("using ==") : None,
+                    },
+                    (),
+                  ),
+                  "\n\n",
+                  "Expected the mock not to have been called with:\n",
+                  indent(
+                    formatExpected(PolymorphicPrint.print(expectedArgs)),
+                  ),
+                  "\nBut it was called with arguments equal to:\n",
+                  indent(
+                    formatReceived(PolymorphicPrint.print(expectedArgs)),
+                  ),
+                ],
+              );
+            ((() => message), false);
+          | (false, false) =>
+            switch (calls) {
+            | [] =>
+              let message =
+                String.concat(
+                  "",
+                  [
+                    matcherHint(
+                      ~expectType=accessorPath,
+                      ~isNot,
+                      ~matcherName=".toBeCalledWith",
+                      ~received="mock",
+                      ~options={
+                        comment:
+                          isUsingDefaultEquality ? Some("using ==") : None,
+                      },
+                      (),
+                    ),
+                    "\n\n",
+                    "Expected the mock to have been called with:\n",
+                    indent(
+                      formatExpected(PolymorphicPrint.print(expectedArgs)),
+                    ),
+                    "But it was ",
+                    formatReceived("not called"),
+                    ".",
+                  ],
+                );
+              ((() => message), false);
+            | calls =>
+              let message =
+                String.concat(
+                  "",
+                  [
+                    matcherHint(
+                      ~expectType=accessorPath,
+                      ~isNot,
+                      ~matcherName=".toBeCalledWith",
+                      ~received="mock",
+                      ~options={
+                        comment:
+                          isUsingDefaultEquality ? Some("using ==") : None,
+                      },
+                      (),
+                    ),
+                    "\n\n",
+                    "Expected the mock to have been called with:\n",
+                    indent(
+                      formatExpected(PolymorphicPrint.print(expectedArgs)),
+                    ),
+                    "\nBut it was called with:\n",
+                    indent(formatCalls(calls, formatReceived)),
+                  ],
+                );
+              ((() => message), false);
+            }
+          };
+        });
+      let lastCalledWith = isNot =>
+        createMatcher(
+          (
+            {matcherHint, formatReceived, formatExpected, indent},
+            actualThunk,
+            expectedThunk,
+          ) => {
+          let mock = actualThunk();
+          let (equals, expectedArgs) = expectedThunk();
+          let isUsingDefaultEquality = equals === defaultEqualityFn;
+
+          let calls = M.getCalls(mock);
+          let wasLastCalledWithExpected =
+            switch (calls) {
+            | [] => false
+            | [h, ...t] => equals(h, expectedArgs)
+            };
+
+          switch (isNot, wasLastCalledWithExpected) {
+          | (true, false)
+          | (false, true) => (passMessageThunk, true)
+          | (true, true) =>
+            let message =
+              String.concat(
+                "",
+                [
+                  matcherHint(
+                    ~expectType=accessorPath,
+                    ~isNot,
+                    ~matcherName=".lastCalledWith",
+                    ~received="mock",
+                    ~options={
+                      comment:
+                        isUsingDefaultEquality ? Some("using ==") : None,
+                    },
+                    (),
+                  ),
+                  "\n\n",
+                  "Expected the mock not to have been last called with:\n",
+                  indent(
+                    formatExpected(PolymorphicPrint.print(expectedArgs)),
+                  ),
+                  "\nBut it was called with arguments equal to:\n",
+                  indent(
+                    formatReceived(PolymorphicPrint.print(expectedArgs)),
+                  ),
+                ],
+              );
+            ((() => message), false);
+          | (false, false) =>
+            switch (calls) {
+            | [] =>
+              let message =
+                String.concat(
+                  "",
+                  [
+                    matcherHint(
+                      ~expectType=accessorPath,
+                      ~isNot,
+                      ~matcherName=".lastCalledWith",
+                      ~received="mock",
+                      ~options={
+                        comment:
+                          isUsingDefaultEquality ? Some("using ==") : None,
+                      },
+                      (),
+                    ),
+                    "\n\n",
+                    "Expected the mock to have been last called with:\n",
+                    indent(
+                      formatExpected(PolymorphicPrint.print(expectedArgs)),
+                    ),
+                    "\nBut it was ",
+                    formatReceived("not called"),
+                    ".",
+                  ],
+                );
+              ((() => message), false);
+            | [lastCall, ...rest] =>
+              let message =
+                String.concat(
+                  "",
+                  [
+                    matcherHint(
+                      ~expectType=accessorPath,
+                      ~isNot,
+                      ~matcherName=".lastCalledWith",
+                      ~received="mock",
+                      ~options={
+                        comment:
+                          isUsingDefaultEquality ? Some("using ==") : None,
+                      },
+                      (),
+                    ),
+                    "\n\n",
+                    "Expected the mock to have been last called with:\n",
+                    indent(
+                      formatExpected(PolymorphicPrint.print(expectedArgs)),
+                    ),
+                    "\nBut it was last called with:\n",
+                    indent(formatCalls([lastCall], formatReceived)),
+                  ],
+                );
+              ((() => message), false);
+            }
+          };
+        });
+
+      let toReturnTimes = isNot =>
+        createMatcher(
+          (
+            {matcherHint, formatReceived, formatExpected, indent},
+            actualThunk,
+            expectedThunk,
+          ) => {
+          let mock = actualThunk();
+          let expectedNumReturns = expectedThunk();
+          let returns = getReturns(mock);
+          let actualNumReturns = List.length(returns);
+          let returnedCorrectNumberOfTimes =
+            expectedNumReturns == actualNumReturns;
+
+          switch (isNot, returnedCorrectNumberOfTimes) {
+          | (true, false)
+          | (false, true) => (passMessageThunk, true)
+          | (true, true) =>
+            let message =
+              String.concat(
+                "",
+                [
+                  matcherHint(
+                    ~expectType=accessorPath,
+                    ~isNot,
+                    ~matcherName=".toReturnTimes",
+                    ~received="mock",
+                    (),
+                  ),
+                  "\n\n",
+                  "Expected the mock not have returned ",
+                  formatExpected(numTimesString(expectedNumReturns)),
+                  ", but it returned exactly ",
+                  formatReceived(numTimesString(actualNumReturns)),
+                  ".",
+                ],
+              );
+            ((() => message), false);
+          | (false, false) =>
+            switch (returns) {
+            | [] =>
+              let message =
+                String.concat(
+                  "",
+                  [
+                    matcherHint(
+                      ~expectType=accessorPath,
+                      ~isNot,
+                      ~matcherName=".toReturnTimes",
+                      ~received="mock",
+                      (),
+                    ),
+                    "\n\n",
+                    "Expected the mock to return ",
+                    formatExpected(numTimesString(expectedNumReturns)),
+                    ", but it didn't return.",
+                  ],
+                );
+              ((() => message), false);
+            | l =>
+              let message =
+                String.concat(
+                  "",
+                  [
+                    matcherHint(
+                      ~expectType=accessorPath,
+                      ~isNot,
+                      ~matcherName=".toReturnTimes",
+                      ~received="mock",
+                      (),
+                    ),
+                    "\n\n",
+                    "Expected the mock to return ",
+                    formatExpected(numTimesString(expectedNumReturns)),
+                    ", but it returned ",
+                    formatReceived(numTimesString(actualNumReturns)),
+                    ".",
+                  ],
+                );
+              ((() => message), false);
+            }
+          };
+        });
+
+      let toReturnWith = isNot =>
+        createMatcher(
+          (
+            {matcherHint, formatReceived, formatExpected, indent},
+            actualThunk,
+            expectedThunk,
+          ) => {
+          let mock = actualThunk();
+          let (equals, expectedReturn) = expectedThunk();
+
+          let returns = getReturns(mock);
+
+          let returnedExpected =
+            List.exists(return => equals(return, expectedReturn), returns);
+          let isUsingDefaultEquality = equals === defaultEqualityFn;
+
+          switch (isNot, returnedExpected) {
+          | (true, false)
+          | (false, true) => (passMessageThunk, true)
+          | (true, true) =>
+            let message =
+              String.concat(
+                "",
+                [
+                  matcherHint(
+                    ~expectType=accessorPath,
+                    ~isNot,
+                    ~matcherName=".toReturnWith",
+                    ~received="mock",
+                    ~options={
+                      comment:
+                        isUsingDefaultEquality ? Some("using ==") : None,
+                    },
+                    (),
+                  ),
+                  "\n\n",
+                  "Expected the mock not to have returned:\n",
+                  indent(
+                    formatExpected(PolymorphicPrint.print(expectedReturn)),
+                  ),
+                  "\nBut it returned a value equal to:\n",
+                  indent(
+                    formatReceived(PolymorphicPrint.print(expectedReturn)),
+                  ),
+                ],
+              );
+            ((() => message), false);
+          | (false, false) =>
+            switch (returns) {
+            | [] =>
+              let message =
+                String.concat(
+                  "",
+                  [
+                    matcherHint(
+                      ~expectType=accessorPath,
+                      ~isNot,
+                      ~matcherName=".toReturnWith",
+                      ~received="mock",
+                      ~options={
+                        comment:
+                          isUsingDefaultEquality ? Some("using ==") : None,
+                      },
+                      (),
+                    ),
+                    "\n\n",
+                    "Expected the mock to have returned:\n",
+                    indent(
+                      formatExpected(PolymorphicPrint.print(expectedReturn)),
+                    ),
+                    "But it did ",
+                    formatReceived("not return"),
+                    ".",
+                  ],
+                );
+              ((() => message), false);
+            | calls =>
+              let message =
+                String.concat(
+                  "",
+                  [
+                    matcherHint(
+                      ~expectType=accessorPath,
+                      ~isNot,
+                      ~matcherName=".toReturnWith",
+                      ~received="mock",
+                      ~options={
+                        comment:
+                          isUsingDefaultEquality ? Some("using ==") : None,
+                      },
+                      (),
+                    ),
+                    "\n\n",
+                    "Expected the mock to have returned:\n",
+                    indent(
+                      formatExpected(PolymorphicPrint.print(expectedReturn)),
+                    ),
+                    "\nBut it returned:\n",
+                    indent(formatReturns(returns, formatReceived)),
+                  ],
+                );
+              ((() => message), false);
+            }
+          };
+        });
+      let lastReturnedWith = isNot =>
+        createMatcher(
+          (
+            {matcherHint, formatReceived, formatExpected, indent},
+            actualThunk,
+            expectedThunk,
+          ) => {
+          let mock = actualThunk();
+          let (equals, expectedReturn) = expectedThunk();
+          let isUsingDefaultEquality = equals === defaultEqualityFn;
+
+          let results = M.getResults(mock);
+          let lastResult =
+            switch (results) {
+            | [h, ...t] => Some(h)
+            | [] => None
+            };
+
+          let lastReturnedExpected =
+            switch (lastResult) {
+            | Some(Exception(_, _, _))
+            | None => false
+            | Some(Mock.Return(value)) => equals(value, expectedReturn)
+            };
+
+          switch (isNot, lastReturnedExpected) {
+          | (true, false)
+          | (false, true) => (passMessageThunk, true)
+          | (true, true) =>
+            exception ShouldNeverGetHere;
+            let actual = switch(lastResult) {
+            | Some(Mock.Return(value)) => value
+            | _ => raise(ShouldNeverGetHere)
+            }
+            let message =
+              String.concat(
+                "",
+                [
+                  matcherHint(
+                    ~expectType=accessorPath,
+                    ~isNot,
+                    ~matcherName=".lastReturnedWith",
+                    ~received="mock",
+                    ~options={
+                      comment:
+                        isUsingDefaultEquality ? Some("using ==") : None,
+                    },
+                    (),
+                  ),
+                  "\n\n",
+                  "Expected the mock to not have last returned:\n",
+                  indent(
+                    formatExpected(PolymorphicPrint.print(expectedReturn)),
+                  ),
+                  "\nBut it last returned:\n",
+                  indent(
+                    formatReceived(
+                      PolymorphicPrint.print(actual),
+                    ),
+                  ),
+                ],
+              );
+            ((() => message), false);
+          | (false, false) =>
+            switch (lastResult) {
+            | None =>
+              let message =
+                String.concat(
+                  "",
+                  [
+                    matcherHint(
+                      ~expectType=accessorPath,
+                      ~isNot,
+                      ~matcherName=".lastReturnedWith",
+                      ~received="mock",
+                      ~options={
+                        comment:
+                          isUsingDefaultEquality ? Some("using ==") : None,
+                      },
+                      (),
+                    ),
+                    "\n\n",
+                    "Expected the mock to have last returned:\n",
+                    indent(
+                      formatExpected(PolymorphicPrint.print(expectedReturn)),
+                    ),
+                    "\nBut it did ",
+                    formatReceived("not return"),
+                    ".",
+                  ],
+                );
+              ((() => message), false);
+            | Some(Return(actualValue)) =>
+              let message =
+                String.concat(
+                  "",
+                  [
+                    matcherHint(
+                      ~expectType=accessorPath,
+                      ~isNot,
+                      ~matcherName=".lastReturnedWith",
+                      ~received="mock",
+                      ~options={
+                        comment:
+                          isUsingDefaultEquality ? Some("using ==") : None,
+                      },
+                      (),
+                    ),
+                    "\n\n",
+                    "Expected the mock to have last returned:\n",
+                    indent(
+                      formatExpected(PolymorphicPrint.print(expectedReturn)),
+                    ),
+                    "\nBut the last call returned:\n",
+                    indent(formatReceived(PolymorphicPrint.print(actualValue))),
+                  ],
+                );
+              ((() => message), false);
+              | Some(Exception(e, _, _)) =>
+              let message =
+                String.concat(
+                  "",
+                  [
+                    matcherHint(
+                      ~expectType=accessorPath,
+                      ~isNot,
+                      ~matcherName=".lastReturnedWith",
+                      ~received="mock",
+                      ~options={
+                        comment:
+                          isUsingDefaultEquality ? Some("using ==") : None,
+                      },
+                      (),
+                    ),
+                    "\n\n",
+                    "Expected the mock to have last returned:\n",
+                    indent(
+                      formatExpected(PolymorphicPrint.print(expectedReturn)),
+                    ),
+                    "\nBut the last call raised:\n",
+                    indent(formatReceived(Printexc.to_string(e))),
+                  ],
+                );
+              ((() => message), false);
+            }
+          };
+        });
+
+      let matchers = {
+        not: {
+          toThrow: () => notToThrow(() => mock, () => ()),
+          toBeCalled: () => toBeCalled(true, () => mock, () => ()),
+          toBeCalledTimes: numTimes =>
+            toBeCalledTimes(true, () => mock, () => numTimes),
+          toBeCalledWith: (~equals=defaultEqualityFn, expectedArgs) =>
+            toBeCalledWith(true, () => mock, () => (equals, expectedArgs)),
+          lastCalledWith: (~equals=defaultEqualityFn, expectedArgs) =>
+            lastCalledWith(true, () => mock, () => (equals, expectedArgs)),
+          toReturnTimes: numTimes =>
+            toReturnTimes(true, () => mock, () => numTimes),
+          toReturnWith: (~equals=defaultEqualityFn, expectedReturn) =>
+            toReturnWith(true, () => mock, () => (equals, expectedReturn)),
+          lastReturnedWith: (~equals=defaultEqualityFn, expectedReturn) =>
+            lastReturnedWith(
+              true,
+              () => mock,
+              () => (equals, expectedReturn),
+            ),
+        },
+        toThrow: () => toThrow(() => mock, () => ()),
+        toThrowException: expectedException =>
+          toThrowException(() => mock, () => expectedException),
+        toBeCalled: () => toBeCalled(false, () => mock, () => ()),
+        toBeCalledTimes: numTimes =>
+          toBeCalledTimes(false, () => mock, () => numTimes),
+        toBeCalledWith: (~equals=defaultEqualityFn, expectedArgs) =>
+          toBeCalledWith(false, () => mock, () => (equals, expectedArgs)),
+        lastCalledWith: (~equals=defaultEqualityFn, expectedArgs) =>
+          lastCalledWith(false, () => mock, () => (equals, expectedArgs)),
+        toReturnTimes: numTimes =>
+          toReturnTimes(false, () => mock, () => numTimes),
+        toReturnWith: (~equals=defaultEqualityFn, expectedReturn) =>
+          toReturnWith(false, () => mock, () => (equals, expectedReturn)),
+        lastReturnedWith: (~equals=defaultEqualityFn, expectedReturn) =>
+          lastReturnedWith(
+            false,
+            () => mock,
+            () => (equals, expectedReturn),
+          ),
+      };
+      matchers;
+    };
+    createMockMatchers;
+  };
+};

--- a/tests/__snapshots__/mock_matchers_failing_output.0731d24c.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.0731d24c.0.snapshot
@@ -1,0 +1,6 @@
+mock matchers › failing output › expect.mock.lastReturnedWith wasn't called
+<dim>expect.mock(</dim><red>mock</red><dim>).lastReturnedWith(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected the mock to have last returned:
+  <green>2</green>
+But it did <red>not return</red>.

--- a/tests/__snapshots__/mock_matchers_failing_output.0a5f67ff.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.0a5f67ff.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.toReturnWith multiple other calls
+<dim>expect.mock(</dim><red>mock</red><dim>).toReturnWith(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected the mock to have returned:
+  <green>4</green>
+But it returned:
+  <red>3</red>, <red>3</red>, <red>2</red><red> and two more values.</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.0eab92f9.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.0eab92f9.0.snapshot
@@ -1,0 +1,5 @@
+mock matchers › failing output › expect.mock.toThrow
+<dim>expect.mock(</dim><red>mock</red><dim>).toThrow(</dim><green></green><dim>)</dim>
+
+Expected the function to throw an error.
+But it didn't throw anything.

--- a/tests/__snapshots__/mock_matchers_failing_output.17bb22ca.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.17bb22ca.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.toThrowException multiple wrong exceptions
+<dim>expect.mock(</dim><red>function</red><dim>).toThrowException(</dim><green>exception</green><dim>)</dim>
+
+Expected the function to throw an error matching:
+  <green>Not_found</green>
+Instead, it threw:
+  <red>[\"Division_by_zero\", \"Division_by_zero\"]</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.17bb22ca.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.17bb22ca.0.snapshot
@@ -4,4 +4,4 @@ mock matchers › failing output › expect.mock.toThrowException multiple wrong
 Expected the function to throw an error matching:
   <green>Not_found</green>
 Instead, it threw:
-  <red>[\"Division_by_zero\", \"Division_by_zero\"]</red>
+  <red>Division_by_zero</red>, <red>Division_by_zero</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.23e291d6.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.23e291d6.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.not.toBeCalledWith custom equals
+<dim>expect.mock(</dim><red>mock</red><dim>).toBeCalledWith(</dim><green>expected</green><dim>)</dim>
+
+Expected the mock to have been called with:
+  <green>0.8</green>
+But it was called with:
+  <red>1.</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.2988fa6e.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.2988fa6e.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.lastReturnedWith threw exception
+<dim>expect.mock(</dim><red>mock</red><dim>).lastReturnedWith(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected the mock to have last returned:
+  <green>7</green>
+But the last call raised:
+  <red>Not_found</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.2f261fc0.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.2f261fc0.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.not.toReturnWith custom equals
+<dim>expect.mock(</dim><red>mock</red><dim>).toReturnWith(</dim><green>expected</green><dim>)</dim>
+
+Expected the mock to have returned:
+  <green>0.8</green>
+But it returned:
+  <red>1.</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.34315207.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.34315207.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.toThrowException wrong exception
+<dim>expect.mock(</dim><red>function</red><dim>).toThrowException(</dim><green>exception</green><dim>)</dim>
+
+Expected the function to throw an error matching:
+  <green>Not_found</green>
+Instead, it threw:
+  <red>Division_by_zero</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.3a888f1f.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.3a888f1f.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.lastCalledWith multiple calls
+<dim>expect.mock(</dim><red>mock</red><dim>).lastCalledWith(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected the mock to have been last called with:
+  <green>1</green>
+But it was last called with:
+  <red>2</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.4864ea0b.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.4864ea0b.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.not.lastReturnedWith single call
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>.lastReturnedWith(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected the mock to not have last returned:
+  <green>2</green>
+But it last returned:
+  <red>2</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.4a5fe18e.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.4a5fe18e.0.snapshot
@@ -1,0 +1,5 @@
+mock matchers › failing output › expect.mock.not.toBeCalled don't overflow print
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>.toBeCalled(</dim><green></green><dim>)</dim>
+
+Expected the mock not be called, but it was called with:
+  <red>{3, 4}</red>, <red>{1, 2}</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.4aaa80d7.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.4aaa80d7.0.snapshot
@@ -1,0 +1,4 @@
+mock matchers › failing output › expect.mock.toBeCalledTimes wasn't called
+<dim>expect.mock(</dim><red>mock</red><dim>).toBeCalledTimes(</dim><green>expected</green><dim>)</dim>
+
+Expected the mock to have been called <green>two times</green>, but it was <red>not called</red>.

--- a/tests/__snapshots__/mock_matchers_failing_output.534ec036.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.534ec036.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.not.toBeCalledWith custom equals
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>.toBeCalledWith(</dim><green>expected</green><dim>)</dim>
+
+Expected the mock not to have been called with:
+  <green>0.99</green>
+But it was called with arguments equal to:
+  <red>0.99</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.54bc298d.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.54bc298d.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.not.lastReturnedWith multiple calls
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>.lastReturnedWith(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected the mock to not have last returned:
+  <green>2</green>
+But it last returned:
+  <red>2</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.61a9d36d.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.61a9d36d.0.snapshot
@@ -1,0 +1,4 @@
+mock matchers › failing output › expect.mock.toBeCalledTimes called different number of times
+<dim>expect.mock(</dim><red>mock</red><dim>).toBeCalledTimes(</dim><green>expected</green><dim>)</dim>
+
+Expected the mock to have been called <green>two times</green>, but it was called <red>one time</red>.

--- a/tests/__snapshots__/mock_matchers_failing_output.706fb052.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.706fb052.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.lastReturnedWith multiple calls
+<dim>expect.mock(</dim><red>mock</red><dim>).lastReturnedWith(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected the mock to have last returned:
+  <green>1</green>
+But the last call returned:
+  <red>2</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.74075ad7.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.74075ad7.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.not.lastReturnedWith custom equals
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>.lastReturnedWith(</dim><green>expected</green><dim>)</dim>
+
+Expected the mock to not have last returned:
+  <green>1.99</green>
+But it last returned:
+  <red>2.</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.7bf52742.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.7bf52742.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.toBeCalledWith multiple other calls
+<dim>expect.mock(</dim><red>mock</red><dim>).toBeCalledWith(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected the mock to have been called with:
+  <green>4</green>
+But it was called with:
+  <red>3</red>, <red>1</red>, <red>2</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.901ed992.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.901ed992.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.not.toBeCalledWith only call
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>.toBeCalledWith(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected the mock not to have been called with:
+  <green>1</green>
+But it was called with arguments equal to:
+  <red>1</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.9b327749.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.9b327749.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.not.toReturnWith only call
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>.toReturnWith(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected the mock not to have returned:
+  <green>1</green>
+But it returned a value equal to:
+  <red>1</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.a25fa19c.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.a25fa19c.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.not.lastCalledWith custom equals
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>.lastCalledWith(</dim><green>expected</green><dim>)</dim>
+
+Expected the mock not to have been last called with:
+  <green>1.99</green>
+But it was called with arguments equal to:
+  <red>1.99</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.a3ef428c.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.a3ef428c.0.snapshot
@@ -3,4 +3,4 @@ mock matchers › failing output › expect.mock.not.toThrow multiple exceptions
 
 Expected the function not to throw an error.
 Instead, it threw: 
-  <red>[\"Not_found\", \"Not_found\"]</red>
+  <red>Not_found</red>, <red>Not_found</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.a3ef428c.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.a3ef428c.0.snapshot
@@ -1,0 +1,6 @@
+mock matchers › failing output › expect.mock.not.toThrow multiple exceptions
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>toThrow(</dim><green></green><dim>)</dim>
+
+Expected the function not to throw an error.
+Instead, it threw: 
+  <red>[\"Not_found\", \"Not_found\"]</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.a58ff95e.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.a58ff95e.0.snapshot
@@ -1,0 +1,6 @@
+mock matchers › failing output › expect.mock.toThrowException no exception
+<dim>expect.mock(</dim><red>function</red><dim>).toThrowException(</dim><green>exception</green><dim>)</dim>
+
+Expected the function to throw an error matching:
+  <green>Not_found</green>
+But it didn't throw anything.

--- a/tests/__snapshots__/mock_matchers_failing_output.a72f61da.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.a72f61da.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.not.toBeCalledWith other call
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>.toBeCalledWith(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected the mock not to have been called with:
+  <green>1</green>
+But it was called with arguments equal to:
+  <red>1</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.ab1098b8.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.ab1098b8.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.not.lastCalledWith multiple calls
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>.lastCalledWith(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected the mock not to have been last called with:
+  <green>2</green>
+But it was called with arguments equal to:
+  <red>2</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.b7c954fd.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.b7c954fd.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.lastCalledWith custom equals
+<dim>expect.mock(</dim><red>mock</red><dim>).lastCalledWith(</dim><green>expected</green><dim>)</dim>
+
+Expected the mock to have been last called with:
+  <green>1.</green>
+But it was last called with:
+  <red>2.</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.bab75b6e.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.bab75b6e.0.snapshot
@@ -1,0 +1,4 @@
+mock matchers › failing output › expect.mock.toReturnTimes wasn't called
+<dim>expect.mock(</dim><red>mock</red><dim>).toReturnTimes(</dim><green>expected</green><dim>)</dim>
+
+Expected the mock to return <green>two times</green>, but it didn't return.

--- a/tests/__snapshots__/mock_matchers_failing_output.bfb3274f.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.bfb3274f.0.snapshot
@@ -1,0 +1,4 @@
+mock matchers › failing output › expect.mock.toReturnTimes returned different number of times
+<dim>expect.mock(</dim><red>mock</red><dim>).toReturnTimes(</dim><green>expected</green><dim>)</dim>
+
+Expected the mock to return <green>two times</green>, but it returned <red>one time</red>.

--- a/tests/__snapshots__/mock_matchers_failing_output.c15667de.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.c15667de.0.snapshot
@@ -1,0 +1,4 @@
+mock matchers › failing output › expect.mock.not.toBeCalledTimes
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>.toBeCalledTimes(</dim><green>expected</green><dim>)</dim>
+
+Expected the mock not be called <green>two times</green>, but it was called exactly <red>two times</red>.

--- a/tests/__snapshots__/mock_matchers_failing_output.c4cc9b77.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.c4cc9b77.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.lastCalledWith single call
+<dim>expect.mock(</dim><red>mock</red><dim>).lastCalledWith(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected the mock to have been last called with:
+  <green>1</green>
+But it was last called with:
+  <red>2</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.c6ef3a32.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.c6ef3a32.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.not.lastCalledWith single call
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>.lastCalledWith(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected the mock not to have been last called with:
+  <green>2</green>
+But it was called with arguments equal to:
+  <red>2</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.cf48ac01.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.cf48ac01.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.not.toReturnWith other call
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>.toReturnWith(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected the mock not to have returned:
+  <green>1</green>
+But it returned a value equal to:
+  <red>1</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.d07ff557.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.d07ff557.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.lastReturnedWith single call
+<dim>expect.mock(</dim><red>mock</red><dim>).lastReturnedWith(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected the mock to have last returned:
+  <green>1</green>
+But the last call returned:
+  <red>2</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.d4089856.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.d4089856.0.snapshot
@@ -1,0 +1,4 @@
+mock matchers › failing output › expect.mock.toReturnTimes threw exception
+<dim>expect.mock(</dim><red>mock</red><dim>).toReturnTimes(</dim><green>expected</green><dim>)</dim>
+
+Expected the mock to return <green>one time</green>, but it didn't return.

--- a/tests/__snapshots__/mock_matchers_failing_output.e7dac68e.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.e7dac68e.0.snapshot
@@ -1,0 +1,5 @@
+mock matchers › failing output › expect.mock.not.toBeCalled overflow print
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>.toBeCalled(</dim><green></green><dim>)</dim>
+
+Expected the mock not be called, but it was called with:
+  <red>{10, 11}</red>, <red>{7, 8}</red>, <red>{5, 6}</red><red> and two more calls.</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.ee29f390.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.ee29f390.0.snapshot
@@ -1,0 +1,6 @@
+mock matchers › failing output › expect.mock.not.toThrow single exception
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>toThrow(</dim><green></green><dim>)</dim>
+
+Expected the function not to throw an error.
+Instead, it threw: 
+  <red>Not_found</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.f5261140.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.f5261140.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.not.toReturnWith custom equals
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>.toReturnWith(</dim><green>expected</green><dim>)</dim>
+
+Expected the mock not to have returned:
+  <green>0.99</green>
+But it returned a value equal to:
+  <red>0.99</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.f53031a1.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.f53031a1.0.snapshot
@@ -1,0 +1,4 @@
+mock matchers › failing output › expect.mock.toBeCalled
+<dim>expect.mock(</dim><red>mock</red><dim>).toBeCalled(</dim><green></green><dim>)</dim>
+
+Expected the mock to be called, but it was not called.

--- a/tests/__snapshots__/mock_matchers_failing_output.f8dbe02b.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.f8dbe02b.0.snapshot
@@ -1,0 +1,7 @@
+mock matchers › failing output › expect.mock.lastReturnedWith custom equals
+<dim>expect.mock(</dim><red>mock</red><dim>).lastReturnedWith(</dim><green>expected</green><dim>)</dim>
+
+Expected the mock to have last returned:
+  <green>1.</green>
+But the last call returned:
+  <red>2.</red>

--- a/tests/__snapshots__/mock_matchers_failing_output.fb892fbe.0.snapshot
+++ b/tests/__snapshots__/mock_matchers_failing_output.fb892fbe.0.snapshot
@@ -1,0 +1,4 @@
+mock matchers › failing output › expect.mock.not.toReturnTimes
+<dim>expect.mock(</dim><red>mock</red><dim>).</dim>not<dim>.toReturnTimes(</dim><green>expected</green><dim>)</dim>
+
+Expected the mock not have returned <green>two times</green>, but it returned exactly <red>two times</red>.

--- a/tests/__tests__/rely/MatcherSnapshotTestRunner.re
+++ b/tests/__tests__/rely/MatcherSnapshotTestRunner.re
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+let snapshotFailingTestCase =
+    (testUtils: Rely.Test.testUtils('ext), testBody) => {
+  module TestFramework =
+    Rely.Make({
+      let config =
+        Rely.TestFrameworkConfig.(
+          initialize({snapshotDir: "unused", projectDir: ""})
+        );
+    });
+
+  TestFramework.describe("unused, doesn't matter", ({test}) =>
+    test("not used", testBody)
+  );
+
+  module Reporter =
+    TestReporter.Make({});
+
+  Reporter.onRunComplete(result => {
+    let output =
+      result.testSuiteResults
+      |> List.map((a: Rely.Reporter.testSuiteResult) => a.testResults)
+      |> List.flatten
+      |> List.map((testResult: Rely.Reporter.testResult) => {
+            switch (testResult.testStatus) {
+           | Failed(message, loc, stack) => message
+           | _ => ""
+           };
+        }
+         )
+      |> String.concat("");
+
+    testUtils.expect.string(output).toMatchSnapshot();
+  });
+
+  Pastel.useMode(HumanReadable, () => {
+    TestFramework.run(
+        Rely.RunConfig.(
+          initialize()
+          |> withReporters([Custom(Reporter.reporter)])
+          |> onTestFrameworkFailure(() => ())
+        ),
+      );
+  });
+};

--- a/tests/__tests__/rely/MockMatchers_test.re
+++ b/tests/__tests__/rely/MockMatchers_test.re
@@ -1,0 +1,801 @@
+open TestFramework;
+
+describe("mock matchers", ({describe}) => {
+  describe("passing output", ({test}) => {
+    test("expect.mock.toThrow", ({expect}) => {
+      let mock = Mock.mock1(a => raise(Not_found));
+
+      try (Mock.fn(mock, 7)) {
+      | _ => ()
+      };
+
+      expect.mock(mock).toThrow();
+    });
+    test("expect.mock.not.toThrow", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 7);
+
+      expect.mock(mock).not.toThrow();
+    });
+    test("expect.mock.toThrowException", ({expect}) => {
+      let mock = Mock.mock1(a => raise(Not_found));
+
+      try (Mock.fn(mock, 7)) {
+      | _ => ()
+      };
+
+      expect.mock(mock).toThrowException(Not_found);
+    });
+    test("expect.mock.toBeCalled", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 7);
+
+      expect.mock(mock).toBeCalled();
+    });
+    test("expect.mock.not.toBeCalled", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      expect.mock(mock).not.toBeCalled();
+    });
+    test("expect.mock.toBeCalledTimes", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 7);
+      let _ = Mock.fn(mock, 7);
+
+      expect.mock(mock).toBeCalledTimes(2);
+    });
+    test("expect.mock.not.toBeCalledTimes wasn't called", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      expect.mock(mock).not.toBeCalledTimes(2);
+    });
+    test(
+      "expect.mock.not.toBeCalledTimes called different number of times",
+      ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 7);
+
+      expect.mock(mock).not.toBeCalledTimes(2);
+    });
+    test("expect.mock.toBeCalledWith only call", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 1);
+
+      expect.mock(mock).toBeCalledWith(1);
+    });
+    test("expect.mock.toBeCalledWith other calls", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 2);
+      let _ = Mock.fn(mock, 1);
+      let _ = Mock.fn(mock, 3);
+
+      expect.mock(mock).toBeCalledWith(1);
+    });
+    test("expect.mock.toBeCalledWith custom equals", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 1.);
+      let equals = (a, b) => abs_float(a -. b) < 0.1;
+
+      expect.mock(mock).toBeCalledWith(~equals, 0.99);
+    });
+    test("expect.mock.not.toBeCalledWith", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 2);
+      let _ = Mock.fn(mock, 1);
+      let _ = Mock.fn(mock, 3);
+
+      expect.mock(mock).not.toBeCalledWith(4);
+    });
+    test("expect.mock.not.toBeCalledWith custom equals", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 1.);
+      let equals = (a, b) => abs_float(a -. b) < 0.1;
+
+      expect.mock(mock).not.toBeCalledWith(~equals, 0.8);
+    });
+    test("expect.mock.lastCalledWith single call", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 2);
+
+      expect.mock(mock).lastCalledWith(2);
+    });
+    test("expect.mock.lastCalledWith custom equals", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 2.);
+      let equals = (a, b) => abs_float(a -. b) < 0.1;
+
+      expect.mock(mock).lastCalledWith(~equals, 1.99);
+    });
+    test("expect.mock.lastCalledWith multiple calls", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 1);
+      let _ = Mock.fn(mock, 2);
+
+      expect.mock(mock).lastCalledWith(2);
+    });
+    test("expect.mock.not.lastCalledWith single call", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 2);
+
+      expect.mock(mock).not.lastCalledWith(1);
+    });
+    test("expect.mock.not.lastCalledWith multiple calls", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 1);
+      let _ = Mock.fn(mock, 2);
+
+      expect.mock(mock).not.lastCalledWith(1);
+    });
+    test("expect.mock.not.lastCalledWith custom equals", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 2.);
+      let equals = (a, b) => abs_float(a -. b) < 0.1;
+
+      expect.mock(mock).not.lastCalledWith(~equals, 1.);
+    });
+    test("expect.mock.toReturnTimes", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 7);
+      let _ = Mock.fn(mock, 7);
+
+      expect.mock(mock).toReturnTimes(2);
+    });
+    test("expect.mock.not.toReturnTimes wasn't called", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      expect.mock(mock).not.toReturnTimes(2);
+    });
+    test("expect.mock.not.toReturnTimes threw exception", ({expect}) => {
+      let mock = Mock.mock1(a => raise(Not_found));
+
+      try (Mock.fn(mock, 1)) {
+      | _ => ()
+      };
+
+      expect.mock(mock).not.toReturnTimes(1);
+    });
+    test(
+      "expect.mock.not.toReturnTimes returned different number of times",
+      ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 7);
+
+      expect.mock(mock).not.toReturnTimes(2);
+    });
+    test("expect.mock.toReturnWith only call", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 1);
+
+      expect.mock(mock).toReturnWith(1);
+    });
+    test("expect.mock.toReturnWith other calls", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 2);
+      let _ = Mock.fn(mock, 1);
+      let _ = Mock.fn(mock, 3);
+
+      expect.mock(mock).toReturnWith(1);
+    });
+    test("expect.mock.toReturnWith custom equals", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 1.);
+      let equals = (a, b) => abs_float(a -. b) < 0.1;
+
+      expect.mock(mock).toReturnWith(~equals, 0.99);
+    });
+    test("expect.mock.not.toReturnWith", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 2);
+      let _ = Mock.fn(mock, 1);
+      let _ = Mock.fn(mock, 3);
+
+      expect.mock(mock).not.toReturnWith(4);
+    });
+    test("expect.mock.not.toReturnWith custom equals", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 1.);
+      let equals = (a, b) => abs_float(a -. b) < 0.1;
+
+      expect.mock(mock).not.toReturnWith(~equals, 0.8);
+    });
+    test("expect.mock.lastReturnedWith single call", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 2);
+
+      expect.mock(mock).lastReturnedWith(2);
+    });
+    test("expect.mock.lastReturnedWith custom equals", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 2.);
+      let equals = (a, b) => abs_float(a -. b) < 0.1;
+
+      expect.mock(mock).lastReturnedWith(~equals, 1.99);
+    });
+    test("expect.mock.lastReturnedWith multiple calls", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 1);
+      let _ = Mock.fn(mock, 2);
+
+      expect.mock(mock).lastReturnedWith(2);
+    });
+    test("expect.mock.not.lastReturnedWith single call", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 2);
+
+      expect.mock(mock).not.lastReturnedWith(1);
+    });
+    test("expect.mock.not.lastReturnedWith multiple calls", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 1);
+      let _ = Mock.fn(mock, 2);
+
+      expect.mock(mock).not.lastReturnedWith(1);
+    });
+    test("expect.mock.not.lastReturnedWith custom equals", ({expect}) => {
+      let mock = Mock.mock1(a => a);
+
+      let _ = Mock.fn(mock, 2.);
+      let equals = (a, b) => abs_float(a -. b) < 0.1;
+
+      expect.mock(mock).not.lastReturnedWith(~equals, 1.);
+    });
+  });
+
+  describe("failing output", ({test}) => {
+    test("expect.mock.not.toThrow single exception", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => raise(Not_found));
+
+          try (Mock.fn(mock, 7)) {
+          | _ => ()
+          };
+
+          expect.mock(mock).not.toThrow();
+        },
+      )
+    );
+    test("expect.mock.not.toThrow multiple exceptions", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => raise(Not_found));
+
+          try (Mock.fn(mock, 7)) {
+          | _ => ()
+          };
+
+          try (Mock.fn(mock, 7)) {
+          | _ => ()
+          };
+
+          expect.mock(mock).not.toThrow();
+        },
+      )
+    );
+    test("expect.mock.toThrow", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 7);
+
+          expect.mock(mock).toThrow();
+        },
+      )
+    );
+    test("expect.mock.toThrowException no exception", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 7);
+
+          expect.mock(mock).toThrowException(Not_found);
+        },
+      )
+    );
+    test("expect.mock.toThrowException wrong exception", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => raise(Division_by_zero));
+
+          try (Mock.fn(mock, 7)) {
+          | _ => ()
+          };
+
+          expect.mock(mock).toThrowException(Not_found);
+        },
+      )
+    );
+    test("expect.mock.toThrowException multiple wrong exceptions", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => raise(Division_by_zero));
+
+          try (Mock.fn(mock, 7)) {
+          | _ => ()
+          };
+          try (Mock.fn(mock, 7)) {
+          | _ => ()
+          };
+
+          expect.mock(mock).toThrowException(Not_found);
+        },
+      )
+    );
+    test("expect.mock.toBeCalled", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          expect.mock(mock).toBeCalled();
+        },
+      )
+    );
+    test("expect.mock.not.toBeCalled don't overflow print", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock2((a, b) => a + b);
+
+          let _ = Mock.fn(mock, 1, 2);
+          let _ = Mock.fn(mock, 3, 4);
+
+          expect.mock(mock).not.toBeCalled();
+        },
+      )
+    );
+    test("expect.mock.not.toBeCalled overflow print", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock2((a, b) => a + b);
+
+          let _ = Mock.fn(mock, 1, 2);
+          let _ = Mock.fn(mock, 3, 4);
+          let _ = Mock.fn(mock, 5, 6);
+          let _ = Mock.fn(mock, 7, 8);
+          let _ = Mock.fn(mock, 10, 11);
+
+          expect.mock(mock).not.toBeCalled();
+        },
+      )
+    );
+    test("expect.mock.toBeCalledTimes wasn't called", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          expect.mock(mock).toBeCalledTimes(2);
+        },
+      )
+    );
+    test(
+      "expect.mock.toBeCalledTimes called different number of times", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 7);
+
+          expect.mock(mock).toBeCalledTimes(2);
+        },
+      )
+    );
+    test("expect.mock.not.toBeCalledTimes", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 7);
+          let _ = Mock.fn(mock, 7);
+
+          expect.mock(mock).not.toBeCalledTimes(2);
+        },
+      )
+    );
+    test("expect.mock.not.toBeCalledWith only call", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 1);
+
+          expect.mock(mock).not.toBeCalledWith(1);
+        },
+      )
+    );
+    test("expect.mock.not.toBeCalledWith other call", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 2);
+          let _ = Mock.fn(mock, 1);
+          let _ = Mock.fn(mock, 3);
+
+          expect.mock(mock).not.toBeCalledWith(1);
+        },
+      )
+    );
+    test("expect.mock.not.toBeCalledWith custom equals", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 1.);
+          let equals = (a, b) => abs_float(a -. b) < 0.1;
+
+          expect.mock(mock).not.toBeCalledWith(~equals, 0.99);
+        },
+      )
+    );
+    test("expect.mock.toBeCalledWith multiple other calls", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 2);
+          let _ = Mock.fn(mock, 1);
+          let _ = Mock.fn(mock, 3);
+
+          expect.mock(mock).toBeCalledWith(4);
+        },
+      )
+    );
+    test("expect.mock.not.toBeCalledWith custom equals", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 1.);
+          let equals = (a, b) => abs_float(a -. b) < 0.1;
+
+          expect.mock(mock).toBeCalledWith(~equals, 0.8);
+        },
+      )
+    );
+    test("expect.mock.not.lastCalledWith single call", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 2);
+
+          expect.mock(mock).not.lastCalledWith(2);
+        },
+      )
+    );
+    test("expect.mock.not.lastCalledWith custom equals", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 2.);
+          let equals = (a, b) => abs_float(a -. b) < 0.1;
+
+          expect.mock(mock).not.lastCalledWith(~equals, 1.99);
+        },
+      )
+    );
+    test("expect.mock.not.lastCalledWith multiple calls", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 1);
+          let _ = Mock.fn(mock, 2);
+
+          expect.mock(mock).not.lastCalledWith(2);
+        },
+      )
+    );
+    test("expect.mock.lastCalledWith single call", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 2);
+
+          expect.mock(mock).lastCalledWith(1);
+        },
+      )
+    );
+    test("expect.mock.lastCalledWith multiple calls", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 1);
+          let _ = Mock.fn(mock, 2);
+
+          expect.mock(mock).lastCalledWith(1);
+        },
+      )
+    );
+    test("expect.mock.lastCalledWith custom equals", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 2.);
+          let equals = (a, b) => abs_float(a -. b) < 0.1;
+
+          expect.mock(mock).lastCalledWith(~equals, 1.);
+        },
+      )
+    );
+    test("expect.mock.not.toReturnTimes", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 7);
+          let _ = Mock.fn(mock, 7);
+
+          expect.mock(mock).not.toReturnTimes(2);
+        },
+      )
+    );
+    test("expect.mock.toReturnTimes wasn't called", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          expect.mock(mock).toReturnTimes(2);
+        },
+      )
+    );
+    test("expect.mock.toReturnTimes threw exception", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => raise(Not_found));
+
+          try (Mock.fn(mock, 1)) {
+          | _ => ()
+          };
+
+          expect.mock(mock).toReturnTimes(1);
+        },
+      )
+    );
+    test(
+      "expect.mock.toReturnTimes returned different number of times", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 7);
+
+          expect.mock(mock).toReturnTimes(2);
+        },
+      )
+    );
+    test("expect.mock.not.toReturnWith only call", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 1);
+
+          expect.mock(mock).not.toReturnWith(1);
+        },
+      )
+    );
+    test("expect.mock.not.toReturnWith other call", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 2);
+          let _ = Mock.fn(mock, 1);
+          let _ = Mock.fn(mock, 3);
+
+          expect.mock(mock).not.toReturnWith(1);
+        },
+      )
+    );
+    test("expect.mock.not.toReturnWith custom equals", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 1.);
+          let equals = (a, b) => abs_float(a -. b) < 0.1;
+
+          expect.mock(mock).not.toReturnWith(~equals, 0.99);
+        },
+      )
+    );
+    test("expect.mock.toReturnWith multiple other calls", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 3);
+          let _ = Mock.fn(mock, 3);
+          let _ = Mock.fn(mock, 2);
+          let _ = Mock.fn(mock, 1);
+          let _ = Mock.fn(mock, 3);
+
+          expect.mock(mock).toReturnWith(4);
+        },
+      )
+    );
+    test("expect.mock.not.toReturnWith custom equals", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 1.);
+          let equals = (a, b) => abs_float(a -. b) < 0.1;
+
+          expect.mock(mock).toReturnWith(~equals, 0.8);
+        },
+      )
+    );
+    test("expect.mock.not.lastReturnedWith single call", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 2);
+
+          expect.mock(mock).not.lastReturnedWith(2);
+        },
+      )
+    );
+    test("expect.mock.not.lastReturnedWith custom equals", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 2.);
+          let equals = (a, b) => abs_float(a -. b) < 0.1;
+
+          expect.mock(mock).not.lastReturnedWith(~equals, 1.99);
+        },
+      )
+    );
+    test("expect.mock.not.lastReturnedWith multiple calls", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 1);
+          let _ = Mock.fn(mock, 2);
+
+          expect.mock(mock).not.lastReturnedWith(2);
+        },
+      )
+    );
+    test("expect.mock.lastReturnedWith single call", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 2);
+
+          expect.mock(mock).lastReturnedWith(1);
+        },
+      )
+    );
+    test("expect.mock.lastReturnedWith multiple calls", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 1);
+          let _ = Mock.fn(mock, 2);
+
+          expect.mock(mock).lastReturnedWith(1);
+        },
+      )
+    );
+    test("expect.mock.lastReturnedWith custom equals", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          let _ = Mock.fn(mock, 2.);
+          let equals = (a, b) => abs_float(a -. b) < 0.1;
+
+          expect.mock(mock).lastReturnedWith(~equals, 1.);
+        },
+      )
+    );
+
+    test("expect.mock.lastReturnedWith wasn't called", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => a);
+
+          expect.mock(mock).lastReturnedWith(2);
+        },
+      )
+    );
+    test("expect.mock.lastReturnedWith threw exception", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let mock = Mock.mock1(a => raise(Not_found));
+
+          try (
+            {
+              let _ = Mock.fn(mock, 7);
+              ();
+            }
+          ) {
+          | _ => ()
+          };
+
+          expect.mock(mock).lastReturnedWith(7);
+        },
+      )
+    );
+  });
+});

--- a/tests/__tests__/rely/Mock_test.re
+++ b/tests/__tests__/rely/Mock_test.re
@@ -11,7 +11,7 @@ module type MockTestCase = {
   type returnType;
   type tupledArgs;
   exception MockException;
-  let create: fnType => Mock.t(fnType, returnType, tupledArgs);
+  let create: fnType => Rely.Mock.t(fnType, returnType, tupledArgs);
   let call: (fnType, tupledArgs) => returnType;
   let implementation1: fnType;
   let implementation2: fnType;
@@ -43,7 +43,7 @@ module MakeTestSuite = (TestCase: MockTestCase) => {
             let expectedResults = ref([]);
 
             for (i in 1 to numCalls) {
-              let result = Mock.Return(call(Mock.fn(mock), args));
+              let result = Rely.Mock.Return(call(Mock.fn(mock), args));
               expectedCalls := expectedCalls^ @ [args];
               expectedResults := expectedResults^ @ [result];
             };
@@ -67,7 +67,7 @@ module MakeTestSuite = (TestCase: MockTestCase) => {
           Mock.getResults(mock)
           |> List.map(r =>
                switch (r) {
-               | Mock.Exception(e, _, _) => Some(e)
+               | Rely.Mock.Exception(e, _, _) => Some(e)
                | _ => None
                }
              );


### PR DESCRIPTION
Implement matchers for Rely.mock

The actual MockMatchers.re and MockMatchers_test.re need to be manually expand because they are too large to be rendered by default.

MatcherSnapshotTestRunner.re is also worth checking out as a better way for writing snapshot tests for matcher output leveraging the now exposed Reporter API (and converting stuff over could be bootcamped internally/added as an issue here)

I had to do some finagling to get types to flow through correctly, I don't love that the mock type itself isn't in Mock.Sig, but that clearly needs to be done now to prevent having to do other breaking changes (such as moving Describe and Test modules into the Rely.Make functor). We already know that with the next major version we will be doing some consolidation into the Rely.Make functor, but I am less sure as to what belongs there and what does not, with the main concern being the eventual composability of test projects/having a top level executable for dynamically loading and executing test libraries.