### PR TITLE
Add rely e2e snapshot tests

### DIFF
--- a/src/rely/RelyAPI.re
+++ b/src/rely/RelyAPI.re
@@ -4,138 +4,15 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
-open Common.Collections;
-open Common.Option.Infix;
-open MatcherUtils;
-open Reporter;
-open SnapshotIO;
-open TestResult;
 include RunConfig;
+include TestFramework;
 include TestFrameworkConfig;
 module MatcherTypes = MatcherTypes;
 module MatcherUtils = MatcherUtils;
 module Mock = Mock;
 module Reporter = Reporter;
 module Time = Time;
-exception InvalidWhileRunning(string);
 module Test = Test;
 include Test;
 module Describe = Describe;
 include Describe;
-open TestSuite;
-
-type describeConfig = {
-  updateSnapshots: bool,
-  snapshotDir: string,
-  getTime: unit => Time.t,
-};
-
-exception TestAlreadyRan(string);
-exception PendingTestException(string);
-
-type testLibrary = list(TestSuite.t);
-type combineResult = {
-  run: RunConfig.t => unit,
-  cli: unit => unit,
-  testLibrary,
-};
-
-let combine = libraries => {
-  let testLibrary = List.flatten(libraries);
-  let run = config => TestSuiteRunner.run(config, testLibrary);
-  let cli = () => TestSuiteRunner.cli(testLibrary);
-
-  {testLibrary, run, cli};
-};
-
-module type TestFramework = {
-  module Mock: Mock.Sig;
-  include (module type of Describe);
-  include (module type of Test);
-
-  let describe: Describe.describeFn(unit);
-  let describeSkip: Describe.describeFn(unit);
-  let extendDescribe:
-    MatcherTypes.matchersExtensionFn('ext) => extensionResult('ext);
-  let run: RunConfig.t => unit;
-  let cli: unit => unit;
-  let toLibrary: unit => testLibrary;
-};
-
-module type FrameworkConfig = {let config: TestFrameworkConfig.t;};
-
-module Make = (UserConfig: FrameworkConfig) => {
-  include Describe;
-  include Test;
-  module StackTrace =
-    StackTrace.Make({
-      let baseDir = UserConfig.config.projectDir;
-      /* using both "/" and "\\" here because Filename.dir_sep is flaky on windows */
-      let exclude = [
-        Filename.dirname(__FILE__) ++ "/",
-        Filename.dirname(__FILE__) ++ "\\",
-      ];
-      let formatLink = Pastel.cyan;
-      let formatText = Pastel.dim;
-    });
-  module Mock =
-    Mock.Make(
-      StackTrace,
-      {
-        let maxNumCalls = UserConfig.config.maxNumMockCalls;
-      },
-    );
-
-  module TestSuiteFactory =
-    TestSuite.Factory({
-      module StackTrace = StackTrace;
-      module Mock = Mock;
-      module Snapshot =
-        FileSystemSnapshot.Make({
-          let snapshotDir = UserConfig.config.snapshotDir;
-          module IO = FileSystemSnapshotIO;
-        });
-    });
-
-  let testSuites: ref(list(TestSuite.t)) = ref([]);
-  let makeDescribeFunction = extensionFn => {
-    let describe = (name, fn) =>
-      testSuites :=
-        testSuites^
-        @ [
-          TestSuiteFactory.makeTestSuite({
-            name,
-            usersDescribeFn: fn,
-            skip: false,
-            extensionFn,
-          }),
-        ];
-    describe;
-  };
-  let makeDescribeSkipFunction = extensionFn => {
-    let describeSkip = (name, fn) =>
-      testSuites :=
-        testSuites^
-        @ [
-          TestSuiteFactory.makeTestSuite({
-            name,
-            usersDescribeFn: fn,
-            skip: true,
-            extensionFn,
-          }),
-        ];
-    describeSkip;
-  };
-  let describe = makeDescribeFunction(_ => ());
-  let describeSkip = makeDescribeSkipFunction(_ => ());
-  let extendDescribe = createCustomMatchers => {
-    describe: makeDescribeFunction(createCustomMatchers),
-    describeSkip: makeDescribeSkipFunction(createCustomMatchers),
-  };
-
-  let run = (config: RunConfig.t) => TestSuiteRunner.run(config, testSuites^);
-
-  let cli = () => TestSuiteRunner.cli(testSuites^);
-
-  let toLibrary = () => testSuites^;
-};

