### PR TITLE
change extendDescribe to return a record so that we can preserve type…

### DIFF
--- a/src/rely/Rely.re
+++ b/src/rely/Rely.re
@@ -464,50 +464,50 @@ module Make = (UserConfig: FrameworkConfig) => {
     value;
   };
 
-  let makeDescribeFunction = (extensionFn) => {
+  let makeDescribeFunction = extensionFn => {
     let describe = (name, fn) =>
-    errorIfRunning(
-      () =>
-        testSuites :=
-          testSuites^
-          @ [
-            TestSuiteInternal({
-              name,
-              fn,
-              matchersExtensionFn: extensionFn,
-              skip: false,
-            }),
-          ],
-      "TestFramework.describe cannot be nested, instead use the describe supplied by the parent describe block, e.g. describe(\"parent describe\", {test, describe} => { ... });",
-    );
+      errorIfRunning(
+        () =>
+          testSuites :=
+            testSuites^
+            @ [
+              TestSuiteInternal({
+                name,
+                fn,
+                matchersExtensionFn: extensionFn,
+                skip: false,
+              }),
+            ],
+        "TestFramework.describe cannot be nested, instead use the describe supplied by the parent describe block, e.g. describe(\"parent describe\", {test, describe} => { ... });",
+      );
     describe;
   };
 
-  let makeDescribeSkipFunction = (extensionFn) => {
+  let makeDescribeSkipFunction = extensionFn => {
     let describeSkip = (name, fn) =>
-    errorIfRunning(
-      () =>
-        testSuites :=
-          testSuites^
-          @ [
-            TestSuiteInternal({
-              name,
-              fn,
-              matchersExtensionFn: extensionFn,
-              skip: true,
-            }),
-          ],
-      "TestFramework.describeSkip cannot be nested, instead use the describe supplied by the parent describe block, e.g. describe(\"parent describe\", {test, describe} => { ... });",
-    );
+      errorIfRunning(
+        () =>
+          testSuites :=
+            testSuites^
+            @ [
+              TestSuiteInternal({
+                name,
+                fn,
+                matchersExtensionFn: extensionFn,
+                skip: true,
+              }),
+            ],
+        "TestFramework.describeSkip cannot be nested, instead use the describe supplied by the parent describe block, e.g. describe(\"parent describe\", {test, describe} => { ... });",
+      );
     describeSkip;
-  }
+  };
 
   let describe = makeDescribeFunction(_ => ());
   let describeSkip = makeDescribeSkipFunction(_ => ());
 
-  let extendDescribe = (createCustomMatchers) => {
+  let extendDescribe = createCustomMatchers => {
     describe: makeDescribeFunction(createCustomMatchers),
-    describeSkip: makeDescribeSkipFunction(createCustomMatchers)
+    describeSkip: makeDescribeSkipFunction(createCustomMatchers),
   };
 
   type testSuiteAccumulator = {

--- a/src/rely/Rely.rei
+++ b/src/rely/Rely.rei
@@ -25,6 +25,11 @@ module Describe: {
     testSkip: Test.testFn('ext),
   }
   and describeFn('ext) = (string, describeUtils('ext) => unit) => unit;
+
+  type extensionResult('ext) = {
+    describe: describeFn('ext),
+    describeSkip: describeFn('ext),
+  };
 };
 
 module RunConfig: {
@@ -78,12 +83,16 @@ module MatcherTypes: {
 
 module type TestFramework = {
   module Mock: Mock.Sig;
+  include (module type of Describe);
+  include (module type of Test);
+
   let describe: Describe.describeFn(unit);
-  let describeSkip: Describe.describeFn('a);
+  let describeSkip: Describe.describeFn(unit);
   let extendDescribe:
-    MatcherTypes.matchersExtensionFn('ext) => Describe.describeFn('ext);
+    MatcherTypes.matchersExtensionFn('ext) => extensionResult('ext);
   let run: RunConfig.t => unit;
   let cli: unit => unit;
+
 };
 
 type requiredConfiguration = TestFrameworkConfig.requiredConfiguration;

--- a/tests/__tests__/rely/CustomMatchers_test.re
+++ b/tests/__tests__/rely/CustomMatchers_test.re
@@ -232,7 +232,7 @@ module User = {
  */
 open User;
 
-let { describe } = extendDescribe(User.Test.matchers);
+let {describe} = extendDescribe(User.Test.matchers);
 
 /* Alice is a Facebook user with string data. */
 let alice = {
@@ -317,7 +317,7 @@ module Account = {
  * necessary to combine the custom matchers and use them within the same
  * describe block.
  */
-let { describe } = extendDescribe(Account.Test.matchers)
+let {describe} = extendDescribe(Account.Test.matchers);
 
 describe("Separate type of Custom Matchers", ({test}) => {
   test("Alice tests", ({expect}) => {
@@ -352,7 +352,7 @@ module Combined = {
 };
 
 /* Use the combined matchers */
-let { describe } = extendDescribe(Combined.matchers);
+let {describe} = extendDescribe(Combined.matchers);
 
 describe("Combined Custom Matchers", ({test}) => {
   test("Alice tests", ({expect}) => {

--- a/tests/__tests__/rely/CustomMatchers_test.re
+++ b/tests/__tests__/rely/CustomMatchers_test.re
@@ -232,7 +232,7 @@ module User = {
  */
 open User;
 
-let describe = extendDescribe(User.Test.matchers);
+let { describe } = extendDescribe(User.Test.matchers);
 
 /* Alice is a Facebook user with string data. */
 let alice = {
@@ -317,7 +317,7 @@ module Account = {
  * necessary to combine the custom matchers and use them within the same
  * describe block.
  */
-let describe = extendDescribe(Account.Test.matchers);
+let { describe } = extendDescribe(Account.Test.matchers)
 
 describe("Separate type of Custom Matchers", ({test}) => {
   test("Alice tests", ({expect}) => {
@@ -352,7 +352,7 @@ module Combined = {
 };
 
 /* Use the combined matchers */
-let describe = extendDescribe(Combined.matchers);
+let { describe } = extendDescribe(Combined.matchers);
 
 describe("Combined Custom Matchers", ({test}) => {
   test("Alice tests", ({expect}) => {


### PR DESCRIPTION
… information for describeOnly. Include Test and Describe modules in TestFramework for better syntax end users.