### PR TITLE
Benderson/pastel infer mode

### DIFF
--- a/scripts/test.cmd
+++ b/scripts/test.cmd
@@ -4,7 +4,7 @@
 :; DIR="$(cd "$(dirname "$0")" && pwd)"
 
 :; # Run refmterr tests.
-:; esy x bash -cx ./src/refmterr/runTests.cmd
+:; FORCE_COLOR=true esy x bash -cx ./src/refmterr/runTests.cmd
 
 :; # Run ReasonNativeTests.exe with correct root set.
 :; REASON_NATIVE_ROOT="$DIR/../" esy x "ReasonNativeTests.exe" "$@"

--- a/src/pastel/PastelFactory.re
+++ b/src/pastel/PastelFactory.re
@@ -9,11 +9,19 @@ open Decorators;
 open ColorName;
 
 module Make = (()) => {
+  let inferMode = fd =>
+    switch (SupportsColor.inferLevel(fd)) {
+    | NoSupport => Disabled
+    | BasicColorSupport
+    | Has256ColorSupport
+    | TrueColorSupport => Terminal
+    };
+
+  let defaultMode = inferMode(Unix.stdin);
+  let mode = ref(defaultMode);
   let modifierInternal = ref(TerminalImplementation.modifier);
   let colorInternal = ref(TerminalImplementation.color);
   let bgInternal = ref(TerminalImplementation.bg);
-
-  let mode = ref(Terminal);
 
   let setMode = m => {
     switch (m) {
@@ -33,8 +41,9 @@ module Make = (()) => {
     mode := m;
   };
 
+  setMode(defaultMode);
+
   let getMode = () => mode^;
-  let defaultMode = Terminal;
 
   let useMode = (mode, f) => {
     let prevMode = getMode();

--- a/src/pastel/SupportsColor.re
+++ b/src/pastel/SupportsColor.re
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+let (>>=) = (o, f) =>
+  switch (o) {
+  | Some(x) => f(x)
+  | None => None
+  };
+
+type level =
+  | NoSupport
+  | BasicColorSupport
+  | Has256ColorSupport
+  | TrueColorSupport;
+
+let forceColor = Sys.getenv_opt("FORCE_COLOR") >>= bool_of_string_opt;
+let (disable, minLevel) =
+  switch (forceColor) {
+  | None => (false, NoSupport)
+  | Some(true) => (false, BasicColorSupport)
+  | Some(false) => (true, NoSupport)
+  };
+
+let isTTY = fileDescriptor => Unix.isatty(fileDescriptor);
+
+let inferLevel = fileDescriptor =>
+  if (disable) {
+    NoSupport;
+  } else {
+    switch (isTTY(fileDescriptor)) {
+    | false => minLevel
+    | true => BasicColorSupport
+    };
+  };
+
+let stdin = inferLevel(Unix.stdin);

--- a/src/pastel/SupportsColor.rei
+++ b/src/pastel/SupportsColor.rei
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+
+type level =
+  | NoSupport
+  | BasicColorSupport
+  | Has256ColorSupport
+  | TrueColorSupport;
+
+let inferLevel: Unix.file_descr => level;
+
+let stdin: level;

--- a/src/pastel/dune
+++ b/src/pastel/dune
@@ -2,7 +2,7 @@
 (library
    (name Pastel)
    (public_name pastel.lib)
-   (libraries  str )
+   (libraries  str unix )
    (c_names winConsoleColorsSupport)
    (js_of_ocaml
      (flags (--pretty))

--- a/tests/__snapshots__/FloatMatchers.56a40b03.0.snapshot
+++ b/tests/__snapshots__/FloatMatchers.56a40b03.0.snapshot
@@ -1,6 +1,6 @@
 FloatMatchers › failure output .toBeCloseTo
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>failure output .toBeCloseTo</whiteBright>\027[89D\027[K\027[32m\027[1m\027[7m PASS \027[27m\027[22m\027[39m <whiteBright>failure output .toBeCloseTo</whiteBright>
+<green><bold><inverse> PASS </inverse></bold></green> <whiteBright>failure output .toBeCloseTo</whiteBright>
 
 <whiteBright><bold>Test Suites: </bold></whiteBright>0 failed, <green><bold>1 passed</bold></green>, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright>0 failed, <green><bold>2 passed</bold></green>, 2 total

--- a/tests/__snapshots__/FloatMatchers.db4be1fd.0.snapshot
+++ b/tests/__snapshots__/FloatMatchers.db4be1fd.0.snapshot
@@ -1,6 +1,6 @@
 FloatMatchers › failure output .not.toBeCloseTo
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>failure output .not.toBeCloseTo</whiteBright>\027[93D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>failure output .not.toBeCloseTo</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>failure output .not.toBeCloseTo</whiteBright>
 <bold><red>  \226\128\162 failure output .not.toBeCloseTo \226\128\186 0. should not be close to 0. with precision 0</red></bold>
 
     <dim>expect.float(</dim><red>received</red><dim>).</dim>not<dim>.toBeCloseTo(</dim><green>expected, precision</green><dim>)</dim>

--- a/tests/__snapshots__/FnMatchers.2113922b.0.snapshot
+++ b/tests/__snapshots__/FnMatchers.2113922b.0.snapshot
@@ -1,6 +1,6 @@
 FnMatchers › FnMatchers failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>FnMatchers failure output</whiteBright>\027[87D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>FnMatchers failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>FnMatchers failure output</whiteBright>
 <bold><red>  \226\128\162 FnMatchers failure output \226\128\186 Expect to throw, but doesn't</red></bold>
 
     <dim>expect.fn(</dim><red>function</red><dim>).toThrow(</dim><green></green><dim>)</dim>

--- a/tests/__snapshots__/Rely_array_matchers_toBeEmpty.2af8e875.0.snapshot
+++ b/tests/__snapshots__/Rely_array_matchers_toBeEmpty.2af8e875.0.snapshot
@@ -1,6 +1,6 @@
 Rely array matchers › toBeEmpty › expect.array.not.toBeEmpty output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>expect.array.not.toBeEmpty output</whiteBright>\027[95D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>expect.array.not.toBeEmpty output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>expect.array.not.toBeEmpty output</whiteBright>
 <bold><red>  \226\128\162 expect.array.not.toBeEmpty output \226\128\186 empty should not be empty failure output</red></bold>
 
     <dim>expect.array(</dim><red>received</red><dim>).not.toBeEmpty(</dim><green></green><dim>)</dim>

--- a/tests/__snapshots__/Rely_array_matchers_toBeEmpty.af057e34.0.snapshot
+++ b/tests/__snapshots__/Rely_array_matchers_toBeEmpty.af057e34.0.snapshot
@@ -1,6 +1,6 @@
 Rely array matchers › toBeEmpty › expect.array.toBeEmpty output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>expect.array.toBeEmpty output</whiteBright>\027[91D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>expect.array.toBeEmpty output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>expect.array.toBeEmpty output</whiteBright>
 <bold><red>  \226\128\162 expect.array.toBeEmpty output \226\128\186 something should be empty failure output</red></bold>
 
     <dim>expect.array(</dim><red>received</red><dim>).toBeEmpty(</dim><green></green><dim>)</dim>

--- a/tests/__snapshots__/Rely_array_matchers_toContain.53f160c7.0.snapshot
+++ b/tests/__snapshots__/Rely_array_matchers_toContain.53f160c7.0.snapshot
@@ -1,6 +1,6 @@
 Rely array matchers › toContain › expect.array.not.toContain failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>expect.array.not.toContain failure output</whiteBright>\027[103D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>expect.array.not.toContain failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>expect.array.not.toContain failure output</whiteBright>
 <bold><red>  \226\128\162 expect.array.not.toContain failure output \226\128\186 integer contains</red></bold>
 
     <dim>expect.array(</dim><red>array</red><dim>).</dim>not<dim>.toContain(</dim><green>value</green><dim>)</dim> <dim>/* using === */</dim>

--- a/tests/__snapshots__/Rely_array_matchers_toContain.8cf884f5.0.snapshot
+++ b/tests/__snapshots__/Rely_array_matchers_toContain.8cf884f5.0.snapshot
@@ -1,6 +1,6 @@
 Rely array matchers › toContain › expect.array.toContain failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>expect.array.toContain failure output</whiteBright>\027[99D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>expect.array.toContain failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>expect.array.toContain failure output</whiteBright>
 <bold><red>  \226\128\162 expect.array.toContain failure output \226\128\186 empty array</red></bold>
 
     <dim>expect.array(</dim><red>array</red><dim>).toContain(</dim><green>value</green><dim>)</dim> <dim>/* using === */</dim>

--- a/tests/__snapshots__/Rely_array_matchers_toContainEqual.cb9ef9bc.0.snapshot
+++ b/tests/__snapshots__/Rely_array_matchers_toContainEqual.cb9ef9bc.0.snapshot
@@ -1,6 +1,6 @@
 Rely array matchers › toContainEqual › expect.array.not.toContainEqual failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>expect.array.not.toContainEqual failure output</whiteBright>\027[108D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>expect.array.not.toContainEqual failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>expect.array.not.toContainEqual failure output</whiteBright>
 <bold><red>  \226\128\162 expect.array.not.toContainEqual failure output \226\128\186 integer contains</red></bold>
 
     <dim>expect.array(</dim><red>array</red><dim>).</dim>not<dim>.toContainEqual(</dim><green>value</green><dim>)</dim> <dim>/* using == */</dim>

--- a/tests/__snapshots__/Rely_array_matchers_toContainEqual.decf80a6.0.snapshot
+++ b/tests/__snapshots__/Rely_array_matchers_toContainEqual.decf80a6.0.snapshot
@@ -1,6 +1,6 @@
 Rely array matchers › toContainEqual › expect.array.toContainEqual failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>expect.array.toContainEqual failure output</whiteBright>\027[104D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>expect.array.toContainEqual failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>expect.array.toContainEqual failure output</whiteBright>
 <bold><red>  \226\128\162 expect.array.toContainEqual failure output \226\128\186 empty array</red></bold>
 
     <dim>expect.array(</dim><red>array</red><dim>).toContainEqual(</dim><green>value</green><dim>)</dim> <dim>/* using == */</dim>

--- a/tests/__snapshots__/Rely_array_matchers_toEqual.01309343.0.snapshot
+++ b/tests/__snapshots__/Rely_array_matchers_toEqual.01309343.0.snapshot
@@ -1,6 +1,6 @@
 Rely array matchers › toEqual › expect.array.not.toEqual failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>expect.array.not.toEqual failure output</whiteBright>\027[101D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>expect.array.not.toEqual failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>expect.array.not.toEqual failure output</whiteBright>
 <bold><red>  \226\128\162 expect.array.not.toEqual failure output \226\128\186 empty array</red></bold>
 
     <dim>expect.array(</dim><red>received</red><dim>).</dim>not<dim>.toEqual(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>

--- a/tests/__snapshots__/Rely_array_matchers_toEqual.c2e6ea6b.0.snapshot
+++ b/tests/__snapshots__/Rely_array_matchers_toEqual.c2e6ea6b.0.snapshot
@@ -1,6 +1,6 @@
 Rely array matchers › toEqual › expect.array.toEqual failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>expect.array.toEqual failure output</whiteBright>\027[97D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>expect.array.toEqual failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>expect.array.toEqual failure output</whiteBright>
 <bold><red>  \226\128\162 expect.array.toEqual failure output \226\128\186 actual shorter than expected</red></bold>
 
     <dim>expect.array(</dim><red>received</red><dim>).toEqual(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>

--- a/tests/__snapshots__/Rely_list_matchers_toBeEmpty.46fde8fb.0.snapshot
+++ b/tests/__snapshots__/Rely_list_matchers_toBeEmpty.46fde8fb.0.snapshot
@@ -1,6 +1,6 @@
 Rely list matchers › toBeEmpty › expect.list.toBeEmpty output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>expect.list.toBeEmpty output</whiteBright>\027[90D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>expect.list.toBeEmpty output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>expect.list.toBeEmpty output</whiteBright>
 <bold><red>  \226\128\162 expect.list.toBeEmpty output \226\128\186 something should be empty failure output</red></bold>
 
     <dim>expect.list(</dim><red>received</red><dim>).toBeEmpty(</dim><green></green><dim>)</dim>

--- a/tests/__snapshots__/Rely_list_matchers_toBeEmpty.7d8c97ff.0.snapshot
+++ b/tests/__snapshots__/Rely_list_matchers_toBeEmpty.7d8c97ff.0.snapshot
@@ -1,6 +1,6 @@
 Rely list matchers › toBeEmpty › expect.list.not.toBeEmpty output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>expect.list.not.toBeEmpty output</whiteBright>\027[94D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>expect.list.not.toBeEmpty output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>expect.list.not.toBeEmpty output</whiteBright>
 <bold><red>  \226\128\162 expect.list.not.toBeEmpty output \226\128\186 empty should not be empty failure output</red></bold>
 
     <dim>expect.list(</dim><red>received</red><dim>).not.toBeEmpty(</dim><green></green><dim>)</dim>

--- a/tests/__snapshots__/Rely_list_matchers_toContain.472b2cbb.0.snapshot
+++ b/tests/__snapshots__/Rely_list_matchers_toContain.472b2cbb.0.snapshot
@@ -1,6 +1,6 @@
 Rely list matchers › toContain › expect.list.toContain failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>expect.list.toContain failure output</whiteBright>\027[98D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>expect.list.toContain failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>expect.list.toContain failure output</whiteBright>
 <bold><red>  \226\128\162 expect.list.toContain failure output \226\128\186 empty list</red></bold>
 
     <dim>expect.list(</dim><red>list</red><dim>).toContain(</dim><green>value</green><dim>)</dim> <dim>/* using === */</dim>

--- a/tests/__snapshots__/Rely_list_matchers_toContain.50c54e5f.0.snapshot
+++ b/tests/__snapshots__/Rely_list_matchers_toContain.50c54e5f.0.snapshot
@@ -1,6 +1,6 @@
 Rely list matchers › toContain › expect.list.not.toContain failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>expect.list.not.toContain failure output</whiteBright>\027[102D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>expect.list.not.toContain failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>expect.list.not.toContain failure output</whiteBright>
 <bold><red>  \226\128\162 expect.list.not.toContain failure output \226\128\186 integer contains</red></bold>
 
     <dim>expect.list(</dim><red>list</red><dim>).</dim>not<dim>.toContain(</dim><green>value</green><dim>)</dim> <dim>/* using === */</dim>

--- a/tests/__snapshots__/Rely_list_matchers_toContainEqual.2cb46764.0.snapshot
+++ b/tests/__snapshots__/Rely_list_matchers_toContainEqual.2cb46764.0.snapshot
@@ -1,6 +1,6 @@
 Rely list matchers › toContainEqual › expect.list.not.toContainEqual failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>expect.list.not.toContainEqual failure output</whiteBright>\027[107D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>expect.list.not.toContainEqual failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>expect.list.not.toContainEqual failure output</whiteBright>
 <bold><red>  \226\128\162 expect.list.not.toContainEqual failure output \226\128\186 integer contains</red></bold>
 
     <dim>expect.list(</dim><red>list</red><dim>).</dim>not<dim>.toContainEqual(</dim><green>value</green><dim>)</dim> <dim>/* using == */</dim>

--- a/tests/__snapshots__/Rely_list_matchers_toContainEqual.45ad09a9.0.snapshot
+++ b/tests/__snapshots__/Rely_list_matchers_toContainEqual.45ad09a9.0.snapshot
@@ -1,6 +1,6 @@
 Rely list matchers › toContainEqual › expect.list.toContainEqual failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>expect.list.toContainEqual failure output</whiteBright>\027[103D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>expect.list.toContainEqual failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>expect.list.toContainEqual failure output</whiteBright>
 <bold><red>  \226\128\162 expect.list.toContainEqual failure output \226\128\186 empty list</red></bold>
 
     <dim>expect.list(</dim><red>list</red><dim>).toContainEqual(</dim><green>value</green><dim>)</dim> <dim>/* using == */</dim>

--- a/tests/__snapshots__/Rely_list_matchers_toEqual.0ac36f9e.0.snapshot
+++ b/tests/__snapshots__/Rely_list_matchers_toEqual.0ac36f9e.0.snapshot
@@ -1,6 +1,6 @@
 Rely list matchers › toEqual › expect.list.not.toEqual failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>expect.list.not.toEqual failure output</whiteBright>\027[100D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>expect.list.not.toEqual failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>expect.list.not.toEqual failure output</whiteBright>
 <bold><red>  \226\128\162 expect.list.not.toEqual failure output \226\128\186 empty list</red></bold>
 
     <dim>expect.list(</dim><red>received</red><dim>).</dim>not<dim>.toEqual(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>

--- a/tests/__snapshots__/Rely_list_matchers_toEqual.1b8cb7fe.0.snapshot
+++ b/tests/__snapshots__/Rely_list_matchers_toEqual.1b8cb7fe.0.snapshot
@@ -1,6 +1,6 @@
 Rely list matchers › toEqual › expect.list.toEqual failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>expect.list.toEqual failure output</whiteBright>\027[96D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>expect.list.toEqual failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>expect.list.toEqual failure output</whiteBright>
 <bold><red>  \226\128\162 expect.list.toEqual failure output \226\128\186 actual shorter than expected</red></bold>
 
     <dim>expect.list(</dim><red>received</red><dim>).toEqual(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>

--- a/tests/__snapshots__/TestRunner.1e3e5d03.0.snapshot
+++ b/tests/__snapshots__/TestRunner.1e3e5d03.0.snapshot
@@ -1,6 +1,6 @@
 TestRunner › failing tests
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>failing tests</whiteBright>\027[75D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>failing tests</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>failing tests</whiteBright>
 <bold><red>  \226\128\162 failing tests \226\128\186 expect.string.toBeEmpty</red></bold>
 
     <dim>expect.string(</dim><red>received</red><dim>).toBeEmpty(</dim><green></green><dim>)</dim>

--- a/tests/__snapshots__/TestRunner.813890c0.0.snapshot
+++ b/tests/__snapshots__/TestRunner.813890c0.0.snapshot
@@ -1,6 +1,6 @@
 TestRunner › mixed tests
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>mixed tests</whiteBright>\027[73D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>mixed tests</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>mixed tests</whiteBright>
 <bold><red>  \226\128\162 mixed tests \226\128\186 Inner describe 1 \226\128\186 Inner test 2</red></bold>
 
     <dim>expect.string(</dim><red>received</red><dim>).toEqual(</dim><green>expected</green><dim>)</dim>

--- a/tests/__snapshots__/TestRunner.94379a08.0.snapshot
+++ b/tests/__snapshots__/TestRunner.94379a08.0.snapshot
@@ -1,6 +1,6 @@
 TestRunner › nested describes
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>nested describes</whiteBright>\027[78D\027[K\027[32m\027[1m\027[7m PASS \027[27m\027[22m\027[39m <whiteBright>nested describes</whiteBright>
+<green><bold><inverse> PASS </inverse></bold></green> <whiteBright>nested describes</whiteBright>
 
 <whiteBright><bold>Test Suites: </bold></whiteBright>0 failed, <green><bold>1 passed</bold></green>, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright>0 failed, <green><bold>7 passed</bold></green>, 7 total

--- a/tests/__snapshots__/TestRunner.9ae8523f.0.snapshot
+++ b/tests/__snapshots__/TestRunner.9ae8523f.0.snapshot
@@ -1,6 +1,6 @@
 TestRunner › string operations
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>string operations</whiteBright>\027[79D\027[K\027[32m\027[1m\027[7m PASS \027[27m\027[22m\027[39m <whiteBright>string operations</whiteBright>
+<green><bold><inverse> PASS </inverse></bold></green> <whiteBright>string operations</whiteBright>
 
 <whiteBright><bold>Test Suites: </bold></whiteBright>0 failed, <green><bold>1 passed</bold></green>, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright>0 failed, <green><bold>1 passed</bold></green>, 1 total

--- a/tests/__snapshots__/TestRunner.e9296ac9.0.snapshot
+++ b/tests/__snapshots__/TestRunner.e9296ac9.0.snapshot
@@ -1,6 +1,6 @@
 TestRunner › passing tests
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>passing tests</whiteBright>\027[75D\027[K\027[32m\027[1m\027[7m PASS \027[27m\027[22m\027[39m <whiteBright>passing tests</whiteBright>
+<green><bold><inverse> PASS </inverse></bold></green> <whiteBright>passing tests</whiteBright>
 
 <whiteBright><bold>Test Suites: </bold></whiteBright>0 failed, <green><bold>1 passed</bold></green>, 1 total
 <whiteBright><bold>Tests:       </bold></whiteBright>0 failed, <green><bold>2 passed</bold></green>, 2 total

--- a/tests/__snapshots__/equals_matcher.8391adfb.0.snapshot
+++ b/tests/__snapshots__/equals_matcher.8391adfb.0.snapshot
@@ -1,6 +1,6 @@
 equals matcher › equals failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>equals failure output</whiteBright>\027[83D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>equals failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>equals failure output</whiteBright>
 <bold><red>  \226\128\162 equals failure output \226\128\186 ints</red></bold>
 
     <dim>expect.equal(</dim><green>expected</green><dim>, </dim><red>received</red><dim>)</dim> <dim>/* using == */</dim>

--- a/tests/__snapshots__/equals_matcher.985acbef.0.snapshot
+++ b/tests/__snapshots__/equals_matcher.985acbef.0.snapshot
@@ -1,6 +1,6 @@
 equals matcher › not equals failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>not equals failure output</whiteBright>\027[87D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>not equals failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>not equals failure output</whiteBright>
 <bold><red>  \226\128\162 not equals failure output \226\128\186 ints</red></bold>
 
     <dim>expect.notEqual(</dim><green>expected</green><dim>, </dim><red>received</red><dim>)</dim> <dim>/* using == */</dim>

--- a/tests/__snapshots__/same_matcher.3603a3e1.0.snapshot
+++ b/tests/__snapshots__/same_matcher.3603a3e1.0.snapshot
@@ -1,6 +1,6 @@
 same matcher › not same failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>not same failure output</whiteBright>\027[85D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>not same failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>not same failure output</whiteBright>
 <bold><red>  \226\128\162 not same failure output \226\128\186 ints</red></bold>
 
     <dim>expect.notSame(</dim><green>expected</green><dim>, </dim><red>received</red><dim>)</dim> <dim>/* using === */</dim>

--- a/tests/__snapshots__/same_matcher.502acd58.0.snapshot
+++ b/tests/__snapshots__/same_matcher.502acd58.0.snapshot
@@ -1,6 +1,6 @@
 same matcher › same failure output
 Running 1 test suite
-\r\027[33m\027[1m\027[7m RUNS \027[27m\027[22m\027[39m <whiteBright>same failure output</whiteBright>\027[81D\027[K\027[31m\027[1m\027[7m FAIL \027[27m\027[22m\027[39m <whiteBright>same failure output</whiteBright>
+<red><bold><inverse> FAIL </inverse></bold></red> <whiteBright>same failure output</whiteBright>
 <bold><red>  \226\128\162 same failure output \226\128\186 ints</red></bold>
 
     <dim>expect.same(</dim><green>expected</green><dim>, </dim><red>received</red><dim>)</dim> <dim>/* using === */</dim>

--- a/tests/__tests__/pastel/Exhaustiveness_test.re
+++ b/tests/__tests__/pastel/Exhaustiveness_test.re
@@ -9,6 +9,7 @@ open TestFramework;
 open Pastel.ColorName;
 module Pastel = Pastel.Make();
 open Pastel;
+Pastel.setMode(Terminal);
 
 describe("Exhaustiveness test", ({test}) =>
   test("should match snapshot", ({expect}) => {

--- a/tests/__tests__/pastel/PastelMode_test.re
+++ b/tests/__tests__/pastel/PastelMode_test.re
@@ -1,12 +1,6 @@
 open TestFramework;
 
 describe("Pastel modes", ({test}) => {
-  test("Default mode should produce ANSI terminal output", ({expect}) => {
-    module DefaultPastel =
-      Pastel.Make({});
-    let output = <DefaultPastel color=Red> "Hello" </DefaultPastel>;
-    expect.string(output).toEqual("\027[31mHello\027[39m");
-  });
   test("Switching from default to human readable and back", ({expect}) => {
     module Pastel =
       Pastel.Make({});

--- a/tests/__tests__/pastel/Pastel_test.re
+++ b/tests/__tests__/pastel/Pastel_test.re
@@ -9,16 +9,20 @@ open TestFramework;
 describe("Pastel", ({describe, test}) => {
   test(
     "ANSI escape sequences should be applied inside pastels and persisted outside of them",
-    ({expect}) => {
-      let testCase =
-        <Pastel dim=true>
-          "oo"
-          <Pastel color=Green> "hello \027[4mworld!" </Pastel>
-          "unpasteled o_O"
-        </Pastel>
-        ++ " reset to prevent underlines on the rest of stdout \027[0m";
-      expect.string(testCase).toMatchSnapshot();
-    },
+    ({expect}) =>
+    Pastel.useMode(
+      Terminal,
+      () => {
+        let testCase =
+          <Pastel dim=true>
+            "oo"
+            <Pastel color=Green> "hello \027[4mworld!" </Pastel>
+            "unpasteled o_O"
+          </Pastel>
+          ++ " reset to prevent underlines on the rest of stdout \027[0m";
+        expect.string(testCase).toMatchSnapshot();
+      },
+    )
   );
 
   let testMode = (mode, name) => {


### PR DESCRIPTION
Addresses https://github.com/facebookexperimental/reason-native/issues/100

### What this PR does:
- Checks Unix.isatty and the FORCE_COLOR environment variable, and sets the default mode of Pastel accordingly
  - FORCE_COLOR takes precedence
  - if FORCE_COLOR is undefined, then if non tty we disable by default
- Update Rely Terminal reporter to not use Ansi escape characters to erase lines if Pastel.mode != terminal (only prints after a suite has run instead of at beginning in that case)
- Pass FORCE_COLOR true to refmterr tests to not break snapshots
  - There may be a better way to do this than what I did
- Update rely snapshots (the change to terminal reporter behavior broke some old matcher tests)

Ultimately I chose to stop short of publicly exposing supportsColor and inferMode as I think we will want to flush it out a fair bit more (compare to behavior of chalk/supports-color) in terms of things we check as well as modifying our behavior in 16 bit/256 bit/true color support terminals and really figuring out what we want our API to be.

I am not sure if this is a breaking change for Pastel or not and would like to talk that over, once merged I will cut a new version of Pastel (including the powershell support work), and will cut a Rely release as well once Mock matchers are merged to avoid a breaking change with the Mock API that matchers introduced (Rely.Mock hasn't been released yet).

![image](https://user-images.githubusercontent.com/5252755/52888905-5d99d800-3132-11e9-9594-8e3be64e8a60.png)