--- a/src/rely/RelyAPI.rei
+++ b/src/rely/RelyAPI.rei
@@ -7,7 +7,6 @@
 module Reporter = Reporter;
 module Time = Time;
 module Mock = Mock;
-exception InvalidWhileRunning(string);
 
 /* maintained for backwards compatibility */
 module Test = Test;

--- a/src/rely/TestFramework.re
+++ b/src/rely/TestFramework.re
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+open RunConfig;
+open TestFrameworkConfig;
+open SnapshotIO;
+
+type describeConfig = {
+  updateSnapshots: bool,
+  snapshotDir: string,
+  getTime: unit => Time.t,
+};
+
+exception TestAlreadyRan(string);
+exception PendingTestException(string);
+
+type testLibrary = list(TestSuite.t);
+type combineResult = {
+  run: RunConfig.t => unit,
+  cli: unit => unit,
+  testLibrary,
+};
+
+let combine = libraries => {
+  let testLibrary = List.flatten(libraries);
+  let run = config => TestSuiteRunner.run(config, testLibrary);
+  let cli = () => TestSuiteRunner.cli(testLibrary);
+
+  {testLibrary, run, cli};
+};
+
+module type TestFramework = {
+  module Mock: Mock.Sig;
+  include (module type of Describe);
+  include (module type of Test);
+
+  let describe: Describe.describeFn(unit);
+  let describeSkip: Describe.describeFn(unit);
+  let extendDescribe:
+    MatcherTypes.matchersExtensionFn('ext) => extensionResult('ext);
+  let run: RunConfig.t => unit;
+  let cli: unit => unit;
+  let toLibrary: unit => testLibrary;
+};
+
+module type FrameworkConfig = {let config: TestFrameworkConfig.t;};
+
+module MakeInternal = (SnapshotIO: SnapshotIO.SnapshotIO, UserConfig: FrameworkConfig) => {
+  include Describe;
+  include Test;
+  module StackTrace =
+    StackTrace.Make({
+      let baseDir = UserConfig.config.projectDir;
+      /* using both "/" and "\\" here because Filename.dir_sep is flaky on windows */
+      let exclude = [
+        Filename.dirname(__FILE__) ++ "/",
+        Filename.dirname(__FILE__) ++ "\\",
+      ];
+      let formatLink = Pastel.cyan;
+      let formatText = Pastel.dim;
+    });
+  module Mock =
+    Mock.Make(
+      StackTrace,
+      {
+        let maxNumCalls = UserConfig.config.maxNumMockCalls;
+      },
+    );
+
+  module Snapshot =
+    FileSystemSnapshot.Make({
+      let snapshotDir = UserConfig.config.snapshotDir;
+      module IO = SnapshotIO;
+    });
+
+  module TestSuiteFactory =
+    TestSuite.Factory({
+      module StackTrace = StackTrace;
+      module Mock = Mock;
+      module Snapshot = Snapshot;
+    });
+
+  let testSuites: ref(list(TestSuite.t)) = ref([]);
+  let makeDescribeFunction = extensionFn => {
+    let describe = (name, fn) =>
+      testSuites :=
+        testSuites^
+        @ [
+          TestSuiteFactory.makeTestSuite({
+            name,
+            usersDescribeFn: fn,
+            skip: false,
+            extensionFn,
+          }),
+        ];
+    describe;
+  };
+  let makeDescribeSkipFunction = extensionFn => {
+    let describeSkip = (name, fn) =>
+      testSuites :=
+        testSuites^
+        @ [
+          TestSuiteFactory.makeTestSuite({
+            name,
+            usersDescribeFn: fn,
+            skip: true,
+            extensionFn,
+          }),
+        ];
+    describeSkip;
+  };
+  let describe = makeDescribeFunction(_ => ());
+  let describeSkip = makeDescribeSkipFunction(_ => ());
+  let extendDescribe = createCustomMatchers => {
+    describe: makeDescribeFunction(createCustomMatchers),
+    describeSkip: makeDescribeSkipFunction(createCustomMatchers),
+  };
+
+  let run = (config: RunConfig.t) =>
+    TestSuiteRunner.run(config, testSuites^);
+
+  let cli = () => TestSuiteRunner.cli(testSuites^);
+
+  let toLibrary = () => testSuites^;
+};
+
+module Make = MakeInternal(FileSystemSnapshotIO);

