### PR TITLE
 Enable color detection on Mingw/Cygwin/Mintty shells.

### DIFF
--- a/src/pastel/ORIGINS.md
+++ b/src/pastel/ORIGINS.md
@@ -1,0 +1,3 @@
+`iscygpty.h/c` was copied from [here](https://raw.githubusercontent.com/k-takata/ptycheck/master/iscygpty.c) (MIT).
+with a couple of `#define`s at the top to declare the minimum windows versions,
+and most of the features disabled/removed.

--- a/src/pastel/SupportsColor.re
+++ b/src/pastel/SupportsColor.re
@@ -30,7 +30,8 @@ let (disable, minLevel) =
  * https://fossies.org/linux/vim/src/iscygpty.c
  * In the mean time you can set `FORCE_COLOR` in your bashrc.
  */
-let isTTY = fileDescriptor => Unix.isatty(fileDescriptor);
+let isTTY = fileDescriptor =>
+  Unix.isatty(fileDescriptor) || WinCygPtySupport.isCygptyUsed();
 
 let inferLevel = fileDescriptor =>
   if (disable) {

--- a/src/pastel/WinConsoleColorsSupport.re
+++ b/src/pastel/WinConsoleColorsSupport.re
@@ -4,11 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
-external enableWinConsoleAnsiSequences: unit => unit = "enable_windows_console_ansi_sequences";
+external enableWinConsoleAnsiSequences: unit => unit =
+  "enable_windows_console_ansi_sequences";
 
 let enable = () =>
-  if (Sys.win32) {
-    enableWinConsoleAnsiSequences()
+  if (Sys.win32 && !WinCygPtySupport.isCygptyUsed()) {
+    enableWinConsoleAnsiSequences();
   } else {
-    ()
-  }
+    ();
+  };

--- a/src/pastel/WinCygPtySupport.re
+++ b/src/pastel/WinCygPtySupport.re
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+external isCygptyUsed: unit => bool = "is_cygpty_used";

--- a/src/pastel/dune
+++ b/src/pastel/dune
@@ -3,9 +3,9 @@
    (name Pastel)
    (public_name pastel.lib)
    (libraries  str unix )
-   (c_names winConsoleColorsSupport)
+   (c_names winCygPtySupport winConsoleColorsSupport)
    (js_of_ocaml
      (flags (--pretty))
-     (javascript_files winConsoleColorsSupport.js)
+     (javascript_files winCygPtySupport.js winConsoleColorsSupport.js)
    )
 )

--- a/src/pastel/winCygPtySupport.c
+++ b/src/pastel/winCygPtySupport.c
@@ -1,0 +1,150 @@
+/*
+ * iscygpty.c -- part of ptycheck
+ * https://github.com/k-takata/ptycheck
+ *
+ * Copyright (c) 2015-2017 K.Takata
+ *
+ * You can redistribute it and/or modify it under the terms of either
+ * the MIT license (as described below) or the Vim license.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+#define CAML_NAME_SPACE
+// 0x0600 is Windows Vista.
+// See mingw's w32api.h
+// This has to be set before including other header files, and will
+// enable some APIs used to detect mintty.
+#define _WIN32_WINNT 0x0600
+#define WINVER 0x0600
+#include <stdio.h>
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+
+#ifdef _WIN32
+
+#include <ctype.h>
+#include <io.h>
+#include <wchar.h>
+#include <windows.h>
+
+/* Win32 FileID API Library:
+ * http://www.microsoft.com/en-us/download/details.aspx?id=22599
+ * Needed for WinXP. */
+# include <fileextd.h>
+/* VC 8 or earlier. */
+// This at least allows it to run in windows xp lol.
+# if defined(_MSC_VER) && (_MSC_VER < 1500)
+#   define STUB_IMPL
+# endif
+
+# define pGetFileInformationByHandleEx	GetFileInformationByHandleEx
+# define setup_fileid_api()
+
+#define is_wprefix(s, prefix) \
+	(wcsncmp((s), (prefix), sizeof(prefix) / sizeof(WCHAR) - 1) == 0)
+
+#else
+#   define STUB_IMPL   /* On non windows just use stub */
+#endif /* _WIN32 */
+
+#include "winCygPtySupport.h"
+
+/* Check if the fd is a cygwin/msys's pty. */
+int pastel_is_cygpty(int fd)
+{
+#ifdef STUB_IMPL
+	return 0;
+#else
+	HANDLE h;
+	int size = sizeof(FILE_NAME_INFO) + sizeof(WCHAR) * (MAX_PATH - 1);
+	FILE_NAME_INFO *nameinfo;
+	WCHAR *p = NULL;
+
+	setup_fileid_api();
+
+	h = (HANDLE) _get_osfhandle(fd);
+	if (h == INVALID_HANDLE_VALUE) {
+		return 0;
+	}
+	/* Cygwin/msys's pty is a pipe. */
+	if (GetFileType(h) != FILE_TYPE_PIPE) {
+		return 0;
+	}
+	nameinfo = malloc(size + sizeof(WCHAR));
+	if (nameinfo == NULL) {
+		return 0;
+	}
+	/* Check the name of the pipe:
+	 * '\{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-master' */
+	if (pGetFileInformationByHandleEx(h, FileNameInfo, nameinfo, size)) {
+		nameinfo->FileName[nameinfo->FileNameLength / sizeof(WCHAR)] = L'\0';
+		p = nameinfo->FileName;
+		if (is_wprefix(p, L"\\cygwin-")) {		/* Cygwin */
+			p += 8;
+		} else if (is_wprefix(p, L"\\msys-")) {	/* MSYS and MSYS2 */
+			p += 6;
+		} else {
+			p = NULL;
+		}
+		if (p != NULL) {
+			while (*p && isxdigit(*p))	/* Skip 16-digit hexadecimal. */
+				++p;
+			if (is_wprefix(p, L"-pty")) {
+				p += 4;
+			} else {
+				p = NULL;
+			}
+		}
+		if (p != NULL) {
+			while (*p && isdigit(*p))	/* Skip pty number. */
+				++p;
+			if (is_wprefix(p, L"-from-master")) {
+				//p += 12;
+			} else if (is_wprefix(p, L"-to-master")) {
+				//p += 10;
+			} else {
+				p = NULL;
+			}
+		}
+	}
+	free(nameinfo);
+	return (p != NULL);
+#endif /* STUB_IMPL */
+}
+
+/* Check if at least one cygwin/msys pty is used. */
+int pastel_is_cygpty_used_impl(void)
+{
+	int fd, ret = 0;
+
+	for (fd = 0; fd < 3; fd++) {
+		ret |= pastel_is_cygpty(fd);
+	}
+	return ret;
+}
+
+
+CAMLprim value is_cygpty_used()
+{
+  CAMLparam0();
+  CAMLreturn(Val_bool(pastel_is_cygpty_used_impl()));
+}

--- a/src/pastel/winCygPtySupport.h
+++ b/src/pastel/winCygPtySupport.h
@@ -1,0 +1,37 @@
+/*
+ * iscygpty.h -- part of ptycheck
+ * https://github.com/k-takata/ptycheck
+ *
+ * Copyright (c) 2015-2017 K.Takata
+ *
+ * You can redistribute it and/or modify it under the terms of either
+ * the MIT license (as described below) or the Vim license.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef _WINCYGPTYSUPPORT_H
+#define _WINCYGPTYSUPPORT_H
+
+int is_cygpty(int fd);
+int is_cygpty_used_impl(void);
+CAMLprim value is_cygpty_used(void);
+
+#endif /* _WINCYGPTYSUPPORT_H */

--- a/src/pastel/winCygPtySupport.js
+++ b/src/pastel/winCygPtySupport.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+function is_cygpty_used() {
+  return false;
+}


### PR DESCRIPTION
Summary:Unix.is_atty returns false for mintty - kind of a longstanding
bug. This fixes that. It's actually not easy to detect whether or not
you are in a cygwin/mintty shell. I used an open source project as a
starting point.

This also would have fixed our previous bug of failing in the c stub for
setting console mode. But this way we have double coverage.

Eventually this should all go into a standalone library for terminal
capabilities detection.

Test Plan:Will let CI run, and also tested on powershell as well as
mintty shell.

Reviewers:kad

CC:

