### PR TITLE
Qcheck rely

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -6,14 +6,15 @@
   "esy": {
     "build": "refmterr dune build --profile=release",
     "install": [
-      "esy-installer pastel.install",
-      "esy-installer rely.install",
-      "esy-installer path.install",
-      "esy-installer fs.install",
       "esy-installer console.install",
-      "esy-installer pastel-console.install",
       "esy-installer file-context-printer.install",
+      "esy-installer fs.install",
+      "esy-installer pastel.install",
+      "esy-installer pastel-console.install",
+      "esy-installer path.install",
+      "esy-installer qcheck-rely.install",
       "esy-installer refmterr.install",
+      "esy-installer rely.install",
       "esy-installer tests.install",
       "esy-installer unicode.install",
       "esy-installer unicode-config.install"
@@ -32,7 +33,8 @@
     "ocaml": "^4.2.0",
     "@opam/re": "*",
     "@opam/atdgen": "*",
-    "@opam/junit": "*"
+    "@opam/junit": "*",
+    "@opam/qcheck": ">= 0.9 < 0.10"
   },
   "devDependencies": {
     "@opam/merlin": "*",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "6a10cf659218443ea1e01c98b5c4453c",
+  "checksum": "655a51477fdb48fad3e797f31f6c54eb",
   "root": "reason-native-dev@link-dev:./esy.json",
   "node": {
     "refmterr@3.1.10@d41d8cd9": {
@@ -27,8 +27,9 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.1.10@d41d8cd9", "ocaml@4.6.10@d41d8cd9",
-        "@opam/re@opam:1.9.0@7f4a36a5", "@opam/junit@opam:2.0.1@c25e35a7",
-        "@opam/dune@opam:1.9.1@61bdaadf", "@opam/atdgen@opam:2.0.0@5d912e07",
+        "@opam/re@opam:1.9.0@7f4a36a5", "@opam/qcheck@opam:0.9@03f6c58c",
+        "@opam/junit@opam:2.0.1@c25e35a7", "@opam/dune@opam:1.9.1@61bdaadf",
+        "@opam/atdgen@opam:2.0.0@5d912e07",
         "@esy-ocaml/reason@3.3.3@d41d8cd9"
       ],
       "devDependencies": [
@@ -280,8 +281,99 @@
         "ocaml@4.6.10@d41d8cd9", "@opam/seq@opam:0.1@93954fa7"
       ]
     },
-    "@opam/ptime@opam:0.8.4@23eca65b": {
-      "id": "@opam/ptime@opam:0.8.4@23eca65b",
+    "@opam/qcheck-ounit@opam:0.9@7e8b345e": {
+      "id": "@opam/qcheck-ounit@opam:0.9@7e8b345e",
+      "name": "@opam/qcheck-ounit",
+      "version": "opam:0.9",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/77/7782c8cfce30a5fb766d933e99129ee7#md5:7782c8cfce30a5fb766d933e99129ee7",
+          "archive:https://github.com/c-cube/qcheck/archive/0.9.tar.gz#md5:7782c8cfce30a5fb766d933e99129ee7"
+        ],
+        "opam": {
+          "name": "qcheck-ounit",
+          "version": "0.9",
+          "path": "esy.lock/opam/qcheck-ounit.0.9"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.10@d41d8cd9", "@opam/qcheck-core@opam:0.9@0d7b911b",
+        "@opam/ounit@opam:2.0.8@def2c94d", "@opam/dune@opam:1.9.1@61bdaadf",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.6.10@d41d8cd9", "@opam/qcheck-core@opam:0.9@0d7b911b",
+        "@opam/ounit@opam:2.0.8@def2c94d",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
+    },
+    "@opam/qcheck-core@opam:0.9@0d7b911b": {
+      "id": "@opam/qcheck-core@opam:0.9@0d7b911b",
+      "name": "@opam/qcheck-core",
+      "version": "opam:0.9",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/77/7782c8cfce30a5fb766d933e99129ee7#md5:7782c8cfce30a5fb766d933e99129ee7",
+          "archive:https://github.com/c-cube/qcheck/archive/0.9.tar.gz#md5:7782c8cfce30a5fb766d933e99129ee7"
+        ],
+        "opam": {
+          "name": "qcheck-core",
+          "version": "0.9",
+          "path": "esy.lock/opam/qcheck-core.0.9"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.10@d41d8cd9", "@opam/dune@opam:1.9.1@61bdaadf",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.6.10@d41d8cd9", "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
+    },
+    "@opam/qcheck@opam:0.9@03f6c58c": {
+      "id": "@opam/qcheck@opam:0.9@03f6c58c",
+      "name": "@opam/qcheck",
+      "version": "opam:0.9",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/77/7782c8cfce30a5fb766d933e99129ee7#md5:7782c8cfce30a5fb766d933e99129ee7",
+          "archive:https://github.com/c-cube/qcheck/archive/0.9.tar.gz#md5:7782c8cfce30a5fb766d933e99129ee7"
+        ],
+        "opam": {
+          "name": "qcheck",
+          "version": "0.9",
+          "path": "esy.lock/opam/qcheck.0.9"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.10@d41d8cd9", "@opam/qcheck-ounit@opam:0.9@7e8b345e",
+        "@opam/qcheck-core@opam:0.9@0d7b911b",
+        "@opam/dune@opam:1.9.1@61bdaadf",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.6.10@d41d8cd9", "@opam/qcheck-ounit@opam:0.9@7e8b345e",
+        "@opam/qcheck-core@opam:0.9@0d7b911b",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
+    },
+    "@opam/ptime@opam:0.8.4@82555699": {
+      "id": "@opam/ptime@opam:0.8.4@82555699",
       "name": "@opam/ptime",
       "version": "opam:0.8.4",
       "source": {
@@ -330,6 +422,33 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.6.10@d41d8cd9" ]
+    },
+    "@opam/ounit@opam:2.0.8@def2c94d": {
+      "id": "@opam/ounit@opam:2.0.8@def2c94d",
+      "name": "@opam/ounit",
+      "version": "opam:2.0.8",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/bd/bd12d66c9dbd95a50570bb686b0f10f5#md5:bd12d66c9dbd95a50570bb686b0f10f5",
+          "archive:https://download.ocamlcore.org/ounit/ounit/2.0.8/ounit-2.0.8.tar.gz#md5:bd12d66c9dbd95a50570bb686b0f10f5"
+        ],
+        "opam": {
+          "name": "ounit",
+          "version": "2.0.8",
+          "path": "esy.lock/opam/ounit.2.0.8"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.10@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@f744a0c5",
+        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.6.10@d41d8cd9", "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
     },
     "@opam/ocamlfind@opam:1.8.0@f744a0c5": {
       "id": "@opam/ocamlfind@opam:1.8.0@f744a0c5",
@@ -518,11 +637,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/tyxml@opam:4.3.0@15e44054", "@opam/ptime@opam:0.8.4@23eca65b",
+        "@opam/tyxml@opam:4.3.0@15e44054", "@opam/ptime@opam:0.8.4@82555699",
         "@opam/dune@opam:1.9.1@61bdaadf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/tyxml@opam:4.3.0@15e44054", "@opam/ptime@opam:0.8.4@23eca65b"
+        "@opam/tyxml@opam:4.3.0@15e44054", "@opam/ptime@opam:0.8.4@82555699"
       ]
     },
     "@opam/jbuilder@opam:transition@58bdfe0a": {
@@ -722,6 +841,28 @@
       "overrides": [],
       "dependencies": [ "@esy-ocaml/substs@0.0.1@d41d8cd9" ],
       "devDependencies": []
+    },
+    "@opam/base-bytes@opam:base@19d0c2ff": {
+      "id": "@opam/base-bytes@opam:base@19d0c2ff",
+      "name": "@opam/base-bytes",
+      "version": "opam:base",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "base-bytes",
+          "version": "base",
+          "path": "esy.lock/opam/base-bytes.base"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.10@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@f744a0c5",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.6.10@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@f744a0c5"
+      ]
     },
     "@opam/atdgen-runtime@opam:2.0.0@8a75c3bb": {
       "id": "@opam/atdgen-runtime@opam:2.0.0@8a75c3bb",

--- a/esy.lock/opam/base-bytes.base/opam
+++ b/esy.lock/opam/base-bytes.base/opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+maintainer: " "
+authors: " "
+homepage: " "
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "ocamlfind" {>= "1.5.3"}
+]
+synopsis: "Bytes library distributed with the OCaml compiler"

--- a/esy.lock/opam/ounit.2.0.8/opam
+++ b/esy.lock/opam/ounit.2.0.8/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+authors: [ "Maas-Maarten Zeeman" "Sylvain Le Gall" ]
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "http://ounit.forge.ocamlcore.org"
+bug-reports: "https://forge.ocamlcore.org/tracker/?func=browse&group_id=162&atid=730"
+dev-repo: "git+https://github.com/gildor478/ounit.git"
+doc: ["http://ounit.forge.ocamlcore.org/api-ounit/index.html"]
+build: [make "build"]
+remove: [["ocamlfind" "remove" "oUnit"]]
+depends: [
+  "ocaml" {>= "3.11.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "base-bytes"
+]
+install: [make "install"]
+synopsis:
+  "Unit testing framework loosely based on HUnit. It is similar to JUnit, and other XUnit testing frameworks"
+flags: light-uninstall
+url {
+  src: "https://download.ocamlcore.org/ounit/ounit/2.0.8/ounit-2.0.8.tar.gz"
+  checksum: "md5=bd12d66c9dbd95a50570bb686b0f10f5"
+}

--- a/esy.lock/opam/ptime.0.8.4/opam
+++ b/esy.lock/opam/ptime.0.8.4/opam
@@ -15,6 +15,8 @@ depends: [
   "result"
 ]
 depopts: [ "js_of_ocaml" ]
+conflicts: [
+  "js_of_ocaml" {>= "3.4.0"} ]
 build:[[
    "ocaml" "pkg/pkg.ml" "build"
    "--pinned" "%{pinned}%"

--- a/esy.lock/opam/qcheck-core.0.9/opam
+++ b/esy.lock/opam/qcheck-core.0.9/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.orgr>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.03.0"}
+  "base-bytes"
+  "base-unix"
+  "odoc" {doc}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+    ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+synopsis: "QuickCheck inspired property-based testing for OCaml."
+description: """
+This module allows to check invariants (properties of some types) over
+randomly generated instances of the type. It provides combinators for
+generating instances and printing them."""
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
+  checksum: [
+    "md5=7782c8cfce30a5fb766d933e99129ee7"
+    "sha512=e1007b4a3be338406d855efcf8d13ac4961963a6c77b794ab83973950e21c777cb66ab6020a0a714f96866597bc8bf7a76a84243e5062dab5b41978e78422e0b"
+  ]
+}

--- a/esy.lock/opam/qcheck-ounit.0.9/opam
+++ b/esy.lock/opam/qcheck-ounit.0.9/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.orgr>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.03.0"}
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {>= "0.9"}
+  "ounit" {>= "2.0"}
+  "odoc" {doc}
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+    ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+synopsis: "QuickCheck inspired property-based testing for OCaml."
+description: """
+This module provides QCheck integration with OUnit."""
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
+  checksum: [
+    "md5=7782c8cfce30a5fb766d933e99129ee7"
+    "sha512=e1007b4a3be338406d855efcf8d13ac4961963a6c77b794ab83973950e21c777cb66ab6020a0a714f96866597bc8bf7a76a84243e5062dab5b41978e78422e0b"
+  ]
+}

--- a/esy.lock/opam/qcheck.0.9/opam
+++ b/esy.lock/opam/qcheck.0.9/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.orgr>"
+tags: ["test" "property" "quickcheck"]
+homepage: "https://github.com/c-cube/qcheck/"
+doc: "http://c-cube.github.io/qcheck/"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.03.0"}
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" {>= "0.9"}
+  "qcheck-ounit" {>= "0.9"}
+  "odoc" {doc}
+]
+conflicts: [
+  "ounit" {< "2.0"}
+]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+    ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+synopsis: "QuickCheck inspired property-based testing for OCaml."
+description: """
+This module allows to check invariants (properties of some types) over
+randomly generated instances of the type. It provides combinators for
+generating instances and printing them."""
+url {
+  src: "https://github.com/c-cube/qcheck/archive/0.9.tar.gz"
+  checksum: [
+    "md5=7782c8cfce30a5fb766d933e99129ee7"
+    "sha512=e1007b4a3be338406d855efcf8d13ac4961963a6c77b794ab83973950e21c777cb66ab6020a0a714f96866597bc8bf7a76a84243e5062dab5b41978e78422e0b"
+  ]
+}

--- a/qcheck-rely.json
+++ b/qcheck-rely.json
@@ -1,6 +1,6 @@
 {
   "name": "@reason-native/qcheck-rely",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Rely matchers for qcheck",
   "repository": {
     "type": "git",

--- a/qcheck-rely.json
+++ b/qcheck-rely.json
@@ -1,0 +1,27 @@
+{
+  "name": "@reason-native/qcheck-rely",
+  "version": "0.1.0",
+  "description": "Rely matchers for qcheck",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebookexperimental/reason-native/tree/master/src/qcheck-rely"
+  },
+  "license": "MIT",
+  "keywords": ["qcheck", "rely", "unittest", "test", "property test"],
+  "esy": {
+    "build": "dune build -p qcheck-rely",
+    "install": ["esy-installer qcheck-rely.install"],
+    "sandboxEnv": {
+      "PROJECT_DIR": "."
+    }
+  },
+  "dependencies": {
+    "@opam/dune": "*",
+    "@opam/qcheck": ">= 0.9 < 0.10",
+    "@esy-ocaml/reason": "*",
+    "refmterr": "*",
+    "ocaml": "^4.2.0",
+    "@reason-native/rely": "*",
+    "@reason-native/console": "*"
+  }
+}

--- a/src/qcheck-rely/QCheckRely.re
+++ b/src/qcheck-rely/QCheckRely.re
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
 module T = QCheck.Test;
 module Rely = Rely;
 open Rely.MatcherUtils;

--- a/src/qcheck-rely/QCheckRely.re
+++ b/src/qcheck-rely/QCheckRely.re
@@ -1,0 +1,241 @@
+module T = QCheck.Test;
+module Rely = Rely;
+open Rely.MatcherUtils;
+open Rely.MatcherTypes;
+
+let seed: ref(option(int)) = ref(None);
+
+let seed_ =
+  lazy {
+    let s =
+      try (int_of_string @@ Sys.getenv("QCHECK_SEED")) {
+      | _ =>
+        Random.self_init();
+        Random.int(1000000000);
+      };
+    seed := Some(s);
+    s;
+  };
+
+let default_rand = () =>
+  /* random seed, for repeatability of tests */
+  Random.State.make([|Lazy.force(seed_)|]);
+
+let long_ =
+  lazy (
+    switch (Sys.getenv("QCHECK_LONG")) {
+    | "1"
+    | "true" => true
+    | _ => false
+    | exception Not_found => false
+    }
+  );
+
+type qCheckRely = {
+  make: (~long: bool=?, ~rand: Random.State.t=?, QCheck.Test.t) => unit,
+  makeCell:
+    'a.
+    (~long: bool=?, ~rand: Random.State.t=?, QCheck.Test.cell('a)) => unit,
+
+};
+
+module Matchers = {
+  type extension = {
+    qCheckTest:
+      (~long: bool=?, ~rand: Random.State.t=?, QCheck.Test.t) => unit,
+    qCheckCell:
+      'a.
+      (~long: bool=?, ~rand: Random.State.t=?, QCheck.Test.cell('a)) => unit,
+
+  };
+
+  let seedToString = (seed: ref(option(int)), formatSeed) => {
+    switch (seed^) {
+    | None => None
+    | Some(s) =>
+      Some("qcheck random seed: " ++ formatSeed(string_of_int(s)))
+    };
+  };
+
+  let pass = (() => "", true);
+
+  let makeTestMatcher = (createMatcher, accessorPath) => {
+    createMatcher(({formatReceived, indent, matcherHint, _}, actualThunk, _) => {
+      let (QCheck.Test.Test(cell), rand: Random.State.t, long: bool) =
+        actualThunk();
+
+      switch (QCheck.Test.check_cell_exn(~long, ~rand, cell)) {
+      | () => pass
+      | exception (QCheck.Test.Test_fail(name, input)) =>
+        let testNameFailureMessage = "QCheck test \"" ++ name ++ "\" failed";
+        let inputMessage =
+          "generated input: \n"
+          ++ indent(formatReceived(String.concat("\n", input)));
+        let messageParts =
+          switch (seedToString(seed, formatReceived)) {
+          | None => [testNameFailureMessage, "", inputMessage]
+          | Some(s) => [testNameFailureMessage, "", inputMessage, s]
+          };
+
+        let message =
+          String.concat(
+            "\n",
+            [
+              matcherHint(
+                ~expectType=accessorPath,
+                ~matcherName="",
+                ~isNot=false,
+                ~expected="",
+                (),
+              )
+              ++ "\n",
+              ...messageParts,
+            ],
+          );
+        ((() => message), false);
+      | exception (QCheck.Test.Test_error(name, input, e, _)) =>
+        let testNameFailureMessage =
+          "QCheck test \""
+          ++ name
+          ++ "\" failed with exception "
+          ++ Printexc.to_string(e);
+        let inputMessage = "generated input: " ++ formatReceived(input);
+
+        let messageParts =
+          switch (seedToString(seed, formatReceived)) {
+          | None => [testNameFailureMessage, "", inputMessage]
+          | Some(s) => [testNameFailureMessage, "", inputMessage, s]
+          };
+
+        let message =
+          String.concat(
+            "\n",
+            [
+              matcherHint(
+                ~expectType=accessorPath,
+                ~matcherName="",
+                ~isNot=false,
+                ~expected="",
+                (),
+              )
+              ++ "\n",
+              ...messageParts,
+            ],
+          );
+        ((() => message), false);
+      };
+    });
+  };
+
+  let makeCellMatcher = (createMatcher, accessorPath) => {
+    createMatcher(({formatReceived, indent, matcherHint, _}, actualThunk, _) => {
+      let (cell, rand: Random.State.t, long: bool) = actualThunk();
+
+      switch (QCheck.Test.check_cell_exn(~long, ~rand, cell)) {
+      | () => pass
+      | exception (QCheck.Test.Test_fail(name, input)) =>
+        let testNameFailureMessage = "QCheck test \"" ++ name ++ "\" failed";
+        let inputMessage =
+          "generated input: \n"
+          ++ indent(formatReceived(String.concat("\n", input)));
+        let messageParts =
+          switch (seedToString(seed, formatReceived)) {
+          | None => [testNameFailureMessage, "", inputMessage]
+          | Some(s) => [testNameFailureMessage, "", inputMessage, s]
+          };
+
+        let message =
+          String.concat(
+            "\n",
+            [
+              matcherHint(
+                ~expectType=accessorPath,
+                ~matcherName="",
+                ~isNot=false,
+                ~expected="",
+                (),
+              )
+              ++ "\n",
+              ...messageParts,
+            ],
+          );
+        ((() => message), false);
+      | exception (QCheck.Test.Test_error(name, input, e, _)) =>
+        let testNameFailureMessage =
+          "QCheck test \""
+          ++ name
+          ++ "\" failed with exception "
+          ++ Printexc.to_string(e);
+        let inputMessage = "generated input: " ++ formatReceived(input);
+
+        let messageParts =
+          switch (seedToString(seed, formatReceived)) {
+          | None => [testNameFailureMessage, "", inputMessage]
+          | Some(s) => [testNameFailureMessage, "", inputMessage, s]
+          };
+
+        let message =
+          String.concat(
+            "\n",
+            [
+              matcherHint(
+                ~expectType=accessorPath,
+                ~matcherName="",
+                ~isNot=false,
+                ~expected="",
+                (),
+              )
+              ++ "\n",
+              ...messageParts,
+            ],
+          );
+        ((() => message), false);
+      };
+    });
+  };
+
+  let matchers = ({createMatcher}) => {
+    {
+      qCheckTest: (~long=Lazy.force(long_), ~rand=default_rand(), t) =>
+        makeTestMatcher(
+          createMatcher,
+          ".ext.qCheckTest",
+          () => (t, rand, long),
+          () => (),
+        ),
+      qCheckCell: (~long=Lazy.force(long_), ~rand=default_rand(), c) =>
+        makeCellMatcher(
+          createMatcher,
+          ".ext.qCheckCell",
+          () => (c, rand, long),
+          () => (),
+        ),
+    };
+  };
+};
+
+let toRely = (test: Rely.Test.testFn('a)) => {
+  make: (~long=Lazy.force(long_), ~rand=default_rand(), t) => {
+    let QCheck.Test.Test(cell) = t;
+    let name = QCheck.Test.get_name(cell);
+    test(
+      name,
+      _ => {
+        let _ = QCheck.Test.check_cell_exn(~long, ~rand, cell);
+        ();
+      },
+    );
+    ();
+  },
+  makeCell: (~long=Lazy.force(long_), ~rand=default_rand(), cell) => {
+    let name = QCheck.Test.get_name(cell);
+    test(
+      name,
+      _ => {
+        QCheck.Test.check_cell_exn(cell, ~long, ~rand);
+        ();
+      },
+    );
+    ();
+  },
+};

--- a/src/qcheck-rely/QCheckRely.re
+++ b/src/qcheck-rely/QCheckRely.re
@@ -37,14 +37,6 @@ let long_ =
     }
   );
 
-type qCheckRely = {
-  make: (~long: bool=?, ~rand: Random.State.t=?, QCheck.Test.t) => unit,
-  makeCell:
-    'a.
-    (~long: bool=?, ~rand: Random.State.t=?, QCheck.Test.cell('a)) => unit,
-
-};
-
 module Matchers = {
   type extension = {
     qCheckTest:
@@ -218,30 +210,4 @@ module Matchers = {
         ),
     };
   };
-};
-
-let toRely = (test: Rely.Test.testFn('a)) => {
-  make: (~long=Lazy.force(long_), ~rand=default_rand(), t) => {
-    let QCheck.Test.Test(cell) = t;
-    let name = QCheck.Test.get_name(cell);
-    test(
-      name,
-      _ => {
-        let _ = QCheck.Test.check_cell_exn(~long, ~rand, cell);
-        ();
-      },
-    );
-    ();
-  },
-  makeCell: (~long=Lazy.force(long_), ~rand=default_rand(), cell) => {
-    let name = QCheck.Test.get_name(cell);
-    test(
-      name,
-      _ => {
-        QCheck.Test.check_cell_exn(cell, ~long, ~rand);
-        ();
-      },
-    );
-    ();
-  },
 };

--- a/src/qcheck-rely/QCheckRely.rei
+++ b/src/qcheck-rely/QCheckRely.rei
@@ -39,24 +39,3 @@ module Matchers: {
 
   let matchers: Rely.MatcherTypes.extendUtils => extension;
 };
-
-type qCheckRely = {
-  make: (~long: bool=?, ~rand: Random.State.t=?, QCheck.Test.t) => unit,
-  makeCell:
-    'a.
-    (~long: bool=?, ~rand: Random.State.t=?, QCheck.Test.cell('a)) => unit,
-
-};
-
-/** Convert a qcheck test into a rely test
- *  @param long whether to run long tests, (default: false)
- *  @param rand the random generator to use (default: [random_state ()])
- *  @since NEXT_RELEASE
- *
- * describe("my testSuite", ({test}) => {
- *   let { make, makeCell } = QCheckRely.toRely(test);
- *   make(myQCheckTest);
- *   ();
- * })
-*/
-let toRely: Rely.Test.testFn('a) => qCheckRely;

--- a/src/qcheck-rely/QCheckRely.rei
+++ b/src/qcheck-rely/QCheckRely.rei
@@ -1,4 +1,10 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+/**
   {1 Rely backend for QCheck}
 
     We can also use environment variables for controlling QCheck here

--- a/src/qcheck-rely/QCheckRely.rei
+++ b/src/qcheck-rely/QCheckRely.rei
@@ -1,0 +1,56 @@
+/**
+  {1 Rely backend for QCheck}
+
+    We can also use environment variables for controlling QCheck here
+
+    - [QCHECK_SEED] if an integer, will fix the seed
+    - [QCHECK_LONG] is present, will trigger long tests
+
+    @since NEXT_RELEASE
+*/;
+
+/** Custom qcheck matchers for Rely, usage looks like:
+ *
+ * let { describe } = extendDescribe(QCheckRely.Matchers.matchers);
+ * describe("my testSuite", ({test}) => {
+ *   test("my qcheck test", ({expect}) => {
+ *     expect.ext.qCheckTest(myQCheckTest);
+ *     ();
+ *   });
+ *   ();
+ * })
+ *
+ */
+module Matchers: {
+  type extension = {
+    qCheckTest:
+      (~long: bool=?, ~rand: Random.State.t=?, QCheck.Test.t) => unit,
+    qCheckCell:
+      'a.
+      (~long: bool=?, ~rand: Random.State.t=?, QCheck.Test.cell('a)) => unit,
+
+  };
+
+  let matchers: Rely.MatcherTypes.extendUtils => extension;
+};
+
+type qCheckRely = {
+  make: (~long: bool=?, ~rand: Random.State.t=?, QCheck.Test.t) => unit,
+  makeCell:
+    'a.
+    (~long: bool=?, ~rand: Random.State.t=?, QCheck.Test.cell('a)) => unit,
+
+};
+
+/** Convert a qcheck test into a rely test
+ *  @param long whether to run long tests, (default: false)
+ *  @param rand the random generator to use (default: [random_state ()])
+ *  @since NEXT_RELEASE
+ *
+ * describe("my testSuite", ({test}) => {
+ *   let { make, makeCell } = QCheckRely.toRely(test);
+ *   make(myQCheckTest);
+ *   ();
+ * })
+*/
+let toRely: Rely.Test.testFn('a) => qCheckRely;

--- a/src/qcheck-rely/README.md
+++ b/src/qcheck-rely/README.md
@@ -1,0 +1,39 @@
+# qcheck-rely
+
+`qcheck-rely` contains custom Rely matchers that allow for easily using [QCheck](https://github.com/c-cube/qcheck) with Rely. QCheck is a "QuickCheck inspired property-based testing for OCaml, and combinators to generate random values to run tests on."
+
+### Installation (assuming [esy](https://esy.sh/) for package management and dune for building)
+
+You will want to add both `@opam/qcheck` and `@reason-native/qcheck-rely` to your `package.json` or `eys.json` file and
+`qcheck-core` and `qcheck-rely` to your `dune` file.
+
+### Usage
+
+For writing QCheck tests, see [QCheck](https://github.com/c-cube/qcheck). Integration with Rely can be done as below:
+
+```reason
+open TestFramework;
+open QCheckRely;
+
+let {describe, _} = extendDescribe(QCheckRely.Matchers.matchers);
+
+describe("qcheck-rely", ({test, _}) => {
+  test("qcheck tests", ({expect}) => {
+    let myQCheckTest = ...
+    expect.ext.qCheckTest(myQCheckTest);
+    ();
+  });
+  test("qcheck cells", ({expect}) => {
+    let myQCheckCell = ...
+    expect.ext.qCheckCell(myQCheckCell);
+    ();
+  });
+  test("qcheck tests with custom random seed", ({expect}) => {
+    let myQCheckTest = ...
+    /* can also be specified by the QCHECK_SEED environment variable */
+    let customRandomSeed = Random.State.make([|42|]);
+    expect.ext.qCheckTest(~rand=customRandomSeed, myQCheckTest);
+    ();
+  });
+```
+

--- a/src/qcheck-rely/dune
+++ b/src/qcheck-rely/dune
@@ -1,0 +1,5 @@
+(library
+  (name QCheckRely)
+  (public_name qcheck-rely)
+  (libraries qcheck-core rely.lib console.lib)
+)

--- a/tests/__snapshots__/qcheck_rely.0e5fd4bb.0.snapshot
+++ b/tests/__snapshots__/qcheck_rely.0e5fd4bb.0.snapshot
@@ -1,0 +1,7 @@
+qcheck-rely › failing test
+<dim>expect.ext.qCheckTest(</dim><red>received</red><dim>)(</dim><green></green><dim>)</dim>
+
+QCheck test \"fail_sort_id\" failed
+
+generated input: 
+  <red>[1; 0] (after 12 shrink steps)</red>

--- a/tests/__snapshots__/qcheck_rely.a75930cc.0.snapshot
+++ b/tests/__snapshots__/qcheck_rely.a75930cc.0.snapshot
@@ -1,0 +1,12 @@
+qcheck-rely › simple failure test
+<dim>expect.ext.qCheckTest(</dim><red>received</red><dim>)(</dim><green></green><dim>)</dim>
+
+QCheck test \"fail_check_err_message\" failed
+
+generated input: 
+  <red>0 (after 5 shrink steps)
+  this
+  will
+  always
+  fail
+  </red>

--- a/tests/__snapshots__/qcheck_rely.c64dfd8b.0.snapshot
+++ b/tests/__snapshots__/qcheck_rely.c64dfd8b.0.snapshot
@@ -1,0 +1,6 @@
+qcheck-rely › error test
+<dim>expect.ext.qCheckTest(</dim><red>received</red><dim>)(</dim><green></green><dim>)</dim>
+
+QCheck test \"error_raise_exn\" failed with exception Error
+
+generated input: <red>0 (after 60 shrink steps)</red>

--- a/tests/__tests__/qcheck-rely/QCheckRely_test.re
+++ b/tests/__tests__/qcheck-rely/QCheckRely_test.re
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+open TestFramework;
+open QCheckRely;
+
+let {describe, _} = extendDescribe(QCheckRely.Matchers.matchers);
+
+let seed = Random.State.make([|42|]);
+
+describe("qcheck-rely", ({test, _}) => {
+  test("passing test", ({expect}) => {
+    let passing =
+      QCheck.Test.make(
+        ~count=1000,
+        ~name="list_rev_is_involutive",
+        QCheck.(list(small_int)),
+        l =>
+        List.rev(List.rev(l)) == l
+      );
+    expect.ext.qCheckTest(~rand=seed, passing);
+    ();
+  });
+  test("failing test", testUtils =>
+    MatcherSnapshotTestRunner.snapshotFailingTestCaseCustomMatchers(
+      QCheckRely.Matchers.matchers,
+      testUtils,
+      ({expect}) => {
+        let failing =
+          QCheck.Test.make(
+            ~count=10, ~name="fail_sort_id", QCheck.(list(small_int)), l =>
+            l == List.sort(compare, l)
+          );
+
+        expect.ext.qCheckTest(~rand=seed, failing);
+      },
+    )
+  );
+
+  test("error test", testUtils =>
+    MatcherSnapshotTestRunner.snapshotFailingTestCaseCustomMatchers(
+      QCheckRely.Matchers.matchers,
+      testUtils,
+      ({expect}) => {
+        exception Error;
+
+        let error =
+          QCheck.Test.make(~count=10, ~name="error_raise_exn", QCheck.int, _ =>
+            raise(Error)
+          );
+
+        expect.ext.qCheckTest(~rand=seed, error);
+        ();
+      },
+    )
+  );
+
+  test("simple failure test", testUtils =>
+    MatcherSnapshotTestRunner.snapshotFailingTestCaseCustomMatchers(
+      QCheckRely.Matchers.matchers,
+      testUtils,
+      ({expect}) => {
+        let simple_qcheck =
+          QCheck.Test.make(
+            ~name="fail_check_err_message", ~count=100, QCheck.small_int, _ =>
+            QCheck.Test.fail_reportf("@[<v>this@ will@ always@ fail@]")
+          );
+
+        expect.ext.qCheckTest(~rand=seed, simple_qcheck);
+        ();
+      },
+    )
+  );
+
+  /** Alternate syntax, worse matcher output */
+  let {make, _} = QCheckRely.toRely(test);
+
+  let simplePassingTest =
+    QCheck.Test.make(
+      ~count=1000, ~name="list_rev_is_involutive", QCheck.(list(small_int)), l =>
+      List.rev(List.rev(l)) == l
+    );
+  make(~rand=seed, simplePassingTest);
+});

--- a/tests/__tests__/qcheck-rely/QCheckRely_test.re
+++ b/tests/__tests__/qcheck-rely/QCheckRely_test.re
@@ -74,14 +74,4 @@ describe("qcheck-rely", ({test, _}) => {
       },
     )
   );
-
-  /** Alternate syntax, worse matcher output */
-  let {make, _} = QCheckRely.toRely(test);
-
-  let simplePassingTest =
-    QCheck.Test.make(
-      ~count=1000, ~name="list_rev_is_involutive", QCheck.(list(small_int)), l =>
-      List.rev(List.rev(l)) == l
-    );
-  make(~rand=seed, simplePassingTest);
 });

--- a/tests/__tests__/rely/MatcherSnapshotTestRunner.re
+++ b/tests/__tests__/rely/MatcherSnapshotTestRunner.re
@@ -4,6 +4,61 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
+
+let runInternal = (run, testUtils: Rely.Test.testUtils('ext)) => {
+  module Reporter =
+    TestReporter.Make({});
+
+  Reporter.onRunComplete(result => {
+    let output =
+      result.testSuiteResults
+      |> List.map((a: Rely.Reporter.testSuiteResult) => a.testResults)
+      |> List.flatten
+      |> List.map((testResult: Rely.Reporter.testResult) =>
+           switch (testResult.testStatus) {
+           | Failed(message, loc, stack) => message
+           | _ => ""
+           }
+         )
+      |> String.concat("");
+
+    testUtils.expect.string(output).toMatchSnapshot();
+  });
+
+  Pastel.useMode(HumanReadable, () =>
+    run(
+      Rely.RunConfig.(
+        initialize()
+        |> withReporters([Custom(Reporter.reporter)])
+        |> onTestFrameworkFailure(() => ())
+      ),
+    )
+  );
+};
+
+let snapshotFailingTestCaseCustomMatchers =
+    (
+      createCustomMatchers: Rely.MatcherTypes.matchersExtensionFn('ext),
+      testUtils: Rely.Test.testUtils('ext),
+      testBody,
+    ) => {
+  module TestFramework =
+    Rely.Make({
+      let config =
+        Rely.TestFrameworkConfig.(
+          initialize({snapshotDir: "unused", projectDir: ""})
+        );
+    });
+  open Rely.Describe;
+  let {describe} = TestFramework.extendDescribe(createCustomMatchers);
+
+  describe("unused, doesn't matter", ({test}) =>
+    test("not used", testBody)
+  );
+
+  runInternal(TestFramework.run, testUtils);
+};
+
 let snapshotFailingTestCase =
     (testUtils: Rely.Test.testUtils('ext), testBody) => {
   module TestFramework =
@@ -18,33 +73,5 @@ let snapshotFailingTestCase =
     test("not used", testBody)
   );
 
-  module Reporter =
-    TestReporter.Make({});
-
-  Reporter.onRunComplete(result => {
-    let output =
-      result.testSuiteResults
-      |> List.map((a: Rely.Reporter.testSuiteResult) => a.testResults)
-      |> List.flatten
-      |> List.map((testResult: Rely.Reporter.testResult) => {
-            switch (testResult.testStatus) {
-           | Failed(message, loc, stack) => message
-           | _ => ""
-           };
-        }
-         )
-      |> String.concat("");
-
-    testUtils.expect.string(output).toMatchSnapshot();
-  });
-
-  Pastel.useMode(HumanReadable, () => {
-    TestFramework.run(
-        Rely.RunConfig.(
-          initialize()
-          |> withReporters([Custom(Reporter.reporter)])
-          |> onTestFrameworkFailure(() => ())
-        ),
-      );
-  });
+  runInternal(TestFramework.run, testUtils);
 };

--- a/tests/dune
+++ b/tests/dune
@@ -12,6 +12,8 @@
     pastel.lib
     console.lib
     pastel-console.lib
+    qcheck-core
+    qcheck-rely
     sexplib0
   )
   (modules (:standard \ TestDev TestCi))


### PR DESCRIPTION
Basically just ported my work over from https://github.com/c-cube/qcheck/pull/62 after we decided that it makes sense for this to live here

Open questions I see are

a) The seed printing logic is kinda weird, if ANY modules using qcheck rely cause the random seed to be generated, all failures will print that seed whether or not it was overridden for the specific matcher/run

b) Do we want a  custom matchers and a non custom matchers API (currently both are implemented)

Custom matchers output (also very open to feedback here)

![image](https://user-images.githubusercontent.com/5252755/56699675-60252a80-66ab-11e9-93fa-aa9893cd4afd.png)
