### PR TITLE
result matchers

### DIFF
--- a/src/rely/matchers/DefaultMatchers.re
+++ b/src/rely/matchers/DefaultMatchers.re
@@ -34,6 +34,9 @@ type matchers('ext) = {
     MockMatchers.matchersWithNot('tupledArgs, 'ret),
 
   option: 'a. option('a) => OptionMatchers.optionMatchersWithNot('a),
+  result:
+    'a 'b.
+    result('a, 'b) => ResultMatchers.resultMatchersWithNot('a, 'b),
   ext: 'ext,
 };
 
@@ -79,6 +82,7 @@ module Make = (Mock: Mock.Sig) => {
     notSame: (expected, actual) =>
       SameMatcher.makeNotSameMatcher(".notSame", utils, expected, actual),
     option: o => OptionMatchers.makeMatchers(".option", utils, o),
+    result: r => ResultMatchers.makeMatchers(".result", utils, r),
     ext: makeMatchers(utils),
   };
 };

--- a/src/rely/matchers/ResultMatchers.re
+++ b/src/rely/matchers/ResultMatchers.re
@@ -1,0 +1,236 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+open MatcherTypes;
+
+type equalsFn('a) = ('a, 'a) => bool;
+
+type resultMatchers('a, 'b) = {
+  toBeOk: unit => unit,
+  toBeError: unit => unit,
+  toBe:
+    (
+      ~equalsOk: equalsFn('a)=?,
+      ~equalsError: equalsFn('b)=?,
+      result('a, 'b)
+    ) =>
+    unit,
+};
+
+type resultMatchersWithNot('a, 'b) = {
+  not: resultMatchers('a, 'b),
+  toBeOk: unit => unit,
+  toBeError: unit => unit,
+  toBe:
+    (
+      ~equalsOk: equalsFn('a)=?,
+      ~equalsError: equalsFn('b)=?,
+      result('a, 'b)
+    ) =>
+    unit,
+};
+
+let passMessageThunk = () => "";
+let defaultEqualityFn = (==);
+
+let printResult = res =>
+  switch (res) {
+  | Ok(v) => String.concat("", ["Ok(", PolymorphicPrint.print(v), ")"])
+  | Error(v) =>
+    String.concat("", ["Error(", PolymorphicPrint.print(v), ")"])
+  };
+
+let isOk = res =>
+  switch (res) {
+  | Ok(_) => true
+  | Error(_) => false
+  };
+
+let isError = res =>
+  switch (res) {
+  | Ok(_) => false
+  | Error(_) => true
+  };
+
+let makeMatchers = (accessorPath, {createMatcher}) => {
+  let createResultMatchers = actual => {
+    let toBe = isNot =>
+      createMatcher(
+        (
+          {matcherHint, formatReceived, formatExpected},
+          actualThunk,
+          expectedThunk,
+        ) => {
+        let actual = actualThunk();
+        let (equalsOk, equalsError, expected) = expectedThunk();
+        let actualEqualsExpected =
+          switch (actual, expected) {
+          | (Error(actual), Error(expected))
+              when equalsError(actual, expected) =>
+            true
+          | (Ok(actualValue), Ok(expectedValue))
+              when equalsOk(actualValue, expectedValue) =>
+            true
+          | (_, _) => false
+          };
+        let pass =
+          actualEqualsExpected && !isNot || !actualEqualsExpected && isNot;
+        if (!pass) {
+          let isUsingDefaultEquality =
+            isOk(actual) ?
+              equalsOk === defaultEqualityFn :
+              equalsError === defaultEqualityFn;
+          let displayEqualityMessage = isUsingDefaultEquality;
+          let message =
+            String.concat(
+              "",
+              [
+                matcherHint(
+                  ~expectType=accessorPath,
+                  ~matcherName=".toBe",
+                  ~isNot,
+                  ~options={
+                    comment: displayEqualityMessage ? Some("using ==") : None,
+                  },
+                  (),
+                ),
+                "\n\n",
+                "Expected: ",
+                formatExpected(printResult(expected)),
+                "\n",
+                "Received: ",
+                formatReceived(printResult(actual)),
+              ],
+            );
+          (() => message, pass);
+        } else {
+          (passMessageThunk, pass);
+        };
+      });
+
+    let toBeError = isNot =>
+      createMatcher(
+        (
+          {matcherHint, formatReceived, formatExpected},
+          actualThunk,
+          expectedThunk,
+        ) => {
+        let actual = actualThunk();
+        let actualIsError = isError(actual);
+        switch (actualIsError, isNot) {
+        | (true, false)
+        | (false, true) => (passMessageThunk, true)
+        | (false, false) =>
+          let message =
+            String.concat(
+              "",
+              [
+                matcherHint(
+                  ~expectType=accessorPath,
+                  ~matcherName=".toBeError",
+                  ~expected="",
+                  ~isNot,
+                  (),
+                ),
+                "\n\n",
+                "Expected value to be Error, but received: ",
+                formatReceived(printResult(actual)),
+              ],
+            );
+          ((() => message), false);
+        | (true, true) =>
+          let message =
+            String.concat(
+              "",
+              [
+                matcherHint(
+                  ~expectType=accessorPath,
+                  ~matcherName=".toBeError",
+                  ~expected="",
+                  ~isNot,
+                  (),
+                ),
+                "\n\n",
+                "Expected value to not be Error, but received: ",
+                formatReceived(printResult(actual)),
+              ],
+            );
+          ((() => message), false);
+        };
+      });
+
+    let toBeOk = isNot =>
+      createMatcher(
+        (
+          {matcherHint, formatReceived, formatExpected},
+          actualThunk,
+          expectedThunk,
+        ) => {
+        let actual = actualThunk();
+        let actualIsOk = isOk(actual);
+
+        switch (actualIsOk, isNot) {
+        | (true, false)
+        | (false, true) => (passMessageThunk, true)
+        | (false, false) =>
+          let message =
+            String.concat(
+              "",
+              [
+                matcherHint(
+                  ~expectType=accessorPath,
+                  ~matcherName=".toBeOk",
+                  ~expected="",
+                  ~isNot,
+                  (),
+                ),
+                "\n\n",
+                "Expected value to be Ok, but received: ",
+                formatReceived(printResult(actual)),
+              ],
+            );
+          ((() => message), false);
+        | (true, true) =>
+          let message =
+            String.concat(
+              "",
+              [
+                matcherHint(
+                  ~expectType=accessorPath,
+                  ~matcherName=".toBeOk",
+                  ~expected="",
+                  ~isNot,
+                  (),
+                ),
+                "\n\n",
+                "Expected value to not be Ok, but received: ",
+                formatReceived(printResult(actual)),
+              ],
+            );
+          ((() => message), false);
+        };
+      });
+    let makeResultMatchers = isNot => {
+      toBe:
+        (
+          ~equalsOk=defaultEqualityFn,
+          ~equalsError=defaultEqualityFn,
+          expected,
+        ) =>
+        toBe(isNot, () => actual, () => (equalsOk, equalsError, expected)),
+      toBeError: () => toBeError(isNot, () => actual, () => ()),
+      toBeOk: () => toBeOk(isNot, () => actual, () => ()),
+    };
+    let resultMatchers = makeResultMatchers(false);
+    {
+      not: makeResultMatchers(true),
+      toBe: resultMatchers.toBe,
+      toBeError: resultMatchers.toBeError,
+      toBeOk: resultMatchers.toBeOk,
+    };
+  };
+  createResultMatchers;
+};

--- a/tests/__snapshots__/result_matchers_failing_output.0acd6e65.0.snapshot
+++ b/tests/__snapshots__/result_matchers_failing_output.0acd6e65.0.snapshot
@@ -1,0 +1,5 @@
+result matchers › failing output › expect.result.toBe Ok(42) is Ok(41)
+<dim>expect.result(</dim><red>received</red><dim>).toBe(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected: <green>Ok(41)</green>
+Received: <red>Ok(42)</red>

--- a/tests/__snapshots__/result_matchers_failing_output.0e88aed0.0.snapshot
+++ b/tests/__snapshots__/result_matchers_failing_output.0e88aed0.0.snapshot
@@ -1,0 +1,4 @@
+result matchers › failing output › expect.result.not.toBeError
+<dim>expect.result(</dim><red>received</red><dim>).</dim>not<dim>.toBeError(</dim><green></green><dim>)</dim>
+
+Expected value to not be Error, but received: <red>Error(42)</red>

--- a/tests/__snapshots__/result_matchers_failing_output.19b7f49b.0.snapshot
+++ b/tests/__snapshots__/result_matchers_failing_output.19b7f49b.0.snapshot
@@ -1,0 +1,4 @@
+result matchers › failing output › expect.result.toBeOk Error is Ok
+<dim>expect.result(</dim><red>received</red><dim>).toBeOk(</dim><green></green><dim>)</dim>
+
+Expected value to be Ok, but received: <red>Error(42)</red>

--- a/tests/__snapshots__/result_matchers_failing_output.5eefb767.0.snapshot
+++ b/tests/__snapshots__/result_matchers_failing_output.5eefb767.0.snapshot
@@ -1,0 +1,5 @@
+result matchers › failing output › expect.result.toBe custom equals
+<dim>expect.result(</dim><red>received</red><dim>).toBe(</dim><green>expected</green><dim>)</dim>
+
+Expected: <green>Ok(42)</green>
+Received: <red>Ok(42)</red>

--- a/tests/__snapshots__/result_matchers_failing_output.70929fe9.0.snapshot
+++ b/tests/__snapshots__/result_matchers_failing_output.70929fe9.0.snapshot
@@ -1,0 +1,5 @@
+result matchers › failing output › expect.result.toBe Error is Ok
+<dim>expect.result(</dim><red>received</red><dim>).toBe(</dim><green>expected</green><dim>)</dim> <dim>/* using == */</dim>
+
+Expected: <green>Ok(failure :()</green>
+Received: <red>Error(failure :()</red>

--- a/tests/__snapshots__/result_matchers_failing_output.74a0bd31.0.snapshot
+++ b/tests/__snapshots__/result_matchers_failing_output.74a0bd31.0.snapshot
@@ -1,0 +1,4 @@
+result matchers › failing output › expect.result.not.toBeOk Ok(42) is not Ok
+<dim>expect.result(</dim><red>received</red><dim>).</dim>not<dim>.toBeOk(</dim><green></green><dim>)</dim>
+
+Expected value to not be Ok, but received: <red>Ok(42)</red>

--- a/tests/__snapshots__/result_matchers_failing_output.fa59e22e.0.snapshot
+++ b/tests/__snapshots__/result_matchers_failing_output.fa59e22e.0.snapshot
@@ -1,0 +1,4 @@
+result matchers › failing output › expect.result.toBeError
+<dim>expect.result(</dim><red>received</red><dim>).toBeError(</dim><green></green><dim>)</dim>
+
+Expected value to be Error, but received: <red>Ok(42)</red>

--- a/tests/__tests__/rely/OptionMatchers_test.re
+++ b/tests/__tests__/rely/OptionMatchers_test.re
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 open TestFramework;
 
 describe("option matchers", ({describe}) => {

--- a/tests/__tests__/rely/ResultMatchers_test.re
+++ b/tests/__tests__/rely/ResultMatchers_test.re
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 open TestFramework;
 
 describe("result matchers", ({describe}) => {

--- a/tests/__tests__/rely/ResultMatchers_test.re
+++ b/tests/__tests__/rely/ResultMatchers_test.re
@@ -1,0 +1,89 @@
+open TestFramework;
+
+describe("result matchers", ({describe}) => {
+  describe("passing output", ({test}) => {
+    test("expect.result.toBe Ok(42) is Ok(42)", ({expect}) =>
+      expect.result(Ok(42)).toBe(Ok(42))
+    );
+    test("expect.result.toBe Error(42) is Error(42)", ({expect}) =>
+      expect.result(Error(42)).toBe(Error(42))
+    );
+    test("expect.result.not.toBe Ok(42) is not Error(42)", ({expect}) =>
+      expect.result(Ok(42)).not.toBe(Error(42))
+    );
+    test("expect.result.not.toBe Error(42) is not Ok(42)", ({expect}) =>
+      expect.result(Error(42)).not.toBe(Ok(42))
+    );
+    test("expect.result.not.toBe Error(42) is not Ok('go')", ({expect}) =>
+      expect.result(Error(42)).not.toBe(Ok("go"))
+    );
+    test("expect.result.toBe custom equals", ({expect}) => {
+      let equalsOk = (f1, f2) => f1 -. f2 < 0.001;
+      expect.result(Ok(1.)).toBe(~equalsOk, Ok(1.000001));
+    });
+    test("expect.result.toBe custom equals", ({expect}) => {
+      let equalsError = (f1, f2) => f1 -. f2 < 0.001;
+      expect.result(Error(1.)).toBe(~equalsError, Error(1.000001));
+    });
+    test("expect.result.toBeError", ({expect}) =>
+      expect.result(Error(42)).toBeError()
+    );
+    test("expect.result.not.toBeError", ({expect}) =>
+      expect.result(Ok(42)).not.toBeError()
+    );
+    test("expect.result.toBeOk Ok(42) is Ok", ({expect}) =>
+      expect.result(Ok(42)).toBeOk()
+    );
+    test("expect.result.not.toBeOk Error is not Ok", ({expect}) =>
+      expect.result(Error(42)).not.toBeOk()
+    );
+  });
+
+  describe("failing output", ({test}) => {
+    test("expect.result.toBe Error is Ok", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils, ({expect}) =>
+        expect.result(Error("failure :(")).toBe(Ok("failure :("))
+      )
+    );
+    test("expect.result.toBe Ok(42) is Ok(41)", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils, ({expect}) =>
+        expect.result(Ok(42)).toBe(Ok(41))
+      )
+    );
+    test("expect.result.toBe custom equals", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils,
+        ({expect}) => {
+          let equalsOk = (_, _) => false;
+          expect.result(Ok(42)).toBe(~equalsOk, Ok(42));
+        },
+      )
+    );
+    test("expect.result.toBeError", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils, ({expect}) =>
+        expect.result(Ok(42)).toBeError()
+      )
+    );
+    test("expect.result.not.toBeError", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils, ({expect}) =>
+        expect.result(Error(42)).not.toBeError()
+      )
+    );
+    test("expect.result.toBeOk Error is Ok", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils, ({expect}) =>
+        expect.result(Error(42)).toBeOk()
+      )
+    );
+    test("expect.result.not.toBeOk Ok(42) is not Ok", testUtils =>
+      MatcherSnapshotTestRunner.snapshotFailingTestCase(
+        testUtils, ({expect}) =>
+        expect.result(Ok(42)).not.toBeOk()
+      )
+    );
+  });
+});


### PR DESCRIPTION
addresses https://github.com/facebookexperimental/reason-native/issues/150

```
type equalsFn('a) = ('a, 'a) => bool;

type resultMatchers('a, 'b) = {
  toBeOk: unit => unit,
  toBeError: unit => unit,
  toBe:
    (
      ~equalsOk: equalsFn('a)=?,
      ~equalsError: equalsFn('b)=?,
      result('a, 'b)
    ) =>
    unit,
};

type resultMatchersWithNot('a, 'b) = {
  not: resultMatchers('a, 'b),
  toBeOk: unit => unit,
  toBeError: unit => unit,
  toBe:
    (
      ~equalsOk: equalsFn('a)=?,
      ~equalsError: equalsFn('b)=?,
      result('a, 'b)
    ) =>
    unit,
};
```

![image](https://user-images.githubusercontent.com/5252755/57659194-500bb700-7596-11e9-8bca-991650b74d6a.png)
