### PR TITLE
Stop crashing when running in cygwin shells.

### DIFF
--- a/src/pastel/SupportsColor.re
+++ b/src/pastel/SupportsColor.re
@@ -24,6 +24,12 @@ let (disable, minLevel) =
   | Some(false) => (true, NoSupport)
   };
 
+/*
+ * `isatty` does not correctly detect cygwin interactive terminals.
+ * See vim's source for an example of how to do this eventually
+ * https://fossies.org/linux/vim/src/iscygpty.c
+ * In the mean time you can set `FORCE_COLOR` in your bashrc.
+ */
 let isTTY = fileDescriptor => Unix.isatty(fileDescriptor);
 
 let inferLevel = fileDescriptor =>


### PR DESCRIPTION
Summary:Microsoft Azure by default runs windows builds in a cygwin shell.
Also, I like to use mingw for local windows development and I don't like
my programs crashing there either.

Test Plan:Tested running in pure powershell and mingw shell and it works
now.

Reviewers:kad

CC: