### PR TITLE
Useful Path operations for filesytem.

### DIFF
--- a/ORIGINS.md
+++ b/ORIGINS.md
@@ -1,0 +1,9 @@
+
+
+Thanks to the following libraries for being useful as references/guides for how
+to handle various system/terminal integration.
+
+- [bos](https://github.com/dbuenzli/bos) For demonstrating how to correctly and
+  robustly handle `Unix` exceptions. It is a great reference for which `Unix`
+  exceptions are raised for which operations, and demonstrates the robust
+  pattern of reattempts on interupt exceptions.

--- a/esy.json
+++ b/esy.json
@@ -8,6 +8,9 @@
     "install": [
       "esy-installer pastel.install",
       "esy-installer rely.install",
+      "esy-installer path.install",
+      "esy-installer fs.install",
+      "esy-installer rely-test.install",
       "esy-installer console.install",
       "esy-installer pastel-console.install",
       "esy-installer file-context-printer.install",

--- a/fs.json
+++ b/fs.json
@@ -1,0 +1,37 @@
+{
+  "name": "@reason-native/fs",
+  "version": "0.0.1",
+  "description": "Reason Native file system API",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebookexperimental/reason-native/tree/master/src/fs"
+  },
+  "license": "MIT",
+  "keywords": [
+    "file-system",
+    "fs",
+    "filesystem",
+    "directories",
+    "reasonml",
+    "reason",
+    "ocaml",
+    "esy"
+  ],
+  "esy": {
+    "build": "dune build -p fs"
+  },
+  "scripts": {
+    "release": "node ./scripts/esy-prepublish.js fs.json"
+  },
+  "dependencies": {
+    "@reason-native/path": ">= 0.0.0 <= 1.0.0",
+    "@opam/dune": "*",
+    "@esy-ocaml/reason": "*",
+    "ocaml": "^4.2.0"
+  },
+  "devDependencies": {
+    "@opam/merlin": "*",
+    "ocaml": "~4.6.0",
+    "@reason-native/rely": "*"
+  }
+}

--- a/src/fs/Fs.re
+++ b/src/fs/Fs.re
@@ -1,0 +1,13 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ */;
+
+/*
+Fs: Reason native filesystem utilities.
+*/
+include Types;
+include Traverse;
+include ReadWriteContents;
+include Operations;
+include Query;
+include Perm;

--- a/src/fs/Fs.rei
+++ b/src/fs/Fs.rei
@@ -1,0 +1,338 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ */;
+
+/**
+FileSystem: Basic file system operations using Path.t as inputs. TODO:
+Migrate most of this to the Unix module instead of Pervasives so that
+handling of interupt signals is more robust.
+*/
+
+type fileStat = Unix.stats;
+
+type queryResultOther =
+  | /** Character device */
+    CharacterDevice
+  | /** Block device */
+    BlockDevice
+  | /** Named pipe */
+    NamedPipe
+  | /** Socket */
+    Socket;
+
+type queryResult =
+  | /** Regular file */
+    File(Path.t(Path.absolute), fileStat)
+  | /** Directory */
+    Dir(Path.t(Path.absolute), fileStat)
+  | /** Symbolic link */
+    Link(
+      Path.t(Path.absolute),
+      Path.firstClass,
+      fileStat,
+    )
+  | /** Other Operating System devices */
+    Other(
+      Path.t(Path.absolute),
+      fileStat,
+      queryResultOther,
+    );
+
+let traverseFileSystemFromPath:
+  (~onNode: (queryResult, unit => unit) => unit, Path.t(Path.absolute)) =>
+  unit;
+
+let query: Path.t(Path.absolute) => option(queryResult);
+
+let queryExn: Path.t(Path.absolute) => queryResult;
+
+/**
+Types of line endings for human viewable/editable files. Windows has a
+different representation of line endings.
+*/
+type lineEnds =
+  | PlatformDefault
+  | Windows
+  | Unix;
+
+type actions =
+  | No
+  | Read
+  | ReadExecute
+  | ReadWrite
+  | ReadWriteExecute;
+
+type perm = {
+  owner: actions,
+  group: actions,
+  other: actions,
+};
+
+/**
+Default permissions - execute, read, read = 755.
+*/
+let defaultPerm: perm;
+
+/**
+Reads a human-readable text file at the absolute path. Newlines generated in
+the file by Windows will be normalized regardless of the current platform.
+Returns `Some(lines)` if the file exists and can be read, else returns
+`None`.
+*/
+let readText: Path.t(Path.absolute) => result(list(string), exn);
+/**
+Same as `readText` but raises exception if file cannot be found or is not
+readable.
+*/
+let readTextExn: Path.t(Path.absolute) => list(string);
+
+/**
+Writes text lines to a file intended for human consumption at `path`,
+creating it if it needs to be created, and clearing existing contents before
+writing. Newlines are inserted after each line, where the platform default
+newline is used by default, but can be overridden by specifying
+`~lineEnds`.
+TODO: Specify and implement behavior when file is an existing symlink
+(verify it does/does not traverse it).
+*/
+let writeText:
+  (~lineEnds: lineEnds=?, Path.t(Path.absolute), list(string)) =>
+  result(unit, exn);
+
+/**
+Like `writeText` but raises exception instead of returning `result`.
+*/
+let writeTextExn:
+  (~lineEnds: lineEnds=?, Path.t(Path.absolute), list(string)) => unit;
+
+/**
+Reads raw bytes from a file from disk. Newlines are not modified from their
+exact form on disk.
+*/
+/* let readBytes: file => option(bytes); */
+/* let readBytesExn: file => bytes; */
+/* let writeBytes: bytes => unit; */
+
+/**
+Forces removal of directory content recursively that does exists - like "rm
+-rf". Will not allow you to specify the root directory, and will raise if the
+supplied file node is not a directory. Returns Error if any removal in the tree
+fails.
+Unlike `rm -r`, it will not remove a symlink at the supplied `path`, it will
+return an `Error(exn)` if supplied `path` is a symlink.
+Returns `Error(exn)` if the directory does not exist.
+*/
+let rmDirExn: Path.t(Path.absolute) => unit;
+
+/**
+Same as `rmDirExn` but returns `result` type.
+*/
+let rmDir: Path.t(Path.absolute) => result(unit, exn);
+
+/**
+Same as `rmDirExn` but throws if directory not empty.  Note how there
+is not `rmEmptyDirIfExistsExn`. If you don't know if a directory
+exists, you probably don't know if it is empty.
+return an `Error(exn)` if supplied `path` is a symlink.
+Returns `Error(exn)` if the directory does not exist.
+Returns `Error(exn)` if the directory is not empty.
+*/
+let rmEmptyDirExn: Path.t(Path.absolute) => unit;
+
+/**
+Same as `rmEmptyDirExn` but returns `Error(exn)` if directory not
+empty.
+*/
+let rmEmptyDir: Path.t(Path.absolute) => result(unit, exn);
+
+/**
+ * TODO: Every file operation should have a binary file mode too.
+ */;
+
+/**
+Delete the file at the path. Returns `Ok()` if file was able to be deleted.
+Throws exception if the path points to a directory. Will remove a symlink.
+*/
+let rm: Path.t(Path.absolute) => result(unit, exn);
+
+/**
+Same as `rm` but raises if the file doesn't exist.
+*/
+let rmExn: Path.t(Path.absolute) => unit;
+
+/**
+Ensures a file is deleted if it exists. Returns `Ok()` if file was able to be
+deleted, or if it already did not exist at the supplied path. Throws exception
+if the path points to a directory. Will remove a symlink.
+*/
+let rmIfExists: Path.t(Path.absolute) => result(unit, exn);
+
+/**
+Same as `rmIfExists` but raises instead of returning `Error`.
+*/
+let rmIfExistsExn: Path.t(Path.absolute) => unit;
+
+/**
+Makes a directory at the path and returns Ok(). Returns Error(_) if a directory
+cannot be made at the location for any reason including if a directory already
+exists at the `path`, or if the path is occupied by a symlink. `~perm` should
+be supplied in the form `{owner: action, group: action, other: action}` where
+`action` is `FileSystem.perm = No|Read|ReadExecute|ReadWrite|ReadWriteExecute`.
+*/
+let mkDir: (~perm: perm=?, Path.t(Path.absolute)) => result(unit, exn);
+
+/**
+Same as `mkDir`, but throws instead of returning `Error`. `~perm` should be
+supplied in the form `{owner: action, group: action, other: action}` where
+`action` is `FileSystem.perm = No|Read|ReadExecute|ReadWrite|ReadWriteExecute`.
+*/
+let mkDirExn: (~perm: perm=?, Path.t(Path.absolute)) => unit;
+
+/**
+Similar to `mkdirp` unix command. Makes all required directories.  Each path
+prefix from the supplied path to the root directory must be either
+- Non-existent
+- Already a directory
+- A symlink that transitively points to an existing directory
+
+Otherwise, will return Error()
+
+`~perm` should be of form `{owner:action, group:action, other:action}` where
+`action` is `FileSystem.perm = No|Read|ReadExecute|ReadWrite|ReadWriteExecute`.
+*/
+let mkDirP: (~perm: perm=?, Path.t(Path.absolute)) => result(unit, exn);
+
+/**
+The same as `mkDirP` but throws exception instead of returning `Error`.
+
+`~perm` should be of form `{owner:action, group:action, other:action}` where
+`action` is `FileSystem.perm = No|Read|ReadExecute|ReadWrite|ReadWriteExecute`.
+*/
+let mkDirPExn: (~perm: perm=?, Path.t(Path.absolute)) => unit;
+
+/**
+Creates symlink from `~from` to `~toTarget` which must be a file. Will unlink
+existing symlink at `~from` if necessary, but won't remove files/directories
+and returns `Error(e)` in that case.
+*/
+let link:
+  (~from: Path.t(Path.absolute), ~toTarget: Path.t('any)) =>
+  result(unit, exn);
+
+/**
+Same as `link` but throws exception instead of returning `Error`.
+*/
+let linkExn: (~from: Path.t(Path.absolute), ~toTarget: Path.t('any)) => unit;
+
+/**
+Creates symlink from `~from` to `~toTarget` which must be a directory. Will
+unlink existing symlink at `~from` if necessary, but won't remove
+files/directories and returns `Error()` in that case.
+*/
+let linkDir:
+  (~from: Path.t(Path.absolute), ~toTarget: Path.t('any)) =>
+  result(unit, exn);
+
+/**
+Same as `linkDir` but throws exception instead of returning `Error`.
+*/
+let linkDirExn:
+  (~from: Path.t(Path.absolute), ~toTarget: Path.t('any)) => unit;
+
+/**
+Reads a symlink, and returns `Error` if no symlink exists at the path.
+*/
+let readLink: Path.t(Path.absolute) => result(Path.firstClass, exn);
+
+/**
+Same as `readLink` but raises exception instead of returning `Error`.
+*/
+let readLinkExn: Path.t(Path.absolute) => Path.firstClass;
+
+/**
+Reads a symlink "transitively" by following links until it reaches a non link.
+Returns the absolute path of the final target, along with the final resource at
+that final absolute path(`None` means the final symlink pointed to nothing).
+
+Returns `Error` if supplied path is not a symlink or doesn't exist on disk.
+
+Not exposing this in the interface. Use `resolve`/`followList` instead.
+
+let followLink:
+  Path.t(Path.absolute) => result(Path.t(Path.absolute), exn);
+*/
+
+/**
+Same as `readLink` but raises exception instead of returning `Error`. Not
+exposing this in the interface. Use `resolve`/`followList` instead.
+
+let followLinkExn: Path.t(Path.absolute) => Path.t(Path.absolute);
+*/
+
+/**
+Same as `followLink` but accepts any valid paths and follows the path if it
+happens to be a symlink. Returns Error if the path supplied does not exist on
+disk.
+
+The path returned is not necessarily the "realpath" of the final destination
+because the computed path may be inside of a directory that is a symlink.  A
+separate call to `realPath` would be required to determine the `realPath`.
+
+It is not guaranteed that the returned paths are realPaths or not - only that
+their symlinks have been totally resolved/followed. In non-breaking versions,
+the paths may be returned after being processed by `realPath`.
+
+*/
+let resolveLink:
+  Path.t(Path.absolute) => result(Path.t(Path.absolute), exn);
+
+/**
+Same as `resolveLink` but raises exception instead of returning `Error`.
+*/
+let resolveLinkExn: Path.t(Path.absolute) => Path.t(Path.absolute);
+
+/**
+Same as `resolveLink` but returns the path of file/symlink traversal. It does
+ *not* include the initial path in that list. This is so that you may pattern
+ match on the returned list without the `[]` being meaningless. In this way,
+ `links` can tell you everything you need to know about a path's
+ linkiness.
+
+The paths returned is not necessarily the "realpath" of the final destination
+because the computed path may be inside of a directory that is a symlink. A
+separate call to `realPath` would be required to determine the `realPath`.
+
+It is not guaranteed that the returned paths are realPaths or not - only that
+their symlinks have been totally resolved/followed. In non-breaking versions,
+the paths may be returned after being processed by `realPath`.
+
+    switch(links(myPath)) {
+    | Ok([]) => "not a symlink"
+    | Ok([hd, ...tl] as lst) => String.concat("->", lst)
+    | Error(_) => "path doesn't even exist on file system"
+    }
+
+If you only care about the final destination, use `links` instead
+because `links` returns a list with the `hd` being the first link, and the last
+item in the list being the final destination.
+
+*/
+let links:
+  Path.t(Path.absolute) => result(list(Path.t(Path.absolute)), exn);
+
+/**
+Same as `links` but raises exception instead of returning `Error`.
+*/
+let linksExn: Path.t(Path.absolute) => list(Path.t(Path.absolute));
+
+/**
+Returns the set of paths inside a directory (excluding .. and .) Returns
+`Error` if the directory does not exist or the path is not a directory.
+*/
+let readDir:
+  Path.t(Path.absolute) => result(list(Path.t(Path.absolute)), exn);
+
+/**
+Same as `readDir` but raises exception instead of returning `Error`.
+*/
+let readDirExn: Path.t(Path.absolute) => list(Path.t(Path.absolute));

--- a/src/fs/Operations.re
+++ b/src/fs/Operations.re
@@ -1,0 +1,269 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ */;
+
+open Types;
+
+let rec readLink = path => {
+  let stringPath = Path.toString(path);
+  try (Ok(Path.testForPathExn(Unix.readlink(stringPath)))) {
+  /* Invalid argument - not a symlink */
+  | Unix.Unix_error(Unix.EINVAL, _, _) =>
+    Error(Invalid_argument("Path is not a symlink " ++ stringPath))
+  | Unix.Unix_error(Unix.EINTR, _, _) => readLink(path)
+  | Unix.Unix_error(e, _, _) as err => Error(err)
+  };
+};
+
+let rec readLinkExn = path => Util.throwErrorResult(readLink(path));
+
+let rec foldKnownLink = (path, acc, f) => {
+  let next = f(path, acc);
+  switch (Query.query(path)) {
+  | Some(Other(_))
+  | Some(File(_))
+  | Some(Dir(_))
+  /* If we've reached a null pointer, we return the address */
+  | None => next
+  | Some(Link(from, toTarget, _)) =>
+    foldKnownLink(Util.resolvePath(from, toTarget), next, f)
+  };
+};
+
+/*
+ * Utility, follows a *known* symlink.
+ */
+let followKnownLink = p => foldKnownLink(p, p, (nextPath, _) => nextPath);
+
+let notALink = p => "followLink: Not a symlink " ++ Path.toString(p);
+let pathNotExist = p => "followLink: path doesn't exist" ++ Path.toString(p);
+let rec followLink = path =>
+  switch (Query.query(path)) {
+  | Some(Other(_))
+  | Some(File(_))
+  | Some(Dir(_)) => Error(Invalid_argument(notALink(path)))
+  | None => Error(Invalid_argument(pathNotExist(path)))
+  | Some(Link(from, toTarget, _)) =>
+    Ok(followKnownLink(Util.resolvePath(from, toTarget)))
+  };
+
+let rec followLinkExn = path => Util.throwErrorResult(followLink(path));
+
+let rec resolveLink = path =>
+  switch (Query.query(path)) {
+  | Some(Other(_))
+  | Some(File(_))
+  | Some(Dir(_)) => Ok(path)
+  | None => Error(Invalid_argument(pathNotExist(path)))
+  | Some(Link(from, toTarget, _)) =>
+    Ok(followKnownLink(Util.resolvePath(from, toTarget)))
+  };
+
+let rec resolveLinkExn = path => Util.throwErrorResult(resolveLink(path));
+
+let rec links = path =>
+  switch (Query.query(path)) {
+  | Some(Other(_))
+  | Some(File(_))
+  | Some(Dir(_)) => Ok([])
+  | None => Error(Invalid_argument(pathNotExist(path)))
+  | Some(Link(from, toTarget, _)) =>
+    let startPath = Util.resolvePath(from, toTarget);
+    Ok(List.rev(foldKnownLink(startPath, [], List.cons)));
+  };
+
+let rec linksExn = path => Util.throwErrorResult(links(path));
+
+let rec rm = path =>
+  try (Ok(Unix.unlink(Path.toString(path)))) {
+  | Unix.Unix_error(Unix.EINTR, _, _) => rm(path)
+  /* Will raise Unix.Unix_error(Unix.ENOENT, _, _) if not exists */
+  | Unix.Unix_error(_) as e => Error(e)
+  };
+
+let rec rmExn = path =>
+  try (Unix.unlink(Path.toString(path))) {
+  | Unix.Unix_error(Unix.EINTR, _, _) => rmExn(path)
+  /* Will raise Unix.Unix_error(Unix.ENOENT, _, _) if not exists */
+  | Unix.Unix_error(_) as e => Util.reraise(e)
+  };
+
+let rec rmEmptyDir = path =>
+  try (Ok(Unix.rmdir(Path.toString(path)))) {
+  | Unix.Unix_error(Unix.EINTR, _, _) => rmEmptyDir(path)
+  /* Will raise Unix.Unix_error(Unix.ENOENT, _, _) if not exists */
+  | Unix.Unix_error(_) as e => Error(e)
+  };
+
+let rec rmEmptyDirExn = path =>
+  try (Unix.rmdir(Path.toString(path))) {
+  | Unix.Unix_error(Unix.EINTR, _, _) => rmEmptyDirExn(path)
+  /* Will raise Unix.Unix_error(Unix.ENOENT, _, _) if not exists */
+  | Unix.Unix_error(_) as e => Util.reraise(e)
+  };
+
+let rec rmIfExists = path =>
+  try (Ok(Unix.unlink(Path.toString(path)))) {
+  | Unix.Unix_error(Unix.ENOENT, _, _) => Ok()
+  | Unix.Unix_error(Unix.EINTR, _, _) => rmIfExists(path)
+  | Unix.Unix_error(_) as e => Error(e)
+  };
+
+let rec rmIfExistsExn = path =>
+  try (Unix.unlink(Path.toString(path))) {
+  | Unix.Unix_error(Unix.ENOENT, _, _) => ()
+  | Unix.Unix_error(Unix.EINTR, _, _) => rmIfExistsExn(path)
+  | Unix.Unix_error(_) as e => Util.reraise(e)
+  };
+
+let rec mkDir = (~perm=Perm.defaultPerm, path) =>
+  try (Ok(Unix.mkdir(Path.toString(path), Perm.toInt(perm)))) {
+  | Unix.Unix_error(Unix.EEXIST, _, _) as e => Error(e)
+  | Unix.Unix_error(Unix.EINTR, _, _) => mkDir(~perm, path)
+  | Unix.Unix_error(_) as e => Error(e)
+  };
+
+let rec mkDirExn = (~perm=Perm.defaultPerm, path) =>
+  try (Unix.mkdir(Path.toString(path), Perm.toInt(perm))) {
+  | Unix.Unix_error(Unix.EEXIST, _, _) as e => Util.reraise(e)
+  | Unix.Unix_error(Unix.EINTR, _, _) => mkDirExn(~perm, path)
+  | Unix.Unix_error(_) as e => Util.reraise(e)
+  };
+
+let onForceRemoveDir = (queryResult, cont) =>
+  switch (queryResult) {
+  | Other(path, _, _) =>
+    rmExn(path);
+    cont();
+  | File(path, _) => rmExn(path)
+  | Dir(path, _) =>
+    cont();
+    /* Post order */
+    rmEmptyDirExn(path);
+  /* For symbolic links, we don't want to continue because either:
+   * 1. The link points to something inside the original removal root
+   * in which case, we'll find it through some other path.
+   * 2. The link points outside the original removal root and in that
+   * case we definitely don't want to remove what it points to.
+   */
+  | Link(path, _, _) => rmExn(path)
+  };
+
+let cannotRemovePathNoExist = p =>
+  "Cannot remove path that does not exist " ++ Path.toDebugString(p);
+let cannotRemovePathNotDir = p =>
+  "Path is not a directory not exist " ++ Path.toDebugString(p);
+let rmDir = path => {
+  assert(Path.hasParentDir(path));
+  switch (Query.query(path)) {
+  | None => Error(Invalid_argument(cannotRemovePathNoExist(path)))
+  | Some(Dir(p, info)) =>
+    Ok(
+      Traverse.traverseFileSystemFromQueryResult(
+        ~onNode=onForceRemoveDir,
+        Dir(p, info),
+      ),
+    )
+  | Some(_) => Error(Invalid_argument(cannotRemovePathNotDir(path)))
+  };
+};
+
+let rmDirExn = path => Util.throwErrorResult(rmDir(path));
+
+/*
+ * Make one directory for the sake of mkdir -p style behavior.
+ */
+let rec mkDirPOneExn = (~perm=Perm.defaultPerm, path) =>
+  try (Unix.mkdir(Path.toString(path), Perm.toInt(perm))) {
+  | Unix.Unix_error(Unix.EEXIST, _, _) as e =>
+    switch (Query.queryExn(path)) {
+    | Link(_)
+    | Other(_)
+    | File(_) => Util.reraise(e)
+    /* Maybe something else made it before we got the chance to? */
+    | Dir(_) => ()
+    }
+  | Unix.Unix_error(Unix.EINTR, _, _) => mkDirPOneExn(~perm, path)
+  | Unix.Unix_error(_) as e => Util.reraise(e)
+  };
+
+/*
+ * TODO: Detect when the mkdirp will fail (something along the path is a
+ * symlink etc).
+ */
+let noRoot = p =>
+  "mkDirP: Why does it appear you have no root directory? "
+  ++ Path.toString(p);
+let nonDir = p =>
+  "mkDirP: The path "
+  ++ Path.toString(p)
+  ++ " is a symlink that points to a non-directory";
+
+let rec pathsToMake = (acc, p) =>
+  switch (Query.query(p)) {
+  | Some(Dir(_)) => Ok(acc)
+  | Some(Link(from, toTarget, _)) =>
+    switch (Query.query(followKnownLink(Util.resolvePath(from, toTarget)))) {
+    /* Relaxes the error in this case - like mkdir -p does */
+    | Some(Dir(_, _)) => Ok(acc)
+    | None
+    | Some(File(_))
+    | Some(Other(_))
+    /* This case should never happen - we already followed */
+    | Some(Link(_)) => Error(Invalid_argument(nonDir(p)))
+    }
+  | None =>
+    if (Path.hasParentDir(p)) {
+      pathsToMake([p, ...acc], Path.dirName(p));
+    } else {
+      Error(Sys_error(noRoot(p)));
+    }
+  | Some(File(_))
+  | Some(Other(_)) =>
+    Error(Invalid_argument("Cannot mkdir at file " ++ Path.toString(p)))
+  };
+
+let mkDirP = (~perm=Perm.defaultPerm, path) => {
+  switch (pathsToMake([], path)) {
+  | Ok(paths) => Ok(List.iter(mkDirPOneExn(~perm), paths))
+  | Error(exn) as e => e
+  };
+};
+
+let mkDirPExn = (~perm=Perm.defaultPerm, path) =>
+  Util.throwErrorResult(mkDirP(~perm, path));
+
+let rec linkImpl = (~isDir, ~from, ~toTarget) =>
+  try (
+    Ok(
+      Unix.symlink(
+        ~to_dir=isDir,
+        Path.toDebugString(toTarget),
+        Path.toString(from),
+      ),
+    )
+  ) {
+  | Unix.Unix_error(Unix.EEXIST, _, _) as e =>
+    switch (Query.queryExn(from)) {
+    | Link(_) =>
+      rmExn(from);
+      linkImpl(~isDir, ~from, ~toTarget);
+    | Dir(_)
+    | Other(_)
+    | File(_) => Error(e)
+    }
+  | Unix.Unix_error(Unix.EINTR, _, _) => linkImpl(~isDir, ~from, ~toTarget)
+  | Unix.Unix_error(_) as e => Error(e)
+  };
+
+let rec link = (~from, ~toTarget) =>
+  linkImpl(~isDir=false, ~from, ~toTarget);
+
+let rec linkExn = (~from, ~toTarget) =>
+  Util.throwErrorResult(link(~from, ~toTarget));
+
+let rec linkDir = (~from, ~toTarget) =>
+  linkImpl(~isDir=true, ~from, ~toTarget);
+
+let rec linkDirExn = (~from, ~toTarget) =>
+  Util.throwErrorResult(linkDir(~from, ~toTarget));

--- a/src/fs/Perm.re
+++ b/src/fs/Perm.re
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ */;
+
+/**
+Number	Octal Permission Representation	Ref
+4	Read permission	          r-- :
+5	Read + execute permission r-x : 4 (read) + 1 (execute)
+6	Read + write permission   rw- : 4 (read) + 2 (write)
+7	All permissions           rwx : 4 (read) + 2 (write) + 1 (execute)
+*/;
+
+open Types;
+
+let actionToInt = a =>
+  switch (a) {
+  | No => 0
+  | Read => 4
+  | ReadExecute => 5
+  | ReadWrite => 6
+  | ReadWriteExecute => 7
+  };
+
+let toInt = ({owner, group, other}) => {
+  actionToInt(other) + 8 * actionToInt(group) + 64 * actionToInt(owner);
+};
+
+let defaultPerm = {
+  owner: ReadWriteExecute,
+  group: ReadExecute,
+  other: ReadExecute,
+};

--- a/src/fs/Query.re
+++ b/src/fs/Query.re
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+
+open Types;
+
+/**
+ * Redundantly coppied from Operations (avoids circular dep) (but avoids
+ * overhead of path conversion - uses string).
+ */
+let rec readLink__ = str =>
+  try (Path.testForPathExn(Unix.readlink(str))) {
+  /* Invalid argument - not a symlink */
+  | Unix.Unix_error(Unix.EINVAL, _, _) =>
+    raise(Invalid_argument("Path is not a symlink " ++ str))
+  | Unix.Unix_error(Unix.EINTR, _, _) => readLink__(str)
+  };
+
+/*
+ * Really, an error is the exceptional case here. Some/None indicates if the
+ * object exists.
+ * Does not follow links because that takes too much control out of our hands
+ * to handle that in various circumstances.
+ */
+let rec stat = path =>
+  try (Some(Unix.lstat(Path.toString(path)))) {
+  | Unix.Unix_error(Unix.ENOENT, _, _) => None
+  | Unix.Unix_error(Unix.EINTR, _, _) => stat(path)
+  | Unix.Unix_error(_) as e => Util.reraise(e)
+  };
+
+let rec statExn = path => {
+  let res = stat(path);
+  switch (res) {
+  | Some(info) => info
+  | None =>
+    raise(
+      Invalid_argument(
+        "Path passed to statExn that does not exist " ++ Path.toString(path),
+      ),
+    )
+  };
+};
+
+let makeResult = (path, fileStat: Unix.stats) =>
+  switch (fileStat.st_kind) {
+  | Unix.S_REG => File(path, fileStat)
+  | Unix.S_DIR => Dir(path, fileStat)
+  | Unix.S_LNK => Link(path, readLink__(Path.toString(path)), fileStat)
+  | Unix.S_CHR => Other(path, fileStat, CharacterDevice)
+  | Unix.S_BLK => Other(path, fileStat, BlockDevice)
+  | Unix.S_FIFO => Other(path, fileStat, NamedPipe)
+  | Unix.S_SOCK => Other(path, fileStat, Socket)
+  };
+
+let query = p =>
+  switch (stat(p)) {
+  | None => None
+  | Some(info) => Some(makeResult(p, info))
+  };
+let queryExn = p => makeResult(p, statExn(p));
+
+let readDirByHandle = handle =>
+  try (Some(Unix.readdir(handle))) {
+  | End_of_file => None
+  };
+
+let rec readDir = path => {
+  let impl = () => {
+    let dirHandle = Unix.opendir(Path.toString(path));
+    /* Making this tail recursive so that if an exception is raised, it's
+     * readable. */
+    let rec scan = (acc, dirHandle) => {
+      let fileName = readDirByHandle(dirHandle);
+      switch (fileName) {
+      | None => acc
+      | Some("..")
+      | Some(".") => scan(acc, dirHandle)
+      | Some(fileName) =>
+        let filePath = Path.append(path, fileName);
+        scan([filePath, ...acc], dirHandle);
+      };
+    };
+    Util.withDirHandle(dirHandle, scan([]));
+  };
+  try (Ok(impl())) {
+  | Unix.Unix_error(Unix.ENOENT, _, _) =>
+    Error(
+      Invalid_argument("Dir " ++ Path.toString(path) ++ " does not exist"),
+    )
+  | Unix.Unix_error(Unix.EINTR, _, _) => readDir(path)
+  | Unix.Unix_error(_, _, _) as e => Error(e)
+  };
+};
+
+let readDirExn = path => Util.throwErrorResult(readDir(path));

--- a/src/fs/ReadWriteContents.re
+++ b/src/fs/ReadWriteContents.re
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+
+open Types;
+
+/*
+ * TODO: test normalization of CRLF even on linux.
+ * Comment about exception catching in core libraries.
+ * https://discuss.ocaml.org/t/how-to-create-a-temporary-directory-in-ocaml/1815/3
+ */
+let readText = path => {
+  let stringPath = Path.toString(path);
+  let impl = inChan => {
+    let lines = {contents: []};
+    let continue = {contents: true};
+    /* TODO: Better Unix usage and robust error handling */
+    while (continue.contents) {
+      try (
+        {
+          let line = input_line(inChan);
+          let len = String.length(line);
+          /* Opened the channel in binary mode so we could manually do
+           * the same line normalization in linux/osx. */
+          let line =
+            if (len > 0 && line.[len - 1] === '\r') {
+              String.sub(line, 0, len - 1);
+            } else {
+              line;
+            };
+          lines.contents = [line, ...lines.contents];
+        }
+      ) {
+      | End_of_file => continue.contents = false
+      };
+    };
+    close_in(inChan);
+    Ok(List.rev(lines.contents));
+  };
+  try (
+    {
+      let inChan = open_in_bin(stringPath);
+      Util.withInChannel(inChan, impl);
+    }
+  ) {
+  | Sys_error(msg) as e => Error(e)
+  };
+};
+let readTextExn = path => Util.throwErrorResult(readText(path));
+
+let writeText = (~lineEnds=PlatformDefault, path, lines) => {
+  let stringPath = Path.toString(path);
+  let impl = outChan => {
+    List.iter(
+      line => {
+        output_string(outChan, line);
+        switch (lineEnds, Sys.win32) {
+        | (PlatformDefault, true)
+        | (Windows, _) => output_string(outChan, "\r\n")
+        | (PlatformDefault, false) => output_string(outChan, "\n")
+        | (Unix, _) => output_string(outChan, "\n")
+        };
+      },
+      lines,
+    );
+    Ok();
+  };
+  try (
+    {
+      let outChan = open_out_bin(stringPath);
+      Util.withOutChannel(outChan, impl);
+    }
+  ) {
+  /* Containing directory likely doesn't exist */
+  | Sys_error(_) as e => Error(e)
+  };
+};
+
+let writeTextExn = (~lineEnds=?, path, lines) =>
+  Util.throwErrorResult(writeText(~lineEnds?, path, lines));

--- a/src/fs/Traverse.re
+++ b/src/fs/Traverse.re
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ */;
+open Types;
+
+/*
+ * Generalizes walking the file system, and allowing the callback `~onNode` to
+ * perform an operation at each query result, and continuing if desired.
+ * This allows preorder operations or postorder operations by supplying
+ * `~onNode` callbacks of the following forms:
+ *
+ * let onNode = (queryResult, cont) => {
+ *   callMyPreorderOperation();
+ *   cont();
+ * };
+ *
+ * let onNode = (queryResult, cont) => {
+ *   cont();
+ *   callMyPostorderOperation();
+ * };
+ *
+ * TODO: Minimize number of file descriptors (reuse some?)
+ * TODO: Statically ensure that only directories, and not symlinks are supplied.
+ * TODO: Don't traverse symlinks by default.
+ */
+let rec traverseFileSystemFromQueryResult = (~onNode, queryResult) =>
+  try (
+    onNode(queryResult, () =>
+      switch (queryResult) {
+      | Other(_)
+      | File(_) => ()
+      | Dir(path, _) =>
+        let paths = Query.readDirExn(path);
+        List.iter(traverseFileSystemFromPath(~onNode), paths);
+      | Link(from, toTarget, _) =>
+        let nextAbsPath = Util.resolvePath(from, toTarget);
+        traverseFileSystemFromPath(~onNode, nextAbsPath);
+      }
+    )
+  ) {
+  /* Some symlink probably was bad, or a file was moved since the directory
+   * scan was performed. TODO: At least log this. */
+  | Unix.Unix_error(ENOENT, _, _) => ()
+  }
+and traverseFileSystemFromPath = (~onNode, path) =>
+  traverseFileSystemFromQueryResult(~onNode, Query.queryExn(path));

--- a/src/fs/Types.re
+++ b/src/fs/Types.re
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+
+type fileStat = Unix.stats;
+
+type lineEnds =
+  | PlatformDefault
+  | Windows
+  | Unix;
+
+type queryResultOther =
+  | /** Character device */
+    CharacterDevice
+  | /** Block device */
+    BlockDevice
+  | /** Named pipe */
+    NamedPipe
+  | /** Socket */
+    Socket;
+
+type queryResult =
+  | /** Regular file */
+    File(Path.t(Path.absolute), fileStat)
+  | /** Directory */
+    Dir(Path.t(Path.absolute), fileStat)
+  | /** Symbolic link */
+    Link(
+      Path.t(Path.absolute),
+      Path.firstClass,
+      fileStat,
+    )
+  | /** Other Operating System devices */
+    Other(
+      Path.t(Path.absolute),
+      fileStat,
+      queryResultOther,
+    );
+
+/* This type is made abstract */
+type permissionCode = int;
+type actions =
+  | No
+  | Read
+  | ReadExecute
+  | ReadWrite
+  | ReadWriteExecute;
+
+type perm = {
+  owner: actions,
+  group: actions,
+  other: actions,
+};

--- a/src/fs/Util.re
+++ b/src/fs/Util.re
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+
+external reraise: exn => _ = "%reraise";
+
+let throwErrorResult = v =>
+  switch (v) {
+  | Ok(value) => value
+  | Error(e) => reraise(e)
+  };
+
+let withInChannel = (resource, doThis) => {
+  let res =
+    try (doThis(resource)) {
+    | e =>
+      try (
+        {
+          close_in(resource);
+          reraise(e);
+        }
+      ) {
+      | _ => reraise(e)
+      }
+    };
+  close_in(resource);
+  res;
+};
+
+let withOutChannel = (resource, doThis) => {
+  let res =
+    try (doThis(resource)) {
+    | e =>
+      try (
+        {
+          close_out(resource);
+          reraise(e);
+        }
+      ) {
+      | _ => reraise(e)
+      }
+    };
+  close_out(resource);
+  res;
+};
+
+let withDirHandle = (resource, doThis) => {
+  let res =
+    try (doThis(resource)) {
+    | e =>
+      try (
+        {
+          Unix.closedir(resource);
+          reraise(e);
+        }
+      ) {
+      | _ => reraise(e)
+      }
+    };
+  Unix.closedir(resource);
+  res;
+};
+
+/*
+ * Some special care is required. Symlinks are read from `readlink` as if the
+ * relative portions are from the perspective of the `from`'s parent directory.
+ * So we apply an additional dirName here.
+ */
+let rec resolvePath = (from, toTarget) =>
+  switch (toTarget) {
+  | Path.Absolute(a) => a
+  | Relative(r) => Path.join(Path.dirName(from), r)
+  };

--- a/src/fs/dune
+++ b/src/fs/dune
@@ -1,0 +1,5 @@
+(library
+   (public_name fs.lib)
+   (libraries path.lib unix)
+   (name Fs)
+)

--- a/src/path/Path.rei
+++ b/src/path/Path.rei
@@ -1,10 +1,4 @@
 /**
- * Copyright 2004-present Facebook. All Rights Reserved.
- *
- * @emails oncall+ads_front_end_infra
- */;
-
-/**
 
 `Path` is a library for creating and operating on file paths consistently on
 all platforms.
@@ -12,20 +6,85 @@ all platforms.
 `Path` works exactly the same on Windows, Linux, and OSX, instead of adjusting
 behavior based on your current OS
 
-*/;
+The `Path` API uses the following conventions:
+
+- Accepts/returns only `t(absolute))` for values that must be absolute paths.
+- Accepts/returns only `t(relative))` for values that must be absolute paths.
+- Accepts `t('any)` for values that may be either absolute or relative paths.
+- Returns `firstClass = Absolute(t(absolute)) | Relative(t(relative)` for
+  return values that could be either. Consumers must pattern match on it.
+- Wraps return values in `Some(..)` / `None` when it is possible that no
+  value may be computed even when the caller supplies valid data.
+- Wraps return values in `Ok(..)` / `Error(exn)` when it is possible that no
+  value may be computed due to an error occuring in either user input or system
+  failure.
+- For every `functionName` that wraps return values in `Ok`/`Error`, an
+  alternative form `functionNameExn` is also supplied which does not wrap
+  the return value, and instead raises an exception.
+
+TODO: Consider the following universal convention instead:
+
+    type specificUsageError = UserNameInvalid | LoggedOut;
+    type blame('usage) = | Caller('usage) | Implementation(exn);
+    // Returns Error only for system blame:
+    result(x, exn)
+    // Returns Error for caller/system blame
+    result(x, blame(usage))
+    // Returns Error only for caller blame
+    result(x, usage)
+    // Returns Error for caller/system blame, but no value expected.
+    result(option(x), blame(usage))
+    // Returns Error for system blame, but no value expected.
+    result(option(x), exn)
+*/
 
 type relative;
 type absolute;
 /**
 A file system path, parameterized on the kind of file system path,
 `Path.t(relative)` or `Path.t(absolute)`.
- */
+*/
 type t('kind);
+
+/**
+Used to allow dynamically checking whether or not a path is absolute or
+relative. Use seldomly.
+*/
+type firstClass =
+  | Absolute(t(absolute))
+  | Relative(t(relative));
 
 let drive: string => t(absolute);
 let root: t(absolute);
 let home: t(relative);
 let dot: t(relative);
+
+/**
+Queries whether a path is absolute or relative. Use seldomly, and typically
+only on end-user input. Once queried, use the wrapped `t(absolute)/t(relative)`
+as the primary path passed around.
+*/
+let testForPath: string => option(firstClass);
+
+/**
+Same as `testForPath`, but raises `Invalid_argument` if no path could be
+detected.
+*/
+let testForPathExn: string => firstClass;
+
+/**
+Creates a "first class" path could be _either_ a relative path or an absolute
+one.
+
+This allows you to return values from functions that might be absolute or might
+be relative. It also allows relative and absolute paths to coexist inside of a
+list together.
+For example, if you create a polymorphic function that accepts any kind of
+path, and then you want to do something differently based on whether or not the
+path is relative or absolute, you would first use `firstClass(path)` and then
+pattern match on the result `Absolute(p) => .. | Relative(p) => ...`.
+*/
+let firstClass: t('any) => firstClass;
 
 /**
  Prints absolute `Path.t` as strings, always removes the final `/` separator.
@@ -39,8 +98,9 @@ let toString: t(absolute) => string;
 let toDebugString: t('kind) => string;
 
 /**
- Parses an absolute path into a `Path.t(absolute)` or returns `None` if the path
- is not a valid.
+Parses an absolute path into a `Path.t(absolute)` or returns `None` if the path
+is not a absolute, yet still valid. Raises Invalid_argument if the path is
+invalid.
  */
 let absolute: string => option(t(absolute));
 /**
@@ -62,47 +122,118 @@ let absoluteExn: string => t(absolute);
 let relativeExn: string => t(relative);
 
 /**
- Accepts any `Path.t` and returns a `Path.t` of the same kind.  Relative path
- inputs return relative path outputs, and absolute path inputs return absolute
- path outputs.
- */
+Creates a relative path from two paths, which is the relative path that is
+required to arive at the `dest`, if starting from `source` directory. The
+`source` and `dest` must both be `t(absolute)` or `t(relative)`, but the
+returned path is always of type `t(relative)`.
+
+If `source` and `dest` are relative, it is assumed that the two relative paths
+are relative to the same yet-to-be-specified absolute path.
+
+relativize(~source=/a, ~dest=/a)                == ./
+relativize(~source=/a/b/c/d /a/b/qqq            == ../c/d
+relativize(~source=/a/b/c/d, ~dest=/f/f/zzz)    == ../../../../f/f/zz
+relativize(~source=/a/b/c/d, ~dest=/a/b/c/d/q)  == ../q
+relativize(~source=./x/y/z, ~dest=./a/b/c)      == ../../a/b/c
+relativize(~source=./x/y/z, ~dest=../a/b/c)     == ../../../a/b/c
+
+Unsupported:
+`relativize` only accepts `source` and `dest` of the same kind of path because
+the following are meaningless:
+
+relativize(~source=/x/y/z, ~dest=./a/b/c) == ???
+relativize(~source=./x/y/z, ~dest=/a/b/c) == ???
+
+Exceptions:
+If it is impossible to create a relative path from `soure` to `dest` an
+exception is raised.
+If `source`/`dest` are absolute paths, the drive must match or an exception is
+thrown. If `source`/`dest` are relative paths, they both must be relative to
+`"~"` vs. `"."`. If both are relative, but the source has more `..` than the
+dest, then it is also impossible to create a relative path and an exception is
+raised.
+
+relativize(~source=./foo/bar, ~dest=~/foo/bar)       == raise(Invalid_argument)
+relativize(~source=~/foo/bar, ~dest=./foo/)          == raise(Invalid_argument)
+relativize(~source=C:/foo/bar, ~dest=/foo/bar)       == raise(Invalid_argument)
+relativize(~source=C:/foo/bar, ~dest=F:/foo/bar)     == raise(Invalid_argument)
+relativize(~source=/foo/bar, ~dest=C:/foo/)          == raise(Invalid_argument)
+relativize(~source=../x/y/z, ~dest=./a/b/c)          == raise(Invalid_argument)
+relativize(~source=../x/y/z, ~dest=../foo/../a/b/c)  == raise(Invalid_argument)
+*/
+let relativizeExn: (~source: t('kind), ~dest: t('kind)) => t(relative);
+/**
+Same as `relativizeExn` but returns `result(Path.t(Path.absolute), exn)`
+instead of throwing an exception.
+*/
+let relativize:
+  (~source: t('kind), ~dest: t('kind)) => result(t(relative), exn);
+
+/**
+Accepts any `Path.t` and returns a `Path.t` of the same kind.  Relative path
+inputs return relative path outputs, and absolute path inputs return absolute
+path outputs.
+*/
 let dirName: t('kind) => t('kind);
 
 /**
- Accepts any `Path.t` and returns the final segment in its path string, or
- `None` if there are no segments in its path string.
+Accepts any `Path.t` and returns the final segment in its path string, or
+`None` if there are no segments in its path string.
 
-    Path.baseName(Path.At(Path.dot /../ ""))
-    None
+   Path.baseName(Path.At(Path.dot /../ ""))
+   None
 
-    Path.baseName(Path.At(Path.dot /../ "foo"))
-    Some("foo")
+   Path.baseName(Path.At(Path.dot /../ "foo"))
+   Some("foo")
 
-    Path.baseName(Path.At(Path.dot /../ "foo" /../ ""))
-    None
+   Path.baseName(Path.At(Path.dot /../ "foo" /../ ""))
+   None
 
-    Path.baseName(Path.At(Path.dot /../ "foo" / "bar" /../ ""))
-    Some("foo")
- */
+   Path.baseName(Path.At(Path.dot /../ "foo" / "bar" /../ ""))
+   Some("foo")
+*/
 let baseName: t('kind) => option(string);
 
 /**
- Appends one path to another. Preserves the relative/absoluteness of the first
- arguments.
- */
+Appends one segment to a path. Preserves the relative/absoluteness of the first
+arguments.
+*/
 let append: (t('kind), string) => t('kind);
-let join: (t('kind1), t('kind2)) => t('kind1);
 
 /**
- Syntactic forms for utilities provided above. These are included in a separate
- module so that it can be opened safely without causing collisions with other
- identifiers in scope such as "root"/"home".
+Appends one path to another. Preserves the relative/absoluteness of the first
+arguments.
+*/
+let join: (t('kind1), t('kind2)) => t('kind1);
 
- Use like this:
+let eq: (t('kind1), t('kind2)) => bool;
 
-     Path.At(Path.root / "foo" / "bar");
-     Path.At(Path.dot /../ "bar");
- */
+/**
+Tests for path equality of two absolute paths.
+*/
+let absoluteEq: (t(absolute), t(absolute)) => bool;
+
+/**
+Tests for path equality of two absolute paths.
+*/
+let relativeEq: (t(relative), t(relative)) => bool;
+
+/**
+Tests whether or not an abssolute path has a parent path. Absolute
+paths such as "C:/" and "/" have no parent dir.
+*/
+let hasParentDir: t(absolute) => bool;
+
+/**
+Syntactic forms for utilities provided above. These are included in a separate
+module so that it can be opened safely without causing collisions with other
+identifiers in scope such as "root"/"home".
+
+Use like this:
+
+    Path.At(Path.root / "foo" / "bar");
+    Path.At(Path.dot /../ "bar");
+*/
 module At: {
   /**
    Performs `append` with infix syntax.

--- a/tests/__tests__/fs/Fs_test.re
+++ b/tests/__tests__/fs/Fs_test.re
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+
+open TestFramework;
+
+external reraise: exn => _ = "%reraise";
+
+let unresolvedExePath = Path.absoluteExn(Sys.executable_name);
+let resolvedExePath = Fs.resolveLinkExn(unresolvedExePath);
+let exeDir = Path.dirName(resolvedExePath);
+let testDir = Path.At.(exeDir / "testDir");
+let testDataDir = Path.At.(exeDir / "testDir" / "data");
+
+let ensureTestDir = () => {
+  switch (Fs.query(testDir)) {
+  | Some(Dir(_)) => Fs.rmDirExn(testDir)
+  | Some(_) => Fs.rmExn(testDir)
+  | None => ()
+  };
+  Fs.mkDirPExn(testDataDir);
+};
+
+let removeTestDir = () => Fs.rmDirExn(testDataDir);
+
+let otherPlatform = Sys.win32 ? Fs.Unix : Fs.Windows;
+
+describe("Fs", ({test}) => {
+  test("Removing directories", ({expect}) => {
+    ensureTestDir();
+    let simpleTextFilePath = Path.append(testDataDir, "simple-text-file.txt");
+    let simpleLines = ["hello", "these", "are", "some", "lines"];
+    Fs.writeTextExn(simpleTextFilePath, simpleLines);
+    expect.fn(() => Fs.rmEmptyDirExn(testDataDir)).toThrow();
+    Fs.writeTextExn(~lineEnds=otherPlatform, simpleTextFilePath, simpleLines);
+    let lines = Fs.readTextExn(simpleTextFilePath);
+    expect.lines(lines).toEqualLines(simpleLines);
+    removeTestDir();
+  });
+  test("Writing lines", ({expect}) => {
+    ensureTestDir();
+    let simpleTextFilePath = Path.append(testDataDir, "simple-text-file.txt");
+    expect.fn(() => Fs.readTextExn(simpleTextFilePath)).toThrow();
+    let simpleLines = ["hello", "these", "are", "some", "lines"];
+    Fs.writeTextExn(simpleTextFilePath, simpleLines);
+    let lines = Fs.readTextExn(simpleTextFilePath);
+    expect.string(String.concat("", lines)).toEqual(
+      String.concat("", simpleLines),
+    );
+    Fs.writeTextExn(simpleTextFilePath, simpleLines);
+    let lines = Fs.readTextExn(simpleTextFilePath);
+    expect.lines(lines).toEqualLines(simpleLines);
+    Fs.writeTextExn(~lineEnds=otherPlatform, simpleTextFilePath, simpleLines);
+    let lines = Fs.readTextExn(simpleTextFilePath);
+    expect.lines(lines).toEqualLines(simpleLines);
+    removeTestDir();
+  });
+  test("Links", ({expect}) => {
+    ensureTestDir();
+    let dir = Path.append(testDataDir, "dir");
+    let dirFoo = Path.append(dir, "foo");
+    expect.fn(() => Fs.readDirExn(dir)).toThrow();
+    Fs.mkDirPExn(dir);
+    expect.fn(() => Fs.readDirExn(dir)).not.toThrow();
+    /* dir/foo still throws */
+    expect.fn(() => Fs.readDirExn(dirFoo)).toThrow();
+    let subdirs = Fs.readDirExn(dir);
+    expect.int(List.length(subdirs)).toBe(0);
+    let linkToDir = Path.append(testDataDir, "toDir");
+    let linkToDirFoo = Path.append(testDataDir, "toDirFoo");
+    /* Create links to files that don't yet exist */
+    Fs.linkDirExn(linkToDir, dir);
+    Fs.linkDirExn(linkToDirFoo, dirFoo);
+    let subdirsInMainTestData = Fs.readDirExn(testDataDir);
+    expect.int(List.length(subdirsInMainTestData)).toBe(3);
+    /* Test that we can remove the link */
+    Fs.rmExn(linkToDir);
+    Fs.rmExn(linkToDirFoo);
+    /* Recreate them */
+    Fs.linkExn(linkToDir, dir);
+    Fs.linkExn(linkToDirFoo, dirFoo);
+
+    /* Test that the links point to the right places */
+    expect.string(Fs.resolveLinkExn(linkToDir) |> Path.toString).toEqual(
+      dir |> Path.toString,
+    );
+    expect.string(Fs.resolveLinkExn(linkToDirFoo) |> Path.toString).toEqual(
+      dirFoo |> Path.toString,
+    );
+    expect.lines(List.map(Path.toString, Fs.linksExn(linkToDir))).
+      toEqualLines([
+      Path.toString(dir),
+    ]);
+    expect.lines(List.map(Path.toString, Fs.linksExn(linkToDirFoo))).
+      toEqualLines([
+      Path.toString(dirFoo),
+    ]);
+
+    /* Two levels of links */
+    let linkToToDirFoo = Path.append(testDataDir, "toToDirFoo");
+    /* Create links to files that don't yet exist */
+    Fs.linkDirExn(linkToToDirFoo, linkToDirFoo);
+    /* Test that the "hops" for multiple links are correct */
+    expect.string(Fs.resolveLinkExn(linkToToDirFoo) |> Path.toString).toEqual(
+      dirFoo |> Path.toString,
+    );
+    expect.lines(List.map(Path.toString, Fs.linksExn(linkToToDirFoo))).
+      toEqualLines([
+      Path.toString(linkToDirFoo),
+      Path.toString(dirFoo),
+    ]);
+
+    /* Now test relative links */
+    let relLinkToDirFoo = Path.append(testDataDir, "relToDirFoo");
+    let relLinkToToDirFoo = Path.append(testDataDir, "relToToDirFoo");
+    /* Create links to files that don't yet exist */
+    Fs.linkExn(relLinkToDirFoo, Path.At.(Path.dot / "dir" / "foo"));
+    Fs.linkExn(relLinkToToDirFoo, Path.At.(Path.dot / "toDirFoo"));
+    /* Test that the "hops" for multiple links are correct */
+    expect.string(Fs.resolveLinkExn(relLinkToDirFoo) |> Path.toString).
+      toEqual(
+      dirFoo |> Path.toString,
+    );
+    expect.string(Fs.resolveLinkExn(relLinkToToDirFoo) |> Path.toString).
+      toEqual(
+      dirFoo |> Path.toString,
+    );
+    expect.lines(List.map(Path.toString, Fs.linksExn(relLinkToDirFoo))).
+      toEqualLines([
+      Path.toString(dirFoo),
+    ]);
+    expect.lines(List.map(Path.toString, Fs.linksExn(relLinkToToDirFoo))).
+      toEqualLines([
+      Path.toString(linkToDirFoo),
+      Path.toString(dirFoo),
+    ]);
+
+    /* Now test sideways links */
+    let deepDir = Path.append(testDataDir, "deepDir");
+    Fs.mkDirExn(deepDir);
+    let sidewaysLinkToDirFoo = Path.append(deepDir, "sidewaysToDirFoo");
+    /* Create links to files that don't yet exist */
+    Fs.linkExn(sidewaysLinkToDirFoo, Path.At.(Path.dot /../ "dir" / "foo"));
+    /* Test that the "hops" for multiple links are correct */
+    expect.string(Fs.resolveLinkExn(sidewaysLinkToDirFoo) |> Path.toString).
+      toEqual(
+      dirFoo |> Path.toString,
+    );
+    expect.lines(List.map(Path.toString, Fs.linksExn(relLinkToDirFoo))).
+      toEqualLines([
+      Path.toString(dirFoo),
+    ]);
+
+    let lines = ["bye", "hello"];
+    /* Test writing lines through the links */
+    Fs.writeTextExn(linkToDirFoo, lines);
+
+    /* Test reading lines through the links */
+    let writtenLines = Fs.readTextExn(linkToDirFoo);
+    expect.lines(writtenLines).toEqualLines(lines);
+
+    let linkDest = Fs.resolveLinkExn(linkToDirFoo);
+    let lines = ["bye", "hello"];
+    /* Test writing lines through the final link destination */
+    Fs.writeTextExn(linkDest, lines);
+    /* Test reading lines through the final link destination */
+    let writtenLines = Fs.readTextExn(linkDest);
+    expect.lines(writtenLines).toEqualLines(lines);
+    /* Test reading lines through the links */
+    let writtenLines = Fs.readTextExn(linkToDirFoo);
+    expect.lines(writtenLines).toEqualLines(lines);
+  });
+});

--- a/tests/dune
+++ b/tests/dune
@@ -5,6 +5,7 @@
   (ocamlopt_flags -linkall -g)
   (libraries
     path.lib
+    fs.lib
     dir.lib
     rely.lib
     rely.internal


### PR DESCRIPTION
Includes the previously accepted changes to Path for "Relative path functions and equality for Path.t"
Combining with this diff to minimize Shipit thrash (had problems with other diff)

Includes many test cases but not enough.