--- a/tests/__tests__/rely/Snapshot_test.re
+++ b/tests/__tests__/rely/Snapshot_test.re
@@ -4,8 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
-open TestFramework;
 open RelyInternal.TestResult.AggregatedResult;
+open TestFramework;
 module StringMap = Map.Make(String);
 
 module MakeInMemorySnapshotIO =
@@ -95,7 +95,6 @@ describe("Rely Snapshot", ({test}) => {
       Snapshot.getSnapshotStatus(),
     );
   });
-
   test(
     "updating an existing snapshot should be reflected in status", ({expect}) => {
     let testPath = (
@@ -121,5 +120,283 @@ describe("Rely Snapshot", ({test}) => {
       },
       Snapshot.getSnapshotStatus(),
     );
+  });
+  test(
+    "Running without update snapshot flag shouldn't create snapshots",
+    ({expect}) => {
+    let readMock = Mock.mock1(s => s);
+    let removeMock = Mock.mock1(_ => ());
+    let writeMock = Mock.mock2((_, _) => ());
+    let existsMock = Mock.mock1(_ => false);
+    let mkdirpMock = Mock.mock1(_ => ());
+
+    module MockSnapshotIO = {
+      let readSnapshotNames = _ => [];
+      let readFile: string => string = Mock.fn(readMock);
+      let removeFile: string => unit = Mock.fn(removeMock);
+      let writeFile: (string, string) => unit = Mock.fn(writeMock);
+      let existsFile: string => bool = Mock.fn(existsMock);
+      let mkdirp = Mock.fn(mkdirpMock);
+    };
+
+    module TestFramework =
+      RelyInternal.TestFramework.MakeInternal(
+        MockSnapshotIO,
+        {
+          let config =
+            RelyInternal.TestFrameworkConfig.TestFrameworkConfig.initialize({
+              snapshotDir: "",
+              projectDir: "",
+            });
+        },
+      );
+
+    let aggregateResult = ref(None);
+
+    module Reporter =
+      TestReporter.Make({});
+
+    Reporter.onRunComplete(res => aggregateResult := Some(res));
+
+    TestFramework.describe("single failing snapshot", ({test}) =>
+      test("a test", ({expect}) =>
+        expect.string("bacon").toMatchSnapshot()
+      )
+    );
+
+    TestFramework.run(
+      RelyInternal.RunConfig.RunConfig.(
+        initialize()
+        |> withReporters([Custom(Reporter.reporter)])
+        |> updateSnapshots(false)
+        |> onTestFrameworkFailure(() => ())
+      ),
+    );
+
+    let res =
+      switch (aggregateResult^) {
+      | None => raise(Invalid_argument("aggregateResult"))
+      | Some(v) => v
+      };
+    let snapshotSummary =
+      switch (res.snapshotSummary) {
+      | None => raise(Invalid_argument("aggregateResult"))
+      | Some(v) => v
+      };
+    expect.mock(writeMock).not.toBeCalled();
+    expect.int(res.numFailedTests).toBe(1);
+    expect.int(snapshotSummary.numCreatedSnapshots).toBe(0);
+    ();
+  });
+  test(
+    "Running with update snapshot flag should create snapshots", ({expect}) => {
+    let readMock = Mock.mock1(s => s);
+    let removeMock = Mock.mock1(_ => ());
+    let writeMock = Mock.mock2((_, _) => ());
+    let existsMock = Mock.mock1(_ => false);
+    let mkdirpMock = Mock.mock1(_ => ());
+
+    module MockSnapshotIO = {
+      let readSnapshotNames = _ => [];
+      let readFile: string => string = Mock.fn(readMock);
+      let removeFile: string => unit = Mock.fn(removeMock);
+      let writeFile: (string, string) => unit = Mock.fn(writeMock);
+      let existsFile: string => bool = Mock.fn(existsMock);
+      let mkdirp = Mock.fn(mkdirpMock);
+    };
+
+    module TestFramework =
+      RelyInternal.TestFramework.MakeInternal(
+        MockSnapshotIO,
+        {
+          let config =
+            RelyInternal.TestFrameworkConfig.TestFrameworkConfig.initialize({
+              snapshotDir: "",
+              projectDir: "",
+            });
+        },
+      );
+
+    let aggregateResult = ref(None);
+
+    module Reporter =
+      TestReporter.Make({});
+
+    Reporter.onRunComplete(res => aggregateResult := Some(res));
+
+    TestFramework.describe("single failing snapshot", ({test}) =>
+      test("a test", ({expect}) =>
+        expect.string("bacon").toMatchSnapshot()
+      )
+    );
+
+    TestFramework.run(
+      RelyInternal.RunConfig.RunConfig.(
+        initialize()
+        |> withReporters([Custom(Reporter.reporter)])
+        |> updateSnapshots(true)
+        |> onTestFrameworkFailure(() => ())
+      ),
+    );
+
+    let res =
+      switch (aggregateResult^) {
+      | None => raise(Invalid_argument("aggregateResult"))
+      | Some(v) => v
+      };
+    let snapshotSummary =
+      switch (res.snapshotSummary) {
+      | None => raise(Invalid_argument("aggregateResult"))
+      | Some(v) => v
+      };
+
+    expect.mock(writeMock).toBeCalled();
+    expect.int(res.numFailedTests).toBe(0);
+    expect.int(snapshotSummary.numCreatedSnapshots).toBe(1);
+    ();
+  });
+  test("unused snapshots should be deleted", ({expect}) => {
+    let readMock = Mock.mock1(s => s);
+    let removeMock = Mock.mock1(_ => ());
+    let writeMock = Mock.mock2((_, _) => ());
+    let existsMock = Mock.mock1(_ => true);
+    let mkdirpMock = Mock.mock1(_ => ());
+
+    module MockSnapshotIO = {
+      let readSnapshotNames = _ => [
+        "Foo.234.0.snapshot",
+        "Bar.234.0.snapshot",
+        "Baz.234.0.snapshot",
+      ];
+      let readFile: string => string = Mock.fn(readMock);
+      let removeFile: string => unit = Mock.fn(removeMock);
+      let writeFile: (string, string) => unit = Mock.fn(writeMock);
+      let existsFile: string => bool = Mock.fn(existsMock);
+      let mkdirp = Mock.fn(mkdirpMock);
+    };
+
+    module TestFramework =
+      RelyInternal.TestFramework.MakeInternal(
+        MockSnapshotIO,
+        {
+          let config =
+            RelyInternal.TestFrameworkConfig.TestFrameworkConfig.initialize({
+              snapshotDir: "",
+              projectDir: "",
+            });
+        },
+      );
+
+    let aggregateResult = ref(None);
+
+    module Reporter =
+      TestReporter.Make({});
+
+    Reporter.onRunComplete(res => aggregateResult := Some(res));
+
+    /* need at least one tests for this to work... seems like probably a reasonable requirement? */
+    TestFramework.describe("single failing test", ({test}) =>
+      test("a test", ({expect}) =>
+        expect.bool(false).toBeTrue()
+      )
+    );
+
+    TestFramework.run(
+      RelyInternal.RunConfig.RunConfig.(
+        initialize()
+        |> withReporters([Custom(Reporter.reporter)])
+        |> onTestFrameworkFailure(() => ())
+      ),
+    );
+
+    let res =
+      switch (aggregateResult^) {
+      | None => raise(Invalid_argument("aggregateResult"))
+      | Some(v) => v
+      };
+    let snapshotSummary =
+      switch (res.snapshotSummary) {
+      | None => raise(Invalid_argument("aggregateResult"))
+      | Some(v) => v
+      };
+
+    expect.mock(removeMock).toBeCalledTimes(3);
+    expect.int(snapshotSummary.numRemovedSnapshots).toBe(3);
+    ();
+  });
+  test("snapshots for a failing test should not be deleted", ({expect}) => {
+    let readMock = Mock.mock1(s => s);
+    let removeMock = Mock.mock1(_ => ());
+    let writeMock = Mock.mock2((_, _) => ());
+    let existsMock = Mock.mock1(_ => true);
+    let mkdirpMock = Mock.mock1(_ => ());
+
+    let testPath = (
+      "my test",
+      RelyInternal.TestPath.Terminal("my describe"),
+    );
+    let testHash = RelyInternal.TestPath.(hash(Test(testPath), 0));
+
+    module MockSnapshotIO = {
+      let readSnapshotNames = _ => [
+        "my_describe." ++ testHash ++ ".0.snapshot",
+        "my_describe." ++ testHash ++ ".1.snapshot",
+        "my_describe." ++ testHash ++ ".2.snapshot",
+        "unrelatedDescribe.fakeTestHash.0.snapshot",
+      ];
+      let readFile: string => string = Mock.fn(readMock);
+      let removeFile: string => unit = Mock.fn(removeMock);
+      let writeFile: (string, string) => unit = Mock.fn(writeMock);
+      let existsFile: string => bool = Mock.fn(existsMock);
+      let mkdirp = Mock.fn(mkdirpMock);
+    };
+
+    module TestFramework =
+      RelyInternal.TestFramework.MakeInternal(
+        MockSnapshotIO,
+        {
+          let config =
+            RelyInternal.TestFrameworkConfig.TestFrameworkConfig.initialize({
+              snapshotDir: "",
+              projectDir: "",
+            });
+        },
+      );
+
+    let aggregateResult = ref(None);
+
+    module Reporter =
+      TestReporter.Make({});
+
+    Reporter.onRunComplete(res => aggregateResult := Some(res));
+
+    TestFramework.describe("my describe", ({test}) =>
+      test("my test", ({expect}) =>
+        expect.bool(false).toBeTrue()
+      )
+    );
+
+    TestFramework.run(
+      RelyInternal.RunConfig.RunConfig.(
+        initialize()
+        |> withReporters([Custom(Reporter.reporter)])
+        |> onTestFrameworkFailure(() => ())
+      ),
+    );
+
+    let res =
+      switch (aggregateResult^) {
+      | None => raise(Invalid_argument("aggregateResult"))
+      | Some(v) => v
+      };
+    let snapshotSummary =
+      switch (res.snapshotSummary) {
+      | None => raise(Invalid_argument("aggregateResult"))
+      | Some(v) => v
+      };
+
+    expect.mock(removeMock).toBeCalledTimes(1);
+    expect.int(snapshotSummary.numRemovedSnapshots).toBe(1);
+    ();
   });
 });


### PR DESCRIPTION
Ended up taking the simplest approach to the code organization that allowed me to inject in memory snapshot IO, I think there are other reasonable options that may be better. I'm not in love with the repetition in the tests, would welcome suggestions there as well. 

I think these tests are important because all of these behaviors have at some point been broken, and I pretty continuously found snaphsot bugs with the latest refactor (though ironically not when writing theses tests in particular).