### PR TITLE
remove matcher hint because it doesn't quite fit the usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# May 1, 2019
+### qcheck-rely 1.0.1
+* Remove confusing matcher hint from qcheck rely output
+
 # April 30, 2019
 ### qcheck-rely 1.0.0
 * Initial release, see the README in the src/qcheck-rely directory for usage

--- a/qcheck-rely.json
+++ b/qcheck-rely.json
@@ -1,6 +1,6 @@
 {
   "name": "@reason-native/qcheck-rely",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Rely matchers for qcheck",
   "repository": {
     "type": "git",

--- a/src/qcheck-rely/QCheckRely.re
+++ b/src/qcheck-rely/QCheckRely.re
@@ -47,18 +47,17 @@ module Matchers = {
 
   };
 
-  let seedToString = (seed: ref(option(int)), formatSeed) => {
+  let seedToString = (seed: ref(option(int)), formatSeed) =>
     switch (seed^) {
     | None => None
     | Some(s) =>
       Some("qcheck random seed: " ++ formatSeed(string_of_int(s)))
     };
-  };
 
   let pass = (() => "", true);
 
-  let makeTestMatcher = (createMatcher, accessorPath) => {
-    createMatcher(({formatReceived, indent, matcherHint, _}, actualThunk, _) => {
+  let makeTestMatcher = (createMatcher, accessorPath) =>
+    createMatcher(({formatReceived, indent, _}, actualThunk, _) => {
       let (QCheck.Test.Test(cell), rand: Random.State.t, long: bool) =
         actualThunk();
 
@@ -75,21 +74,7 @@ module Matchers = {
           | Some(s) => [testNameFailureMessage, "", inputMessage, s]
           };
 
-        let message =
-          String.concat(
-            "\n",
-            [
-              matcherHint(
-                ~expectType=accessorPath,
-                ~matcherName="",
-                ~isNot=false,
-                ~expected="",
-                (),
-              )
-              ++ "\n",
-              ...messageParts,
-            ],
-          );
+        let message = String.concat("\n", messageParts);
         ((() => message), false);
       | exception (QCheck.Test.Test_error(name, input, e, _)) =>
         let testNameFailureMessage =
@@ -105,28 +90,13 @@ module Matchers = {
           | Some(s) => [testNameFailureMessage, "", inputMessage, s]
           };
 
-        let message =
-          String.concat(
-            "\n",
-            [
-              matcherHint(
-                ~expectType=accessorPath,
-                ~matcherName="",
-                ~isNot=false,
-                ~expected="",
-                (),
-              )
-              ++ "\n",
-              ...messageParts,
-            ],
-          );
+        let message = String.concat("\n", messageParts);
         ((() => message), false);
       };
     });
-  };
 
-  let makeCellMatcher = (createMatcher, accessorPath) => {
-    createMatcher(({formatReceived, indent, matcherHint, _}, actualThunk, _) => {
+  let makeCellMatcher = (createMatcher, accessorPath) =>
+    createMatcher(({formatReceived, indent, _}, actualThunk, _) => {
       let (cell, rand: Random.State.t, long: bool) = actualThunk();
 
       switch (QCheck.Test.check_cell_exn(~long, ~rand, cell)) {
@@ -142,21 +112,7 @@ module Matchers = {
           | Some(s) => [testNameFailureMessage, "", inputMessage, s]
           };
 
-        let message =
-          String.concat(
-            "\n",
-            [
-              matcherHint(
-                ~expectType=accessorPath,
-                ~matcherName="",
-                ~isNot=false,
-                ~expected="",
-                (),
-              )
-              ++ "\n",
-              ...messageParts,
-            ],
-          );
+        let message = String.concat("\n", messageParts);
         ((() => message), false);
       | exception (QCheck.Test.Test_error(name, input, e, _)) =>
         let testNameFailureMessage =
@@ -172,42 +128,25 @@ module Matchers = {
           | Some(s) => [testNameFailureMessage, "", inputMessage, s]
           };
 
-        let message =
-          String.concat(
-            "\n",
-            [
-              matcherHint(
-                ~expectType=accessorPath,
-                ~matcherName="",
-                ~isNot=false,
-                ~expected="",
-                (),
-              )
-              ++ "\n",
-              ...messageParts,
-            ],
-          );
+        let message = String.concat("\n", messageParts);
         ((() => message), false);
       };
     });
-  };
 
   let matchers = ({createMatcher}) => {
-    {
-      qCheckTest: (~long=Lazy.force(long_), ~rand=default_rand(), t) =>
-        makeTestMatcher(
-          createMatcher,
-          ".ext.qCheckTest",
-          () => (t, rand, long),
-          () => (),
-        ),
-      qCheckCell: (~long=Lazy.force(long_), ~rand=default_rand(), c) =>
-        makeCellMatcher(
-          createMatcher,
-          ".ext.qCheckCell",
-          () => (c, rand, long),
-          () => (),
-        ),
-    };
+    qCheckTest: (~long=Lazy.force(long_), ~rand=default_rand(), t) =>
+      makeTestMatcher(
+        createMatcher,
+        ".ext.qCheckTest",
+        () => (t, rand, long),
+        () => (),
+      ),
+    qCheckCell: (~long=Lazy.force(long_), ~rand=default_rand(), c) =>
+      makeCellMatcher(
+        createMatcher,
+        ".ext.qCheckCell",
+        () => (c, rand, long),
+        () => (),
+      ),
   };
 };

--- a/tests/__snapshots__/qcheck_rely.0e5fd4bb.0.snapshot
+++ b/tests/__snapshots__/qcheck_rely.0e5fd4bb.0.snapshot
@@ -1,6 +1,4 @@
 qcheck-rely › failing test
-<dim>expect.ext.qCheckTest(</dim><red>received</red><dim>)(</dim><green></green><dim>)</dim>
-
 QCheck test \"fail_sort_id\" failed
 
 generated input: 

--- a/tests/__snapshots__/qcheck_rely.a75930cc.0.snapshot
+++ b/tests/__snapshots__/qcheck_rely.a75930cc.0.snapshot
@@ -1,6 +1,4 @@
 qcheck-rely › simple failure test
-<dim>expect.ext.qCheckTest(</dim><red>received</red><dim>)(</dim><green></green><dim>)</dim>
-
 QCheck test \"fail_check_err_message\" failed
 
 generated input: 

--- a/tests/__snapshots__/qcheck_rely.c64dfd8b.0.snapshot
+++ b/tests/__snapshots__/qcheck_rely.c64dfd8b.0.snapshot
@@ -1,6 +1,4 @@
 qcheck-rely › error test
-<dim>expect.ext.qCheckTest(</dim><red>received</red><dim>)(</dim><green></green><dim>)</dim>
-
 QCheck test \"error_raise_exn\" failed with exception Error
 
 generated input: <red>0 (after 60 shrink steps)</red>


### PR DESCRIPTION
before: (extra "()" because of how matcher hint works )
expect.ext.qcheckTest(received)()

output after
![image](https://user-images.githubusercontent.com/5252755/57031758-6d876b00-6bfd-11e9-8eb9-19de15c0efca.png)

