### PR TITLE
update formatting of exception messages to properly indent long messages

### DIFF
--- a/src/rely/reporters/TerminalReporter.re
+++ b/src/rely/reporters/TerminalReporter.re
@@ -28,7 +28,8 @@ let stackIndent = "      ";
 let titleIndent = "  ";
 let passDisplay = () =>
   <Pastel color=Green inverse=true bold=true> " PASS " </Pastel>;
-let failDisplay = () => <Pastel color=Red inverse=true bold=true> " FAIL " </Pastel>;
+let failDisplay = () =>
+  <Pastel color=Red inverse=true bold=true> " FAIL " </Pastel>;
 let runningDisplay = () =>
   <Pastel color=Yellow inverse=true bold=true> " RUNS " </Pastel>;
 
@@ -97,12 +98,9 @@ let gatherFormattedFailureOutput = (testResults: list(testResult)) =>
                failFormatter(titleIndent ++ titleBullet ++ fullName),
              );
            let exceptionMessage =
-             String.concat(
-               "",
-               [
-                 indent("Exception ", ~indent=messageIndent),
-                 Pastel.dim(Printexc.to_string(e)),
-               ],
+             indent(
+               "Exception " ++ Pastel.dim(Printexc.to_string(e)),
+               ~indent=messageIndent,
              );
            let parts =
              switch (getStackInfo(loc, stack)) {


### PR DESCRIPTION
Cropped up while writing rely-qcheck: Long/multiline exception messages were formatted like
![image](https://user-images.githubusercontent.com/5252755/56158753-cc9b7d80-5f77-11e9-86e6-ae889b30a2ab.png)
After this they are formatted like
![image](https://user-images.githubusercontent.com/5252755/56158771-d624e580-5f77-11e9-9d21-93084e5ac142.png)

Tested manually, the exception matcher test cases are currently commented disabled because of https://github.com/facebookexperimental/reason-native/issues/62, so I didn't add new ones there (and would really just be another snapshot, which doesn't add a ton).