### PR TITLE
Test lifecycle methods

### DIFF
--- a/src/rely/Describe.re
+++ b/src/rely/Describe.re
@@ -4,18 +4,19 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
-type describeUtils('ext) = {
-  describe: describeFn('ext),
-  describeSkip: describeFn('ext),
-  describeOnly: describeFn('ext),
-  test: Test.testFn('ext),
-  testSkip: Test.testFn('ext),
-  testOnly: Test.testFn('ext),
+type describeUtils('ext, 'env) = {
+  describe: describeFn('ext, 'env),
+  describeSkip: describeFn('ext, 'env),
+  describeOnly: describeFn('ext, 'env),
+  test: Test.testFn('ext, 'env),
+  testSkip: Test.testFn('ext, 'env),
+  testOnly: Test.testFn('ext, 'env),
 }
-and describeFn('ext) = (string, describeUtils('ext) => unit) => unit;
+and describeFn('ext, 'env) =
+  (string, describeUtils('ext, 'env) => unit) => unit;
 
-type extensionResult('ext) = {
-  describe: describeFn('ext),
-  describeSkip: describeFn('ext),
-  describeOnly: describeFn('ext),
+type extensionResult('ext, 'env) = {
+  describe: describeFn('ext, 'env),
+  describeSkip: describeFn('ext, 'env),
+  describeOnly: describeFn('ext, 'env),
 };

--- a/src/rely/RelyAPI.rei
+++ b/src/rely/RelyAPI.rei
@@ -201,7 +201,7 @@ module type TestFramework = {
     describeConfig('ext, 'env);
 
   let describeConfig: describeConfig(unit, unit);
-  [@Deprecated]
+  [@Deprecated "use describeConfig |> withCustomMatchers instead"]
   let extendDescribe:
     MatcherTypes.matchersExtensionFn('ext) => extensionResult('ext, unit);
 

--- a/src/rely/RelyAPI.rei
+++ b/src/rely/RelyAPI.rei
@@ -201,8 +201,11 @@ module type TestFramework = {
     describeConfig('ext, 'env);
 
   let describeConfig: describeConfig(unit, unit);
+  [@Deprecated]
   let extendDescribe:
-    describeConfig('ext, 'env) => extensionResult('ext, 'env);
+    MatcherTypes.matchersExtensionFn('ext) => extensionResult('ext, unit);
+
+  let build: describeConfig('ext, 'env) => extensionResult('ext, 'env);
 };
 
 type requiredConfiguration = TestFrameworkConfig.requiredConfiguration;

--- a/src/rely/RelyAPI.rei
+++ b/src/rely/RelyAPI.rei
@@ -14,6 +14,7 @@ include (module type of Test);
 
 /* maintained for backwards compatibility */
 module Describe = Describe;
+
 include (module type of Describe);
 
 module RunConfig: {
@@ -76,19 +77,126 @@ type combineResult = {
 
 let combine: list(testLibrary) => combineResult;
 
+open TestLifecycle;
 module type TestFramework = {
   module Mock: Mock.Sig;
   include (module type of Describe);
   include (module type of Test);
 
-  let describe: Describe.describeFn(unit);
-  let describeSkip: Describe.describeFn(unit);
-  let describeOnly: Describe.describeFn(unit);
-  let extendDescribe:
-    MatcherTypes.matchersExtensionFn('ext) => extensionResult('ext);
+  let describe: Describe.describeFn(unit, unit);
+  let describeSkip: Describe.describeFn(unit, unit);
+  let describeOnly: Describe.describeFn(unit, unit);
   let run: RunConfig.t => unit;
   let cli: unit => unit;
   let toLibrary: unit => testLibrary;
+  let testLifecycle:
+    TestLifecycle.t(
+      beforeAll(beforeAllNotCalled, unit),
+      afterAll(afterAllNotCalled, unit),
+      beforeEach(beforeEachNotCalled, unit, unit),
+      afterEach(afterEachNotCalled, unit),
+      unit,
+      unit,
+    );
+
+  let beforeAll:
+    (
+      unit => 'all,
+      TestLifecycle.t(
+        beforeAll(beforeAllNotCalled, 'oldAll),
+        afterAll(afterAllNotCalled, 'oldAll),
+        beforeEach(beforeEachNotCalled, 'oldAll, 'each),
+        afterEach(afterEachNotCalled, 'each),
+        'oldAll,
+        'each,
+      )
+    ) =>
+    TestLifecycle.t(
+      beforeAll(beforeAllCalled, 'all),
+      afterAll(afterAllNotCalled, 'all),
+      beforeEach(beforeEachNotCalled, 'all, 'all),
+      afterEach(afterEachNotCalled, 'all),
+      'all,
+      'all,
+    );
+
+  let afterAll:
+    (
+      'all => unit,
+      TestLifecycle.t(
+        beforeAll('beforeAllCalled, 'all),
+        afterAll(afterAllNotCalled, 'all),
+        beforeEach('beforeEachCalled, 'all, 'each),
+        afterEach('afterEachCalled, 'each),
+        'all,
+        'each,
+      )
+    ) =>
+    TestLifecycle.t(
+      beforeAll('beforeAllCalled, 'all),
+      afterAll(afterAllCalled, 'all),
+      beforeEach('beforeEachCalled, 'all, 'each),
+      afterEach('afterEachCalled, 'each),
+      'all,
+      'each,
+    );
+
+  let beforeEach:
+    (
+      'all => 'each,
+      TestLifecycle.t(
+        beforeAll('beforeAllCalled, 'all),
+        afterAll('afterAllCalled, 'all),
+        beforeEach(beforeEachNotCalled, 'all, 'oldEach),
+        afterEach(afterEachNotCalled, 'oldEach),
+        'all,
+        'oldEach,
+      )
+    ) =>
+    TestLifecycle.t(
+      beforeAll('beforeAllCalled, 'all),
+      afterAll('afterAllCalled, 'all),
+      beforeEach(beforeEachCalled, 'all, 'each),
+      afterEach(afterEachNotCalled, 'each),
+      'all,
+      'each,
+    );
+
+  let afterEach:
+    (
+      'each => unit,
+      TestLifecycle.t(
+        beforeAll('beforeAllCalled, 'all),
+        afterAll('afterAllCalled, 'all),
+        beforeEach('beforeEachCalled, 'all, 'each),
+        afterEach(afterEachNotCalled, 'each),
+        'all,
+        'each,
+      )
+    ) =>
+    TestLifecycle.t(
+      beforeAll('beforeAllCalled, 'all),
+      afterAll('afterAllCalled, 'all),
+      beforeEach('beforeEachCalled, 'all, 'each),
+      afterEach(afterEachCalled, 'each),
+      'all,
+      'each,
+    );
+
+  type describeConfig('ext, 'env);
+  let withLifecycle:
+    (
+      TestLifecycle.defaultLifecycle => TestLifecycle.t(_, _, _, _, _, 'env),
+      describeConfig('ext, unit)
+    ) =>
+    describeConfig('ext, 'env);
+  let withCustomMatchers:
+    (MatcherTypes.matchersExtensionFn('ext), describeConfig(unit, 'env)) =>
+    describeConfig('ext, 'env);
+
+  let describeConfig: describeConfig(unit, unit);
+  let extendDescribe:
+    describeConfig('ext, 'env) => extensionResult('ext, 'env);
 };
 
 type requiredConfiguration = TestFrameworkConfig.requiredConfiguration;

--- a/src/rely/RelyAPI.rei
+++ b/src/rely/RelyAPI.rei
@@ -90,6 +90,11 @@ module type TestFramework = {
   let cli: unit => unit;
   let toLibrary: unit => testLibrary;
   let testLifecycle: TestLifecycle.defaultLifecycle;
+  /**
+   * Executes before all tests in a test suite, the return value is passed to
+   * beforeEach if provided and is passed as the "env" field of the "test" record
+   * if beforeEach is not provided
+   */
   let beforeAll:
     (
       unit => 'all,
@@ -111,6 +116,9 @@ module type TestFramework = {
       'all,
     );
 
+  /**
+   * Takes the return of beforeAll (or unit) as input
+   */
   let afterAll:
     (
       'all => unit,
@@ -132,6 +140,10 @@ module type TestFramework = {
       'each,
     );
 
+  /**
+   * Takes the return of beforeAll (or unit) as input, the return value is
+   * passed as the "env" field of the record in the "test" function
+   */
   let beforeEach:
     (
       'all => 'each,
@@ -153,6 +165,9 @@ module type TestFramework = {
       'each,
     );
 
+  /**
+   * Takes the return of beforeEach (or unit) as input
+   */
   let afterEach:
     (
       'each => unit,

--- a/src/rely/RelyAPI.rei
+++ b/src/rely/RelyAPI.rei
@@ -89,33 +89,24 @@ module type TestFramework = {
   let run: RunConfig.t => unit;
   let cli: unit => unit;
   let toLibrary: unit => testLibrary;
-  let testLifecycle:
-    TestLifecycle.t(
-      beforeAll(beforeAllNotCalled, unit),
-      afterAll(afterAllNotCalled, unit),
-      beforeEach(beforeEachNotCalled, unit, unit),
-      afterEach(afterEachNotCalled, unit),
-      unit,
-      unit,
-    );
-
+  let testLifecycle: TestLifecycle.defaultLifecycle;
   let beforeAll:
     (
       unit => 'all,
       TestLifecycle.t(
-        beforeAll(beforeAllNotCalled, 'oldAll),
-        afterAll(afterAllNotCalled, 'oldAll),
-        beforeEach(beforeEachNotCalled, 'oldAll, 'each),
-        afterEach(afterEachNotCalled, 'each),
+        beforeAllNotCalled,
+        afterAllNotCalled,
+        beforeEachNotCalled,
+        afterEachNotCalled,
         'oldAll,
         'each,
       )
     ) =>
     TestLifecycle.t(
-      beforeAll(beforeAllCalled, 'all),
-      afterAll(afterAllNotCalled, 'all),
-      beforeEach(beforeEachNotCalled, 'all, 'all),
-      afterEach(afterEachNotCalled, 'all),
+      beforeAllCalled,
+      afterAllNotCalled,
+      beforeEachNotCalled,
+      afterEachNotCalled,
       'all,
       'all,
     );
@@ -124,19 +115,19 @@ module type TestFramework = {
     (
       'all => unit,
       TestLifecycle.t(
-        beforeAll('beforeAllCalled, 'all),
-        afterAll(afterAllNotCalled, 'all),
-        beforeEach('beforeEachCalled, 'all, 'each),
-        afterEach('afterEachCalled, 'each),
+        'beforeAllCalled,
+        afterAllNotCalled,
+        'beforeEachCalled,
+        'afterEachCalled,
         'all,
         'each,
       )
     ) =>
     TestLifecycle.t(
-      beforeAll('beforeAllCalled, 'all),
-      afterAll(afterAllCalled, 'all),
-      beforeEach('beforeEachCalled, 'all, 'each),
-      afterEach('afterEachCalled, 'each),
+      'beforeAllCalled,
+      afterAllCalled,
+      'beforeEachCalled,
+      'afterEachCalled,
       'all,
       'each,
     );
@@ -145,19 +136,19 @@ module type TestFramework = {
     (
       'all => 'each,
       TestLifecycle.t(
-        beforeAll('beforeAllCalled, 'all),
-        afterAll('afterAllCalled, 'all),
-        beforeEach(beforeEachNotCalled, 'all, 'oldEach),
-        afterEach(afterEachNotCalled, 'oldEach),
+        'beforeAllCalled,
+        'afterAllCalled,
+        beforeEachNotCalled,
+        afterEachNotCalled,
         'all,
         'oldEach,
       )
     ) =>
     TestLifecycle.t(
-      beforeAll('beforeAllCalled, 'all),
-      afterAll('afterAllCalled, 'all),
-      beforeEach(beforeEachCalled, 'all, 'each),
-      afterEach(afterEachNotCalled, 'each),
+      'beforeAllCalled,
+      'afterAllCalled,
+      beforeEachCalled,
+      afterEachNotCalled,
       'all,
       'each,
     );
@@ -166,19 +157,19 @@ module type TestFramework = {
     (
       'each => unit,
       TestLifecycle.t(
-        beforeAll('beforeAllCalled, 'all),
-        afterAll('afterAllCalled, 'all),
-        beforeEach('beforeEachCalled, 'all, 'each),
-        afterEach(afterEachNotCalled, 'each),
+        'beforeAllCalled,
+        'afterAllCalled,
+        'beforeEachCalled,
+        afterEachNotCalled,
         'all,
         'each,
       )
     ) =>
     TestLifecycle.t(
-      beforeAll('beforeAllCalled, 'all),
-      afterAll('afterAllCalled, 'all),
-      beforeEach('beforeEachCalled, 'all, 'each),
-      afterEach(afterEachCalled, 'each),
+      'beforeAllCalled,
+      'afterAllCalled,
+      'beforeEachCalled,
+      afterEachCalled,
       'all,
       'each,
     );

--- a/src/rely/Test.re
+++ b/src/rely/Test.re
@@ -4,5 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
-type testUtils('ext) = {expect: DefaultMatchers.matchers('ext)};
-type testFn('ext) = (string, testUtils('ext) => unit) => unit;
+type testUtils('ext, 'env) = {
+  expect: DefaultMatchers.matchers('ext),
+  env: 'env,
+};
+type testFn('ext, 'env) = (string, testUtils('ext, 'env) => unit) => unit;

--- a/src/rely/TestFramework.re
+++ b/src/rely/TestFramework.re
@@ -41,32 +41,24 @@ module type TestFramework = {
   let run: RunConfig.t => unit;
   let cli: unit => unit;
   let toLibrary: unit => testLibrary;
-  let testLifecycle:
-    TestLifecycle.t(
-      beforeAll(beforeAllNotCalled, unit),
-      afterAll(afterAllNotCalled, unit),
-      beforeEach(beforeEachNotCalled, unit, unit),
-      afterEach(afterEachNotCalled, unit),
-      unit,
-      unit,
-    );
+  let testLifecycle: TestLifecycle.defaultLifecycle;
   let beforeAll:
     (
       unit => 'all,
       TestLifecycle.t(
-        beforeAll(beforeAllNotCalled, 'oldAll),
-        afterAll(afterAllNotCalled, 'oldAll),
-        beforeEach(beforeEachNotCalled, 'oldAll, 'each),
-        afterEach(afterEachNotCalled, 'each),
+        beforeAllNotCalled,
+        afterAllNotCalled,
+        beforeEachNotCalled,
+        afterEachNotCalled,
         'oldAll,
         'each,
       )
     ) =>
     TestLifecycle.t(
-      beforeAll(beforeAllCalled, 'all),
-      afterAll(afterAllNotCalled, 'all),
-      beforeEach(beforeEachNotCalled, 'all, 'all),
-      afterEach(afterEachNotCalled, 'all),
+      beforeAllCalled,
+      afterAllNotCalled,
+      beforeEachNotCalled,
+      afterEachNotCalled,
       'all,
       'all,
     );
@@ -75,19 +67,19 @@ module type TestFramework = {
     (
       'all => unit,
       TestLifecycle.t(
-        beforeAll('beforeAllCalled, 'all),
-        afterAll(afterAllNotCalled, 'all),
-        beforeEach('beforeEachCalled, 'all, 'each),
-        afterEach('afterEachCalled, 'each),
+        'beforeAllCalled,
+        afterAllNotCalled,
+        'beforeEachCalled,
+        'afterEachCalled,
         'all,
         'each,
       )
     ) =>
     TestLifecycle.t(
-      beforeAll('beforeAllCalled, 'all),
-      afterAll(afterAllCalled, 'all),
-      beforeEach('beforeEachCalled, 'all, 'each),
-      afterEach('afterEachCalled, 'each),
+      'beforeAllCalled,
+      afterAllCalled,
+      'beforeEachCalled,
+      'afterEachCalled,
       'all,
       'each,
     );
@@ -96,19 +88,19 @@ module type TestFramework = {
     (
       'all => 'each,
       TestLifecycle.t(
-        beforeAll('beforeAllCalled, 'all),
-        afterAll('afterAllCalled, 'all),
-        beforeEach(beforeEachNotCalled, 'all, 'oldEach),
-        afterEach(afterEachNotCalled, 'oldEach),
+        'beforeAllCalled,
+        'afterAllCalled,
+        beforeEachNotCalled,
+        afterEachNotCalled,
         'all,
         'oldEach,
       )
     ) =>
     TestLifecycle.t(
-      beforeAll('beforeAllCalled, 'all),
-      afterAll('afterAllCalled, 'all),
-      beforeEach(beforeEachCalled, 'all, 'each),
-      afterEach(afterEachNotCalled, 'each),
+      'beforeAllCalled,
+      'afterAllCalled,
+      beforeEachCalled,
+      afterEachNotCalled,
       'all,
       'each,
     );
@@ -117,19 +109,19 @@ module type TestFramework = {
     (
       'each => unit,
       TestLifecycle.t(
-        beforeAll('beforeAllCalled, 'all),
-        afterAll('afterAllCalled, 'all),
-        beforeEach('beforeEachCalled, 'all, 'each),
-        afterEach(afterEachNotCalled, 'each),
+        'beforeAllCalled,
+        'afterAllCalled,
+        'beforeEachCalled,
+        afterEachNotCalled,
         'all,
         'each,
       )
     ) =>
     TestLifecycle.t(
-      beforeAll('beforeAllCalled, 'all),
-      afterAll('afterAllCalled, 'all),
-      beforeEach('beforeEachCalled, 'all, 'each),
-      afterEach(afterEachCalled, 'each),
+      'beforeAllCalled,
+      'afterAllCalled,
+      'beforeEachCalled,
+      afterEachCalled,
       'all,
       'each,
     );

--- a/src/rely/TestFramework.re
+++ b/src/rely/TestFramework.re
@@ -139,7 +139,8 @@ module type TestFramework = {
 
   let describeConfig: describeConfig(unit, unit);
   let extendDescribe:
-    describeConfig('ext, 'env) => extensionResult('ext, 'env);
+  MatcherTypes.matchersExtensionFn('ext) => extensionResult('ext, unit);
+  let build: describeConfig('ext, 'env) => extensionResult('ext, 'env);
 };
 
 module type FrameworkConfig = {let config: TestFrameworkConfig.t;};
@@ -239,8 +240,10 @@ module MakeInternal =
 
   let describeConfig =
     DescribeConfig({extensionFn: _ => (), lifecycle: TestLifecycle.default});
-  let extendDescribe = (DescribeConfig({extensionFn, lifecycle})) =>
+  let build = (DescribeConfig({extensionFn, lifecycle})) =>
     makeDescribeFns(lifecycle, extensionFn);
+  let extendDescribe = makeCustomMatchers =>
+    makeDescribeFns(testLifecycle, makeCustomMatchers);
 
   let run = (config: RunConfig.t) =>
     TestSuiteRunner.run(config, testSuites^);

--- a/src/rely/TestLifecycle.re
+++ b/src/rely/TestLifecycle.re
@@ -14,11 +14,6 @@ type beforeEachNotCalled;
 type afterEachCalled;
 type afterEachNotCalled;
 
-type beforeAll('kind, 'ret);
-type afterAll('kind, 'arg);
-type beforeEach('kind, 'arg, 'ret);
-type afterEach('kind, 'arg);
-
 type t('beforeAll, 'afterAll, 'beforeEach, 'afterEach, 'all, 'each) = {
   beforeAll: unit => 'all,
   afterAll: 'all => unit,
@@ -28,23 +23,15 @@ type t('beforeAll, 'afterAll, 'beforeEach, 'afterEach, 'all, 'each) = {
 
 type defaultLifecycle =
   t(
-    beforeAll(beforeAllNotCalled, unit),
-    afterAll(afterAllNotCalled, unit),
-    beforeEach(beforeEachNotCalled, unit, unit),
-    afterEach(afterEachNotCalled, unit),
+    beforeAllNotCalled,
+    afterAllNotCalled,
+    beforeEachNotCalled,
+    afterEachNotCalled,
     unit,
     unit,
   );
 
-let default:
-  t(
-    beforeAll(beforeAllNotCalled, unit),
-    afterAll(afterAllNotCalled, unit),
-    beforeEach(beforeEachNotCalled, unit, unit),
-    afterEach(afterEachNotCalled, unit),
-    unit,
-    unit,
-  ) = {
+let default: defaultLifecycle = {
   beforeAll: () => (),
   afterAll: () => (),
   beforeEach: () => (),
@@ -56,19 +43,19 @@ let beforeAll:
     (
       unit => all,
       t(
-        beforeAll(beforeAllNotCalled, oldAll),
-        afterAll(afterAllNotCalled, oldAll),
-        beforeEach(beforeEachNotCalled, oldAll, each),
-        afterEach(afterEachNotCalled, each),
+        beforeAllNotCalled,
+        afterAllNotCalled,
+        beforeEachNotCalled,
+        afterEachNotCalled,
         oldAll,
         each,
       )
     ) =>
     t(
-      beforeAll(beforeAllCalled, all),
-      afterAll(afterAllNotCalled, all),
-      beforeEach(beforeEachNotCalled, all, all),
-      afterEach(afterEachNotCalled, all),
+      beforeAllCalled,
+      afterAllNotCalled,
+      beforeEachNotCalled,
+      afterEachNotCalled,
       all,
       all,
     ) =
@@ -83,19 +70,19 @@ let afterAll:
     (
       all => unit,
       t(
-        beforeAll(a, all),
-        afterAll(afterAllNotCalled, all),
-        beforeEach(b, all, each),
-        afterEach(c, each),
+        a,
+        afterAllNotCalled,
+        b,
+        c,
         all,
         each,
       )
     ) =>
     t(
-      beforeAll(a, all),
-      afterAll(afterAllCalled, all),
-      beforeEach(b, all, each),
-      afterEach(c, each),
+      a,
+      afterAllCalled,
+      b,
+      c,
       all,
       each,
     ) =
@@ -110,19 +97,19 @@ let beforeEach:
     (
       all => each,
       t(
-        beforeAll(a, all),
-        afterAll(b, all),
-        beforeEach(beforeEachNotCalled, all, oldEach),
-        afterEach(afterEachNotCalled, oldEach),
+        a,
+        b,
+        beforeEachNotCalled,
+        afterEachNotCalled,
         all,
         oldEach,
       )
     ) =>
     t(
-      beforeAll(a, all),
-      afterAll(b, all),
-      beforeEach(beforeEachCalled, all, each),
-      afterEach(afterEachNotCalled, each),
+      a,
+      b,
+      beforeEachCalled,
+      afterEachNotCalled,
       all,
       each,
     ) =
@@ -138,19 +125,19 @@ let afterEach:
     (
       each => unit,
       t(
-        beforeAll(a, all),
-        afterAll(b, all),
-        beforeEach(c, all, each),
-        afterEach(afterEachNotCalled, each),
+        a,
+        b,
+        c,
+        afterEachNotCalled,
         all,
         each,
       )
     ) =>
     t(
-      beforeAll(a, all),
-      afterAll(b, all),
-      beforeEach(c, all, each),
-      afterEach(afterEachCalled, each),
+      a,
+      b,
+      c,
+      afterEachCalled,
       all,
       each,
     ) =

--- a/src/rely/TestLifecycle.re
+++ b/src/rely/TestLifecycle.re
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+
+type beforeAllCalled;
+type beforeAllNotCalled;
+type afterAllCalled;
+type afterAllNotCalled;
+type beforeEachCalled;
+type beforeEachNotCalled;
+type afterEachCalled;
+type afterEachNotCalled;
+
+type beforeAll('kind, 'ret);
+type afterAll('kind, 'arg);
+type beforeEach('kind, 'arg, 'ret);
+type afterEach('kind, 'arg);
+
+type t('beforeAll, 'afterAll, 'beforeEach, 'afterEach, 'all, 'each) = {
+  beforeAll: unit => 'all,
+  afterAll: 'all => unit,
+  beforeEach: 'all => 'each,
+  afterEach: 'each => unit,
+};
+
+type defaultLifecycle =
+  t(
+    beforeAll(beforeAllNotCalled, unit),
+    afterAll(afterAllNotCalled, unit),
+    beforeEach(beforeEachNotCalled, unit, unit),
+    afterEach(afterEachNotCalled, unit),
+    unit,
+    unit,
+  );
+
+let default:
+  t(
+    beforeAll(beforeAllNotCalled, unit),
+    afterAll(afterAllNotCalled, unit),
+    beforeEach(beforeEachNotCalled, unit, unit),
+    afterEach(afterEachNotCalled, unit),
+    unit,
+    unit,
+  ) = {
+  beforeAll: () => (),
+  afterAll: () => (),
+  beforeEach: () => (),
+  afterEach: () => (),
+};
+
+let beforeAll:
+  type all oldAll each.
+    (
+      unit => all,
+      t(
+        beforeAll(beforeAllNotCalled, oldAll),
+        afterAll(afterAllNotCalled, oldAll),
+        beforeEach(beforeEachNotCalled, oldAll, each),
+        afterEach(afterEachNotCalled, each),
+        oldAll,
+        each,
+      )
+    ) =>
+    t(
+      beforeAll(beforeAllCalled, all),
+      afterAll(afterAllNotCalled, all),
+      beforeEach(beforeEachNotCalled, all, all),
+      afterEach(afterEachNotCalled, all),
+      all,
+      all,
+    ) =
+  (beforeAll, setup) => {
+    beforeAll,
+    afterAll: _ => (),
+    beforeEach: all => all,
+    afterEach: _ => (),
+  };
+let afterAll:
+  type a b c all each.
+    (
+      all => unit,
+      t(
+        beforeAll(a, all),
+        afterAll(afterAllNotCalled, all),
+        beforeEach(b, all, each),
+        afterEach(c, each),
+        all,
+        each,
+      )
+    ) =>
+    t(
+      beforeAll(a, all),
+      afterAll(afterAllCalled, all),
+      beforeEach(b, all, each),
+      afterEach(c, each),
+      all,
+      each,
+    ) =
+  (afterAll, setup) => {
+    beforeAll: setup.beforeAll,
+    afterAll,
+    beforeEach: setup.beforeEach,
+    afterEach: setup.afterEach,
+  };
+let beforeEach:
+  type a b all each oldEach.
+    (
+      all => each,
+      t(
+        beforeAll(a, all),
+        afterAll(b, all),
+        beforeEach(beforeEachNotCalled, all, oldEach),
+        afterEach(afterEachNotCalled, oldEach),
+        all,
+        oldEach,
+      )
+    ) =>
+    t(
+      beforeAll(a, all),
+      afterAll(b, all),
+      beforeEach(beforeEachCalled, all, each),
+      afterEach(afterEachNotCalled, each),
+      all,
+      each,
+    ) =
+  (beforeEach, setup) => {
+    beforeAll: setup.beforeAll,
+    afterAll: setup.afterAll,
+    beforeEach,
+    afterEach: _ => (),
+  };
+
+let afterEach:
+  type a b c all each.
+    (
+      each => unit,
+      t(
+        beforeAll(a, all),
+        afterAll(b, all),
+        beforeEach(c, all, each),
+        afterEach(afterEachNotCalled, each),
+        all,
+        each,
+      )
+    ) =>
+    t(
+      beforeAll(a, all),
+      afterAll(b, all),
+      beforeEach(c, all, each),
+      afterEach(afterEachCalled, each),
+      all,
+      each,
+    ) =
+  (afterEach, setup) => {
+    beforeAll: setup.beforeAll,
+    afterAll: setup.afterAll,
+    beforeEach: setup.beforeEach,
+    afterEach,
+  };

--- a/src/rely/dune
+++ b/src/rely/dune
@@ -10,6 +10,7 @@
     (public_name rely.internal)
     (libraries pastel.lib file-context-printer.lib unix junit re)
     (modules (:standard \ Rely))
+    (flags (:standard -w -30-9))
 )
 (copy_files# ../../shared-src/common/*)
 ; objectPrinter lives separately from Common for now because Common has an

--- a/tests/__tests__/path/Path_test.re
+++ b/tests/__tests__/path/Path_test.re
@@ -83,7 +83,7 @@ let customMatchers = extendUtils => {
 };
 
 let describe =
-  (describeConfig |> withCustomMatchers(customMatchers) |> extendDescribe).
+  (describeConfig |> withCustomMatchers(customMatchers) |> build).
     describe;
 
 describe("Path", ({test}) => {

--- a/tests/__tests__/path/Path_test.re
+++ b/tests/__tests__/path/Path_test.re
@@ -82,7 +82,9 @@ let customMatchers = extendUtils => {
     PathMatchers.makeAbsolutePathMatchers(".ext.path", path, extendUtils),
 };
 
-let describe = extendDescribe(customMatchers).describe;
+let describe =
+  (describeConfig |> withCustomMatchers(customMatchers) |> extendDescribe).
+    describe;
 
 describe("Path", ({test}) => {
   test("Basic creation", ({expect}) => {
@@ -693,7 +695,8 @@ describe("Path", ({test}) => {
     let res = isDescendent(~ofPath=At.(root), At.(root / "x" / "y"));
     expect.bool(res).toBeTrue();
 
-    let res = isDescendent(~ofPath=At.(Path.drive("C")), At.(root / "x" / "y"));
+    let res =
+      isDescendent(~ofPath=At.(Path.drive("C")), At.(root / "x" / "y"));
     expect.bool(res).toBeFalse();
   });
 

--- a/tests/__tests__/qcheck-rely/QCheckRely_test.re
+++ b/tests/__tests__/qcheck-rely/QCheckRely_test.re
@@ -10,7 +10,7 @@ open QCheckRely;
 let {describe, _} =
   describeConfig
   |> withCustomMatchers(QCheckRely.Matchers.matchers)
-  |> extendDescribe;
+  |> build;
 
 let seed = Random.State.make([|42|]);
 

--- a/tests/__tests__/qcheck-rely/QCheckRely_test.re
+++ b/tests/__tests__/qcheck-rely/QCheckRely_test.re
@@ -7,7 +7,10 @@
 open TestFramework;
 open QCheckRely;
 
-let {describe, _} = extendDescribe(QCheckRely.Matchers.matchers);
+let {describe, _} =
+  describeConfig
+  |> withCustomMatchers(QCheckRely.Matchers.matchers)
+  |> extendDescribe;
 
 let seed = Random.State.make([|42|]);
 

--- a/tests/__tests__/rely/AggregateResult_test.re
+++ b/tests/__tests__/rely/AggregateResult_test.re
@@ -15,7 +15,7 @@ type singleSuiteInput = {
 
 type multipleSuiteInput = {
   name: string,
-  testSuites: list(TestSuiteBuilder.t),
+  testSuites: list(TestSuiteBuilder.testSuite),
 };
 
 type singleSuiteExpectedOutput = {
@@ -221,6 +221,7 @@ describe("Rely AggregateResult", ({describe, test}) => {
               |> withSkippedTests(input.numSkippedTests)
               |> withPassingTests(input.numPassingTests)
               |> withFailingTests(input.numFailingTests)
+              |> build
             ),
           ];
           module Reporter =
@@ -255,11 +256,11 @@ describe("Rely AggregateResult", ({describe, test}) => {
   });
   describe("Multiple suite cases", ({test}) => {
     let singletonPassingTestSuite =
-      TestSuiteBuilder.(init("passing") |> withPassingTests(1));
+      TestSuiteBuilder.(init("passing") |> withPassingTests(1) |> build);
     let singletonFailingTestSuite =
-      TestSuiteBuilder.(init("failing") |> withFailingTests(1));
+      TestSuiteBuilder.(init("failing") |> withFailingTests(1) |> build);
     let singletonSkippedTestSuite =
-      TestSuiteBuilder.(init("skipped") |> withSkippedTests(1));
+      TestSuiteBuilder.(init("skipped") |> withSkippedTests(1) |> build);
 
     let repeatHelper = (el, n, l) =>
       switch (n) {
@@ -408,6 +409,7 @@ describe("Rely AggregateResult", ({describe, test}) => {
               |> withPassingTests(input.numPassingTests)
               |> withFailingTests(input.numFailingTests)
               |> skipSuite
+              |> build
             ),
           ];
 
@@ -459,10 +461,13 @@ describe("Rely AggregateResult", ({describe, test}) => {
           |> withFailingTests(3)
           |> withSkippedTests(1)
           |> skipSuite
-          |> withNestedTestSuite(
-               ~child=
-                 init("child") |> withPassingTests(2) |> withFailingTests(4),
+          |> withNestedTestSuite(~child= c =>
+               c
+               |> withName("child")
+               |> withPassingTests(2)
+               |> withFailingTests(4)
              )
+          |> build
         );
       module Reporter =
         TestReporter.Make({});

--- a/tests/__tests__/rely/ArrayMatchers_test.re
+++ b/tests/__tests__/rely/ArrayMatchers_test.re
@@ -6,10 +6,11 @@ module ArrayMatchersTests =
     RelyInternal.ArrayMatchers.Array,
     {
       type t('a) = array('a);
-      type matchersWithNot('a) = RelyInternal.ArrayMatchers.matchersWithNot('a);
+      type matchersWithNot('a) =
+        RelyInternal.ArrayMatchers.matchersWithNot('a);
       let ofList = Array.of_list;
       let expectPath:
-        (Rely.Test.testUtils('a), t('b)) => matchersWithNot('b) =
+        (Rely.Test.testUtils('a, 'env), t('b)) => matchersWithNot('b) =
         t => t.expect.array;
       let collectionName = "array";
     },

--- a/tests/__tests__/rely/CollectionMatchersTest.re
+++ b/tests/__tests__/rely/CollectionMatchersTest.re
@@ -12,7 +12,8 @@ module type TestConfiguration = {
   type t('a);
   type matchersWithNot('a);
   let ofList: list('a) => t('a);
-  let expectPath: (Rely.Test.testUtils('a), t('b)) => matchersWithNot('b);
+  let expectPath:
+    (Rely.Test.testUtils('a, 'env), t('b)) => matchersWithNot('b);
 };
 
 type defaultEqualityTestCase =
@@ -43,7 +44,9 @@ module Make =
            TestConfiguration with
              type t('a) = Collection.t('a) and
              type matchersWithNot('a) =
-               RelyInternal.CollectionMatchers.Make(Collection).matchersWithNot('a),
+               RelyInternal.CollectionMatchers.Make(Collection).matchersWithNot(
+                 'a,
+               ),
        ) => {
   let collectionName = Collection.collectionName;
   describe(

--- a/tests/__tests__/rely/CustomMatchers_test.re
+++ b/tests/__tests__/rely/CustomMatchers_test.re
@@ -232,7 +232,8 @@ module User = {
  */
 open User;
 
-let {describe} = extendDescribe(User.Test.matchers);
+let {describe} =
+  describeConfig |> withCustomMatchers(User.Test.matchers) |> extendDescribe;
 
 /* Alice is a Facebook user with string data. */
 let alice = {
@@ -317,7 +318,11 @@ module Account = {
  * necessary to combine the custom matchers and use them within the same
  * describe block.
  */
-let {describe} = extendDescribe(Account.Test.matchers);
+let {describe} =
+  describeConfig
+  |> withCustomMatchers(Account.Test.matchers)
+  |> withLifecycle(l => l |> beforeAll(() => 42))
+  |> extendDescribe;
 
 describe("Separate type of Custom Matchers", ({test}) => {
   test("Alice tests", ({expect}) => {
@@ -352,7 +357,8 @@ module Combined = {
 };
 
 /* Use the combined matchers */
-let {describe} = extendDescribe(Combined.matchers);
+let {describe} =
+  describeConfig |> withCustomMatchers(Combined.matchers) |> extendDescribe;
 
 describe("Combined Custom Matchers", ({test}) => {
   test("Alice tests", ({expect}) => {

--- a/tests/__tests__/rely/CustomMatchers_test.re
+++ b/tests/__tests__/rely/CustomMatchers_test.re
@@ -233,7 +233,7 @@ module User = {
 open User;
 
 let {describe} =
-  describeConfig |> withCustomMatchers(User.Test.matchers) |> extendDescribe;
+  describeConfig |> withCustomMatchers(User.Test.matchers) |> build;
 
 /* Alice is a Facebook user with string data. */
 let alice = {
@@ -322,7 +322,7 @@ let {describe} =
   describeConfig
   |> withCustomMatchers(Account.Test.matchers)
   |> withLifecycle(l => l |> beforeAll(() => 42))
-  |> extendDescribe;
+  |> build;
 
 describe("Separate type of Custom Matchers", ({test}) => {
   test("Alice tests", ({expect}) => {
@@ -358,7 +358,7 @@ module Combined = {
 
 /* Use the combined matchers */
 let {describe} =
-  describeConfig |> withCustomMatchers(Combined.matchers) |> extendDescribe;
+  describeConfig |> withCustomMatchers(Combined.matchers) |> build;
 
 describe("Combined Custom Matchers", ({test}) => {
   test("Alice tests", ({expect}) => {

--- a/tests/__tests__/rely/ListMatchers_test.re
+++ b/tests/__tests__/rely/ListMatchers_test.re
@@ -6,10 +6,11 @@ module ListMatchersTests =
     RelyInternal.ListMatchers.List,
     {
       type t('a) = list('a);
-      type matchersWithNot('a) = RelyInternal.ListMatchers.matchersWithNot('a);
+      type matchersWithNot('a) =
+        RelyInternal.ListMatchers.matchersWithNot('a);
       let ofList = l => l;
       let expectPath:
-        (Rely.Test.testUtils('a), t('b)) => matchersWithNot('b) =
+        (Rely.Test.testUtils('a, 'env), t('b)) => matchersWithNot('b) =
         t => t.expect.list;
       let collectionName = "list";
     },

--- a/tests/__tests__/rely/MatcherSnapshotTestRunner.re
+++ b/tests/__tests__/rely/MatcherSnapshotTestRunner.re
@@ -54,7 +54,7 @@ let snapshotFailingTestCaseCustomMatchers =
     TestFramework.(
       describeConfig
       |> withCustomMatchers(createCustomMatchers)
-      |> extendDescribe
+      |> build
     );
 
   describe("unused, doesn't matter", ({test}) =>

--- a/tests/__tests__/rely/MatcherSnapshotTestRunner.re
+++ b/tests/__tests__/rely/MatcherSnapshotTestRunner.re
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */;
 
-let runInternal = (run, testUtils: Rely.Test.testUtils('ext)) => {
+let runInternal = (run, testUtils: Rely.Test.testUtils('ext, 'env)) => {
   module Reporter =
     TestReporter.Make({});
 
@@ -39,7 +39,7 @@ let runInternal = (run, testUtils: Rely.Test.testUtils('ext)) => {
 let snapshotFailingTestCaseCustomMatchers =
     (
       createCustomMatchers: Rely.MatcherTypes.matchersExtensionFn('ext),
-      testUtils: Rely.Test.testUtils('ext),
+      testUtils: Rely.Test.testUtils('ext, 'env),
       testBody,
     ) => {
   module TestFramework =
@@ -50,7 +50,12 @@ let snapshotFailingTestCaseCustomMatchers =
         );
     });
   open Rely.Describe;
-  let {describe} = TestFramework.extendDescribe(createCustomMatchers);
+  let {describe} =
+    TestFramework.(
+      describeConfig
+      |> withCustomMatchers(createCustomMatchers)
+      |> extendDescribe
+    );
 
   describe("unused, doesn't matter", ({test}) =>
     test("not used", testBody)
@@ -60,7 +65,7 @@ let snapshotFailingTestCaseCustomMatchers =
 };
 
 let snapshotFailingTestCase =
-    (testUtils: Rely.Test.testUtils('ext), testBody) => {
+    (testUtils: Rely.Test.testUtils('ext, 'env), testBody) => {
   module TestFramework =
     Rely.Make({
       let config =

--- a/tests/__tests__/rely/Only_test.re
+++ b/tests/__tests__/rely/Only_test.re
@@ -18,7 +18,10 @@ describe("Rely .only", ({test}) => {
     let testResult = ref(None);
     let testSuite =
       TestSuiteBuilder.(
-        init("") |> withPassingTests(~only=true, 1) |> withPassingTests(1)
+        init("")
+        |> withPassingTests(~only=true, 1)
+        |> withPassingTests(1)
+        |> build
       );
     module Reporter =
       TestReporter.Make({});
@@ -34,8 +37,9 @@ describe("Rely .only", ({test}) => {
   test("Only suites with only should be run", ({expect}) => {
     let testResult = ref(None);
     let onlyTestSuite =
-      TestSuiteBuilder.(init("") |> withPassingTests(2) |> only);
-    let normalTestSuite = TestSuiteBuilder.(init("") |> withPassingTests(3));
+      TestSuiteBuilder.(init("") |> withPassingTests(2) |> only |> build);
+    let normalTestSuite =
+      TestSuiteBuilder.(init("") |> withPassingTests(3) |> build);
     module Reporter =
       TestReporter.Make({});
     Reporter.onRunComplete(r => testResult := Some(r));
@@ -51,9 +55,14 @@ describe("Rely .only", ({test}) => {
     let testResult = ref(None);
     let onlyTestSuite =
       TestSuiteBuilder.(
-        init("") |> withSkippedTests(2) |> withPassingTests(1) |> only
+        init("")
+        |> withSkippedTests(2)
+        |> withPassingTests(1)
+        |> only
+        |> build
       );
-    let normalTestSuite = TestSuiteBuilder.(init("") |> withPassingTests(3));
+    let normalTestSuite =
+      TestSuiteBuilder.(init("") |> withPassingTests(3) |> build);
     module Reporter =
       TestReporter.Make({});
     Reporter.onRunComplete(r => testResult := Some(r));
@@ -73,17 +82,22 @@ describe("Rely .only", ({test}) => {
         init("contains nested")
         |> withSkippedTests(2)
         |> withPassingTests(1)
-        |> withNestedTestSuite(
-             ~child=TestSuiteBuilder.init("nested") |> withPassingTests(1) |> only,
+        |> withNestedTestSuite(~child=c =>
+             c |> withName("nested") |> withPassingTests(1) |> only
            )
+        |> build
       );
-    let normalTestSuite = TestSuiteBuilder.(init("normal") |> withPassingTests(3));
+    let normalTestSuite =
+      TestSuiteBuilder.(init("normal") |> withPassingTests(3) |> build);
 
     module Reporter =
       TestReporter.Make({});
     Reporter.onRunComplete(r => testResult := Some(r));
 
-    TestSuiteRunner.run([nestedOnlyTestSuite, normalTestSuite], Reporter.reporter);
+    TestSuiteRunner.run(
+      [nestedOnlyTestSuite, normalTestSuite],
+      Reporter.reporter,
+    );
     let result = valuex(testResult^);
 
     expect.int(result.numSkippedTests).toBe(6);
@@ -97,18 +111,26 @@ describe("Rely .only", ({test}) => {
         init("contains nested")
         |> withSkippedTests(2)
         |> withPassingTests(1)
-        |> withNestedTestSuite(
-             ~child=TestSuiteBuilder.init("nested") |> withPassingTests(1, ~only=true),
+        |> withNestedTestSuite(~child=c =>
+             c |> withName("nested") |> withPassingTests(1, ~only=true)
            )
+        |> build
       );
-    let normalTestSuite = TestSuiteBuilder.(init("normal") |> withPassingTests(3));
+    let normalTestSuite =
+      TestSuiteBuilder.(init("normal") |> withPassingTests(3) |> build);
 
-    expect.fn(() => TestSuiteRunner.runWithCustomConfig([nestedOnlyTestSuite, normalTestSuite], Rely.RunConfig.(
-      initialize()
-      |> withReporters([])
-      |> ciMode(true)
-      |> onTestFrameworkFailure(() => ())
-    ))).toThrow();
+    expect.fn(() =>
+      TestSuiteRunner.runWithCustomConfig(
+        [nestedOnlyTestSuite, normalTestSuite],
+        Rely.RunConfig.(
+          initialize()
+          |> withReporters([])
+          |> ciMode(true)
+          |> onTestFrameworkFailure(() => ())
+        ),
+      )
+    ).
+      toThrow();
   });
 
   test("CI mode should throw an exception with describeOnly", ({expect}) => {
@@ -117,17 +139,25 @@ describe("Rely .only", ({test}) => {
         init("contains nested")
         |> withSkippedTests(2)
         |> withPassingTests(1)
-        |> withNestedTestSuite(
-             ~child=TestSuiteBuilder.init("nested") |> withPassingTests(1) |> only,
+        |> withNestedTestSuite(~child=c =>
+             c |> withName("nested") |> withPassingTests(1) |> only
            )
+        |> build
       );
-    let normalTestSuite = TestSuiteBuilder.(init("normal") |> withPassingTests(3));
+    let normalTestSuite =
+      TestSuiteBuilder.(init("normal") |> withPassingTests(3) |> build);
 
-    expect.fn(() => TestSuiteRunner.runWithCustomConfig([nestedOnlyTestSuite, normalTestSuite], Rely.RunConfig.(
-      initialize()
-      |> withReporters([])
-      |> ciMode(true)
-      |> onTestFrameworkFailure(() => ())
-    ))).toThrow();
+    expect.fn(() =>
+      TestSuiteRunner.runWithCustomConfig(
+        [nestedOnlyTestSuite, normalTestSuite],
+        Rely.RunConfig.(
+          initialize()
+          |> withReporters([])
+          |> ciMode(true)
+          |> onTestFrameworkFailure(() => ())
+        ),
+      )
+    ).
+      toThrow();
   });
 });

--- a/tests/__tests__/rely/TestFrameworkBuilder.re
+++ b/tests/__tests__/rely/TestFrameworkBuilder.re
@@ -6,7 +6,7 @@
  */;
 
 type testFrameworkBuilder = {
-  testSuites: list(TestSuiteBuilder.t),
+  testSuites: list(TestSuiteBuilder.testSuite),
   snapshotDir: string,
   projectDir: string,
 };
@@ -33,14 +33,17 @@ module Build =
           projectDir: builder.projectDir,
         });
     });
+  module TestSuiteRegisterer = TestSuiteBuilder.Make(TestFramework);
 
   builder.testSuites
-  |> List.map(TestSuiteBuilder.toFunction)
+  |> List.map((TestSuiteBuilder.TestSuite(suite)) =>
+       TestSuiteRegisterer.register(suite)
+     )
   |> List.iter(ts =>
        ts(
          ~describe=TestFramework.describe,
          ~describeSkip=TestFramework.describeSkip,
-         ~describeOnly=TestFramework.describeOnly
+         ~describeOnly=TestFramework.describeOnly,
        )
      );
   include TestFramework;

--- a/tests/__tests__/rely/TestLibrary_test.re
+++ b/tests/__tests__/rely/TestLibrary_test.re
@@ -53,9 +53,11 @@ describe("Rely Test Library", ({test}) => {
             builder
             |> withTestSuite(
                  TestSuiteBuilder.(
-                   init("test suite")
-                   |> withPassingTests(2)
-                   |> withFailingTests(1)
+                   TestSuite(
+                     init("test suite")
+                     |> withPassingTests(2)
+                     |> withFailingTests(1),
+                   )
                  ),
                );
         });
@@ -81,6 +83,7 @@ describe("Rely Test Library", ({test}) => {
                    init("test suite")
                    |> withPassingTests(2)
                    |> withFailingTests(1)
+                   |> build
                  ),
                );
         });
@@ -94,6 +97,7 @@ describe("Rely Test Library", ({test}) => {
                    init("test suite")
                    |> withPassingTests(5)
                    |> withFailingTests(2)
+                   |> build
                  ),
                );
         });
@@ -107,6 +111,7 @@ describe("Rely Test Library", ({test}) => {
                    init("test suite")
                    |> withPassingTests(2)
                    |> withFailingTests(3)
+                   |> build
                  ),
                );
         });
@@ -133,6 +138,7 @@ describe("Rely Test Library", ({test}) => {
                  init("test suite")
                  |> withPassingTests(2)
                  |> withFailingTests(1)
+                 |> build
                ),
              );
       });
@@ -146,6 +152,7 @@ describe("Rely Test Library", ({test}) => {
                  init("test suite")
                  |> withPassingTests(5)
                  |> withFailingTests(2)
+                 |> build
                ),
              );
       });
@@ -159,6 +166,7 @@ describe("Rely Test Library", ({test}) => {
                  init("test suite")
                  |> withPassingTests(2)
                  |> withFailingTests(3)
+                 |> build
                ),
              );
       });

--- a/tests/__tests__/rely/TestLifecycle_test.re
+++ b/tests/__tests__/rely/TestLifecycle_test.re
@@ -29,7 +29,7 @@ describe("test lifecycle methods", ({test}) => {
       TestFrameworkInternal.(
         describeConfig
         |> withLifecycle(l => l |> beforeAll(Mock.fn(beforeAllMock)))
-        |> extendDescribe
+        |> build
       );
 
     describe("beforeAll with no other methods", ({test, describe}) => {
@@ -88,7 +88,7 @@ describe("test lifecycle methods", ({test}) => {
                |> beforeAll(() => uniqueInstance)
                |> afterAll(Mock.fn(afterAllMock))
              )
-          |> extendDescribe
+          |> build
         );
 
       describe(
@@ -122,7 +122,7 @@ describe("test lifecycle methods", ({test}) => {
         TestFrameworkInternal.(
           describeConfig
           |> withLifecycle(l => l |> beforeEach(Mock.fn(beforeEachMock)))
-          |> extendDescribe
+          |> build
         );
 
       describe(
@@ -166,7 +166,7 @@ describe("test lifecycle methods", ({test}) => {
              |> beforeEach(Mock.fn(beforeEachMock))
              |> afterEach(Mock.fn(afterEachMock))
            )
-        |> extendDescribe
+        |> build
       );
 
     describe(
@@ -291,7 +291,7 @@ describe("test lifecycle methods", ({test}) => {
              |> afterEach(Mock.fn(afterEachMock))
              |> afterAll(Mock.fn(afterAllMock))
            )
-        |> extendDescribe
+        |> build
       );
 
     describe("afterEach and afterAll should be called", ({test}) =>

--- a/tests/__tests__/rely/TestLifecycle_test.re
+++ b/tests/__tests__/rely/TestLifecycle_test.re
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+
+open TestFramework;
+
+type testRecord = {foo: int};
+let uniqueInstance = {foo: 42};
+let executeTestFramework = runFn =>
+  runFn(
+    Rely.RunConfig.(
+      initialize() |> withReporters([]) |> onTestFrameworkFailure(() => ())
+    ),
+  );
+
+describe("test lifecycle methods", ({test}) => {
+  test(
+    "env should be equal to ret of beforeAll if no beforeEach", ({expect}) => {
+    module TestFrameworkInternal =
+      TestFrameworkBuilder.Build({
+        let action = a => a;
+      });
+    let beforeAllMock = Mock.mock1(() => uniqueInstance);
+    let expectExternal = expect;
+    let {describe} =
+      TestFrameworkInternal.(
+        describeConfig
+        |> withLifecycle(l => l |> beforeAll(Mock.fn(beforeAllMock)))
+        |> extendDescribe
+      );
+
+    describe("beforeAll with no other methods", ({test, describe}) => {
+      test("should bind env to ret of beforeAll", ({env}) =>
+        expectExternal.equal(env, uniqueInstance)
+      );
+      describe("nested describe", ({test}) =>
+        test("should bind env to ret of beforeAll", ({env, expect}) =>
+          expectExternal.equal(env, uniqueInstance)
+        )
+      );
+    });
+    executeTestFramework(TestFrameworkInternal.run);
+  });
+  test("before all should be called exactly once", ({expect}) => {
+    let beforeAllMock = Mock.mock1(() => uniqueInstance);
+    module TestFrameworkInternal =
+      TestFrameworkBuilder.Build({
+        let action =
+          TestFrameworkBuilder.(
+            a =>
+              a
+              |> withTestSuite(
+                   TestSuiteBuilder.(
+                     init("my test suite")
+                     |> withLifecycle(l =>
+                          l |> beforeAll(Mock.fn(beforeAllMock))
+                        )
+                     |> withPassingTests(3)
+                     |> withFailingTests(2)
+                     |> withNestedTestSuite(~child=c =>
+                          c |> withPassingTests(2)
+                        )
+                     |> build
+                   ),
+                 )
+          );
+      });
+    executeTestFramework(TestFrameworkInternal.run);
+    expect.mock(beforeAllMock).toBeCalledTimes(1);
+  });
+  test(
+    "afterAll should be called once after all tests in the describe with the value returned by beforeAll",
+    ({expect}) => {
+      module TestFrameworkInternal =
+        TestFrameworkBuilder.Build({
+          let action = a => a;
+        });
+      let afterAllMock = Mock.mock1(_ => ());
+      let expectExternal = expect;
+      let {describe} =
+        TestFrameworkInternal.(
+          describeConfig
+          |> withLifecycle(l =>
+               l
+               |> beforeAll(() => uniqueInstance)
+               |> afterAll(Mock.fn(afterAllMock))
+             )
+          |> extendDescribe
+        );
+
+      describe(
+        "afterAll should not be called in this suite", ({test, describe}) => {
+        test("after all should not be called", ({env}) =>
+          expectExternal.mock(afterAllMock).not.toBeCalled()
+        );
+        describe("nested describe", ({test}) =>
+          test(
+            "after all should not be called in a nested test",
+            ({env, expect}) =>
+            expectExternal.mock(afterAllMock).not.toBeCalled()
+          )
+        );
+      });
+      executeTestFramework(TestFrameworkInternal.run);
+      expectExternal.mock(afterAllMock).toBeCalledWith(uniqueInstance);
+      expectExternal.mock(afterAllMock).toBeCalled();
+    },
+  );
+  test(
+    "before each should be called once before each test in the describe with the value returned by the call",
+    ({expect}) => {
+      let beforeEachMock = Mock.mock1(() => uniqueInstance);
+      module TestFrameworkInternal =
+        TestFrameworkBuilder.Build({
+          let action = a => a;
+        });
+      let expectExternal = expect;
+      let {describe} =
+        TestFrameworkInternal.(
+          describeConfig
+          |> withLifecycle(l => l |> beforeEach(Mock.fn(beforeEachMock)))
+          |> extendDescribe
+        );
+
+      describe(
+        "beforeEach should be called before each test in this suite",
+        ({test, describe}) => {
+        test(
+          "before each should be called and equla to ret of beforeEach",
+          ({env}) => {
+          expectExternal.mock(beforeEachMock).toBeCalledTimes(1);
+          expectExternal.equal(uniqueInstance, env);
+          Mock.resetHistory(beforeEachMock);
+        });
+        describe("nested suite", ({test}) =>
+          test(
+            "before each should still be called and be equal to ret of beforeEach",
+            ({env}) => {
+            expectExternal.mock(beforeEachMock).toBeCalledTimes(1);
+            expectExternal.equal(uniqueInstance, env);
+            Mock.resetHistory(beforeEachMock);
+          })
+        );
+      });
+      executeTestFramework(TestFrameworkInternal.run);
+    },
+  );
+  test(
+    "after each should be called once after each test in the describe",
+    ({expect}) => {
+    module TestFrameworkInternal =
+      TestFrameworkBuilder.Build({
+        let action = a => a;
+      });
+    let beforeEachMock = Mock.mock1(() => uniqueInstance);
+    let afterEachMock = Mock.mock1(_ => Mock.resetHistory(beforeEachMock));
+    let expectExternal = expect;
+    let {describe} =
+      TestFrameworkInternal.(
+        describeConfig
+        |> withLifecycle(l =>
+             l
+             |> beforeEach(Mock.fn(beforeEachMock))
+             |> afterEach(Mock.fn(afterEachMock))
+           )
+        |> extendDescribe
+      );
+
+    describe(
+      "afterEach should reset beforeEachMock so it only claims to be called once",
+      ({test, describe}) => {
+        test(
+          "before each should be called once as it should have been reset or not been called",
+          ({env}) => {
+            expectExternal.mock(beforeEachMock).toBeCalledTimes(1);
+            ();
+          },
+        );
+        test(
+          "before each should be called once as it should have been reset or not been called",
+          ({env}) => {
+            expectExternal.mock(beforeEachMock).toBeCalledTimes(1);
+            ();
+          },
+        );
+        describe("nested suite", ({test}) => {
+          test(
+            "before each should be called once as it should have been reset or not been called",
+            ({env}) => {
+              expectExternal.mock(beforeEachMock).toBeCalledTimes(1);
+              ();
+            },
+          );
+          test(
+            "before each should be called once as it should have been reset or not been called",
+            ({env}) => {
+              expectExternal.mock(beforeEachMock).toBeCalledTimes(1);
+              ();
+            },
+          );
+        });
+      },
+    );
+    executeTestFramework(TestFrameworkInternal.run);
+    expect.mock(afterEachMock).toBeCalledTimes(4);
+    ();
+  });
+  test("ret of beforeAll passed as arg to beforeEach", ({expect}) => {
+    let beforeAllMock = Mock.mock1(() => uniqueInstance);
+    module TestFrameworkInternal =
+      TestFrameworkBuilder.Build({
+        let action =
+          TestFrameworkBuilder.(
+            a =>
+              a
+              |> withTestSuite(
+                   TestSuiteBuilder.(
+                     init("my test suite")
+                     |> withLifecycle(l =>
+                          l
+                          |> beforeAll(Mock.fn(beforeAllMock))
+                          |> beforeEach(arg => {
+                               expect.equal(arg, uniqueInstance);
+                               ();
+                             })
+                        )
+                     |> withPassingTests(3)
+                     |> withFailingTests(2)
+                     |> withNestedTestSuite(~child=c =>
+                          c |> withPassingTests(2)
+                        )
+                     |> build
+                   ),
+                 )
+          );
+      });
+    executeTestFramework(TestFrameworkInternal.run);
+    /*ensure inner framework actually ran*/
+    expect.mock(beforeAllMock).toBeCalledTimes(1);
+  });
+  test("ret of beforeEach passed as arg to afterEach", ({expect}) => {
+    let beforeEachMock = Mock.mock1(() => uniqueInstance);
+    module TestFrameworkInternal =
+      TestFrameworkBuilder.Build({
+        let action =
+          TestFrameworkBuilder.(
+            a =>
+              a
+              |> withTestSuite(
+                   TestSuiteBuilder.(
+                     init("my test suite")
+                     |> withLifecycle(l =>
+                          l
+                          |> beforeEach(Mock.fn(beforeEachMock))
+                          |> afterEach(arg => {
+                               expect.equal(arg, uniqueInstance);
+                               ();
+                             })
+                        )
+                     |> withPassingTests(3)
+                     |> withFailingTests(2)
+                     |> withNestedTestSuite(~child=c =>
+                          c |> withPassingTests(2)
+                        )
+                     |> build
+                   ),
+                 )
+          );
+      });
+    executeTestFramework(TestFrameworkInternal.run);
+    /*ensure inner framework actually ran*/
+    expect.mock(beforeEachMock).toBeCalledTimes(7);
+  });
+  test(
+    "exception in test, afterEach, afterAll should still be called",
+    ({expect}) => {
+    let afterEachMock = Mock.mock1(() => ());
+    let afterAllMock = Mock.mock1(() => ());
+    module TestFrameworkInternal =
+      TestFrameworkBuilder.Build({
+        let action = a => a;
+      });
+    let {describe} =
+      TestFrameworkInternal.(
+        describeConfig
+        |> withLifecycle(l =>
+             l
+             |> afterEach(Mock.fn(afterEachMock))
+             |> afterAll(Mock.fn(afterAllMock))
+           )
+        |> extendDescribe
+      );
+
+    describe("afterEach and afterAll should be called", ({test}) =>
+      test("error", _ =>
+        raise(Not_found)
+      )
+    );
+    executeTestFramework(TestFrameworkInternal.run);
+    expect.mock(afterEachMock).toBeCalled();
+    expect.mock(afterAllMock).toBeCalled();
+    ();
+  });
+});

--- a/tests/__tests__/rely/TestResultLocation_test.re
+++ b/tests/__tests__/rely/TestResultLocation_test.re
@@ -6,7 +6,8 @@
  */;
 open TestFramework;
 
-let runTest = (testUtils: Rely.Test.testUtils('ext), expected, testBody) => {
+let runTest =
+    (testUtils: Rely.Test.testUtils('ext, 'env), expected, testBody) => {
   module TestFramework =
     Rely.Make({
       let config =
@@ -15,7 +16,7 @@ let runTest = (testUtils: Rely.Test.testUtils('ext), expected, testBody) => {
         );
     });
 
-  TestFramework.describe("unused, doesn't matter", ({test}) =>{
+  TestFramework.describe("unused, doesn't matter", ({test}) => {
     test("not used", testBody);
     ();
   });
@@ -46,18 +47,12 @@ let runTest = (testUtils: Rely.Test.testUtils('ext), expected, testBody) => {
       |> withReporters([Custom(Reporter.reporter)])
       |> onTestFrameworkFailure(() => ())
     ),
-  )
+  );
 };
 
 describe("Filename should be persisted in test result", ({test}) => {
-  test("captured filename should equal __FILE__", testUtils => {
-    runTest(
-      testUtils,
-      __FILE__,
-      ({expect}) => {
-        expect.bool(true).toBeTrue();
-      },
-    );
-  });
+  test("captured filename should equal __FILE__", testUtils =>
+    runTest(testUtils, __FILE__, ({expect}) => expect.bool(true).toBeTrue())
+  );
   ();
 });

--- a/tests/__tests__/rely/TestSuiteBuilder.re
+++ b/tests/__tests__/rely/TestSuiteBuilder.re
@@ -37,28 +37,14 @@ type builderConfig('ext, 'env) =
     : builderConfig('ext, unit)
   | BuilderConfigWithLifecycle(
       string,
-      RelyInternal.TestLifecycle.t(
-        beforeAll(beforeAllNotCalled, unit),
-        afterAll(afterAllNotCalled, unit),
-        beforeEach(beforeEachNotCalled, unit, unit),
-        afterEach(afterEachNotCalled, unit),
-        unit,
-        unit,
-      ) =>
+      RelyInternal.TestLifecycle.defaultLifecycle =>
       RelyInternal.TestLifecycle.t(_, _, _, _, _, 'env),
     )
     : builderConfig(unit, 'env)
   | BuilderConfigWithLifecycleAndCustomMatchers(
       string,
       Rely.MatcherTypes.matchersExtensionFn('ext),
-      RelyInternal.TestLifecycle.t(
-        beforeAll(beforeAllNotCalled, unit),
-        afterAll(afterAllNotCalled, unit),
-        beforeEach(beforeEachNotCalled, unit, unit),
-        afterEach(afterEachNotCalled, unit),
-        unit,
-        unit,
-      ) =>
+      RelyInternal.TestLifecycle.defaultLifecycle =>
       RelyInternal.TestLifecycle.t(_, _, _, _, _, 'env),
     )
     : builderConfig('ext, 'env);
@@ -81,14 +67,7 @@ and t('ext, 'env, 'describeConfigState) =
   | WithLifecycleAndCustomMatchers{
       config: testSuiteConfig('ext, 'env),
       testLifecycleFactory:
-        RelyInternal.TestLifecycle.t(
-          beforeAll(beforeAllNotCalled, unit),
-          afterAll(afterAllNotCalled, unit),
-          beforeEach(beforeEachNotCalled, unit, unit),
-          afterEach(afterEachNotCalled, unit),
-          unit,
-          unit,
-        ) =>
+        RelyInternal.TestLifecycle.defaultLifecycle =>
         RelyInternal.TestLifecycle.t('a, 'b, 'c, 'd, 'e, 'env),
       customMatchers: Rely.MatcherTypes.matchersExtensionFn('ext),
     }
@@ -96,14 +75,7 @@ and t('ext, 'env, 'describeConfigState) =
   | WithLifecycle{
       config: testSuiteConfig(unit, 'env),
       testLifecycleFactory:
-        RelyInternal.TestLifecycle.t(
-          beforeAll(beforeAllNotCalled, unit),
-          afterAll(afterAllNotCalled, unit),
-          beforeEach(beforeEachNotCalled, unit, unit),
-          afterEach(afterEachNotCalled, unit),
-          unit,
-          unit,
-        ) =>
+        RelyInternal.TestLifecycle.defaultLifecycle =>
         RelyInternal.TestLifecycle.t('a, 'b, 'c, 'd, 'e, 'env),
     }
     : t(unit, 'env, describeConfigFinalized)
@@ -119,14 +91,7 @@ type testSuite =
 let withLifecycle:
   type ext env a.
     (
-      RelyInternal.TestLifecycle.t(
-        beforeAll(beforeAllNotCalled, unit),
-        afterAll(afterAllNotCalled, unit),
-        beforeEach(beforeEachNotCalled, unit, unit),
-        afterEach(afterEachNotCalled, unit),
-        unit,
-        unit,
-      ) =>
+      RelyInternal.TestLifecycle.defaultLifecycle =>
       RelyInternal.TestLifecycle.t(_, _, _, _, _, env),
       t(ext, a, describeConfigNotFinalized)
     ) =>

--- a/tests/__tests__/rely/TestSuiteBuilder.re
+++ b/tests/__tests__/rely/TestSuiteBuilder.re
@@ -393,7 +393,7 @@ module Make = (TestFramework: Rely.TestFramework) => {
             describeConfig
             |> withCustomMatchers(customMatchers)
             |> withLifecycle(testLifecycleFactory)
-            |> extendDescribe
+            |> build
           );
         register(config, describe, describeSkip, describeOnly);
       | WithLifecycle({testLifecycleFactory}) =>
@@ -401,7 +401,7 @@ module Make = (TestFramework: Rely.TestFramework) => {
           TestFramework.(
             describeConfig
             |> withLifecycle(testLifecycleFactory)
-            |> extendDescribe
+            |> build
           );
         register(config, describe, describeSkip, describeOnly);
       | WithCustomMatchers({customMatchers}) =>
@@ -409,7 +409,7 @@ module Make = (TestFramework: Rely.TestFramework) => {
           TestFramework.(
             describeConfig
             |> withCustomMatchers(customMatchers)
-            |> extendDescribe
+            |> build
           );
         register(config, describe, describeSkip, describeOnly);
       };

--- a/tests/__tests__/rely/TestSuiteBuilder.re
+++ b/tests/__tests__/rely/TestSuiteBuilder.re
@@ -4,94 +4,449 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
+
 type mode =
   | Only
   | Normal
   | Skip;
 
-type test = {
+type customTest('ext, 'env) = {
   mode,
-  pass: bool,
-};
-
-type t = {
-  tests: list(test),
-  nestedSuites: list(t),
   name: string,
-  mode,
+  implementation: Rely.Test.testUtils('ext, 'env) => unit,
 };
 
-let init = name => {tests: [], nestedSuites: [], name, mode: Normal};
+type test('ext, 'env) =
+  | Simple{
+      mode,
+      pass: bool,
+    }
+    : test('a, 'b)
+  | Custom(customTest('ext, 'env)): test('ext, 'env);
 
-let withNestedTestSuite: (~child: t, t) => t =
-  (~child, parent) => {
-    ...parent,
-    nestedSuites: parent.nestedSuites @ [child],
+open RelyInternal.TestLifecycle;
+type describeConfigFinalized;
+type describeConfigNotFinalized;
+
+type builderConfig('ext, 'env) =
+  | SimpleBuilderConfig(string): builderConfig(unit, unit)
+  | BuilderConfigWithCustomMatchers(
+      string,
+      Rely.MatcherTypes.matchersExtensionFn('ext),
+    )
+    : builderConfig('ext, unit)
+  | BuilderConfigWithLifecycle(
+      string,
+      RelyInternal.TestLifecycle.t(
+        beforeAll(beforeAllNotCalled, unit),
+        afterAll(afterAllNotCalled, unit),
+        beforeEach(beforeEachNotCalled, unit, unit),
+        afterEach(afterEachNotCalled, unit),
+        unit,
+        unit,
+      ) =>
+      RelyInternal.TestLifecycle.t(_, _, _, _, _, 'env),
+    )
+    : builderConfig(unit, 'env)
+  | BuilderConfigWithLifecycleAndCustomMatchers(
+      string,
+      Rely.MatcherTypes.matchersExtensionFn('ext),
+      RelyInternal.TestLifecycle.t(
+        beforeAll(beforeAllNotCalled, unit),
+        afterAll(afterAllNotCalled, unit),
+        beforeEach(beforeEachNotCalled, unit, unit),
+        afterEach(afterEachNotCalled, unit),
+        unit,
+        unit,
+      ) =>
+      RelyInternal.TestLifecycle.t(_, _, _, _, _, 'env),
+    )
+    : builderConfig('ext, 'env);
+
+type testSuiteConfig('ext, 'env) =
+  | TestSuiteConfig{
+      tests: list(test('ext, 'env)),
+      nestedSuites: list(t('ext, 'env, describeConfigFinalized)),
+      name: string,
+      mode,
+    }
+    : testSuiteConfig('ext, 'env)
+and t('ext, 'env, 'describeConfigState) =
+  | Unfinalized(builderConfig('ext, 'env))
+    : t('ext, 'env, describeConfigNotFinalized)
+  | Simple(testSuiteConfig(unit, unit))
+    : t(unit, unit, describeConfigFinalized)
+  | Child(testSuiteConfig('ext, 'env))
+    : t('ext, 'env, describeConfigFinalized)
+  | WithLifecycleAndCustomMatchers{
+      config: testSuiteConfig('ext, 'env),
+      testLifecycleFactory:
+        RelyInternal.TestLifecycle.t(
+          beforeAll(beforeAllNotCalled, unit),
+          afterAll(afterAllNotCalled, unit),
+          beforeEach(beforeEachNotCalled, unit, unit),
+          afterEach(afterEachNotCalled, unit),
+          unit,
+          unit,
+        ) =>
+        RelyInternal.TestLifecycle.t('a, 'b, 'c, 'd, 'e, 'env),
+      customMatchers: Rely.MatcherTypes.matchersExtensionFn('ext),
+    }
+    : t('ext, 'env, describeConfigFinalized)
+  | WithLifecycle{
+      config: testSuiteConfig(unit, 'env),
+      testLifecycleFactory:
+        RelyInternal.TestLifecycle.t(
+          beforeAll(beforeAllNotCalled, unit),
+          afterAll(afterAllNotCalled, unit),
+          beforeEach(beforeEachNotCalled, unit, unit),
+          afterEach(afterEachNotCalled, unit),
+          unit,
+          unit,
+        ) =>
+        RelyInternal.TestLifecycle.t('a, 'b, 'c, 'd, 'e, 'env),
+    }
+    : t(unit, 'env, describeConfigFinalized)
+  | WithCustomMatchers{
+      config: testSuiteConfig('ext, unit),
+      customMatchers: Rely.MatcherTypes.matchersExtensionFn('ext),
+    }
+    : t('ext, unit, describeConfigFinalized);
+
+type testSuite =
+  | TestSuite(t('ext, 'env, 'describeConfigState)): testSuite;
+
+let withLifecycle:
+  type ext env a.
+    (
+      RelyInternal.TestLifecycle.t(
+        beforeAll(beforeAllNotCalled, unit),
+        afterAll(afterAllNotCalled, unit),
+        beforeEach(beforeEachNotCalled, unit, unit),
+        afterEach(afterEachNotCalled, unit),
+        unit,
+        unit,
+      ) =>
+      RelyInternal.TestLifecycle.t(_, _, _, _, _, env),
+      t(ext, a, describeConfigNotFinalized)
+    ) =>
+    t(ext, env, describeConfigNotFinalized) =
+  (testLifecycleFactory, Unfinalized(config)) =>
+    Unfinalized(
+      switch (config) {
+      | BuilderConfigWithLifecycle(name, _) =>
+        BuilderConfigWithLifecycle(name, testLifecycleFactory)
+      | SimpleBuilderConfig(name) =>
+        BuilderConfigWithLifecycle(name, testLifecycleFactory)
+      | BuilderConfigWithCustomMatchers(name, customMatchers) =>
+        BuilderConfigWithLifecycleAndCustomMatchers(
+          name,
+          customMatchers,
+          testLifecycleFactory,
+        )
+      | BuilderConfigWithLifecycleAndCustomMatchers(name, customMatchers, _) =>
+        BuilderConfigWithLifecycleAndCustomMatchers(
+          name,
+          customMatchers,
+          testLifecycleFactory,
+        )
+      },
+    );
+
+let withCustomMatchers:
+  type ext env a.
+    (
+      Rely.MatcherTypes.matchersExtensionFn(ext),
+      t(a, env, describeConfigNotFinalized)
+    ) =>
+    t(ext, env, describeConfigNotFinalized) =
+  (customMatchers, Unfinalized(config)) =>
+    Unfinalized(
+      switch (config) {
+      | BuilderConfigWithCustomMatchers(name, _) =>
+        BuilderConfigWithCustomMatchers(name, customMatchers)
+      | SimpleBuilderConfig(name) =>
+        BuilderConfigWithCustomMatchers(name, customMatchers)
+      | BuilderConfigWithLifecycle(name, testLifecycleFactory) =>
+        BuilderConfigWithLifecycleAndCustomMatchers(
+          name,
+          customMatchers,
+          testLifecycleFactory,
+        )
+      | BuilderConfigWithLifecycleAndCustomMatchers(
+          name,
+          _,
+          testLifecycleFactory,
+        ) =>
+        BuilderConfigWithLifecycleAndCustomMatchers(
+          name,
+          customMatchers,
+          testLifecycleFactory,
+        )
+      },
+    );
+let finalizeUnfinalized:
+  type ext env.
+    t(ext, env, describeConfigNotFinalized) =>
+    t(ext, env, describeConfigFinalized) =
+  (Unfinalized(builderConfig)) => {
+    let makeConfig = name =>
+      TestSuiteConfig({tests: [], nestedSuites: [], name, mode: Normal});
+    switch (builderConfig) {
+    | SimpleBuilderConfig(name) => Simple(makeConfig(name))
+    | BuilderConfigWithCustomMatchers(name, customMatchers) =>
+      WithCustomMatchers({config: makeConfig(name), customMatchers})
+    | BuilderConfigWithLifecycle(name, testLifecycleFactory) =>
+      WithLifecycle({config: makeConfig(name), testLifecycleFactory})
+    | BuilderConfigWithLifecycleAndCustomMatchers(
+        name,
+        customMatchers,
+        testLifecycleFactory,
+      ) =>
+      WithLifecycleAndCustomMatchers({
+        config: makeConfig(name),
+        customMatchers,
+        testLifecycleFactory,
+      })
+    };
+  };
+let finalize:
+  type ext env finalized.
+    t(ext, env, finalized) => t(ext, env, describeConfigFinalized) =
+  config => {
+    switch (config) {
+    | Unfinalized(_) => finalizeUnfinalized(config)
+    | Simple(_) => config
+    | Child(_) => config
+    | WithLifecycle(_) => config
+    | WithCustomMatchers(_) => config
+    | WithLifecycleAndCustomMatchers(_) => config
+    };
   };
 
-let appendTests = (numTests, test, suite) => {
-  let newTests = Array.make(numTests, test) |> Array.to_list;
-  {...suite, tests: suite.tests @ newTests};
+let init = name => {
+  Unfinalized(SimpleBuilderConfig(name));
 };
+
+let transformConfig:
+  type ext env finalized.
+    (
+      testSuiteConfig(ext, env) => testSuiteConfig(ext, env),
+      t(ext, env, finalized)
+    ) =>
+    t(ext, env, describeConfigFinalized) =
+  (transform, testSuiteConfig) =>
+    switch (finalize(testSuiteConfig)) {
+    | Child(config) => Child(transform(config))
+    | Simple(config) => Simple(transform(config))
+    | WithLifecycleAndCustomMatchers({
+        config,
+        testLifecycleFactory,
+        customMatchers,
+      }) =>
+      WithLifecycleAndCustomMatchers({
+        config: transform(config),
+        testLifecycleFactory,
+        customMatchers,
+      })
+    | WithLifecycle({testLifecycleFactory, config}) =>
+      WithLifecycle({config: transform(config), testLifecycleFactory})
+    | WithCustomMatchers({customMatchers, config}) =>
+      WithCustomMatchers({customMatchers, config: transform(config)})
+    };
+let applyToConfig:
+  type ext env.
+    (
+      testSuiteConfig(ext, env) => unit,
+      t(ext, env, describeConfigFinalized)
+    ) =>
+    unit =
+  (fn, testSuiteConfig) =>
+    switch (testSuiteConfig) {
+    | Child(config) => fn(config)
+    | Simple(config) => fn(config)
+    | WithCustomMatchers({config}) => fn(config)
+    | WithLifecycle({config}) => fn(config)
+    | WithLifecycleAndCustomMatchers({config}) => fn(config)
+    };
+let withName:
+  type ext env finalized.
+    (string, t(ext, env, finalized)) => t(ext, env, describeConfigFinalized) =
+  (name, testSuiteConfig) =>
+    transformConfig(
+      (TestSuiteConfig(config)) => TestSuiteConfig({...config, name}),
+      testSuiteConfig,
+    );
+
+let makeChild:
+  type ext env finalized.
+    t(ext, env, finalized) => t(ext, env, describeConfigFinalized) =
+  config => {
+    let defaultChildConfig =
+      TestSuiteConfig({
+        name: "nested suite",
+        tests: [],
+        nestedSuites: [],
+        mode: Normal,
+      });
+    transformConfig(_ => defaultChildConfig, config);
+  };
+
+let withNestedTestSuite:
+  type ext env describeConfigState.
+    (
+      ~child: t(ext, env, describeConfigFinalized) =>
+              t(ext, env, describeConfigFinalized),
+      t(ext, env, describeConfigState)
+    ) =>
+    t(ext, env, describeConfigFinalized) =
+  (~child, parent) =>
+    transformConfig(
+      (TestSuiteConfig(config)) =>
+        TestSuiteConfig({
+          ...config,
+          nestedSuites: config.nestedSuites @ [child(makeChild(parent))],
+        }),
+      parent,
+    );
+
+let appendTests:
+  type ext env finalized.
+    (int, test(ext, env), t(ext, env, finalized)) =>
+    t(ext, env, describeConfigFinalized) =
+  (numTests, test, suite) => {
+    let newTests = Array.make(numTests, test) |> Array.to_list;
+    transformConfig(
+      (TestSuiteConfig(config)) =>
+        TestSuiteConfig({...config, tests: config.tests @ newTests}),
+      suite,
+    );
+  };
 
 let withFailingTests = (~only=false, numFailingTests, suite) => {
   let mode = only ? Only : Normal;
-  appendTests(numFailingTests, {pass: false, mode}, suite);
+  appendTests(numFailingTests, Simple({pass: false, mode}), suite);
 };
 let withPassingTests = (~only=false, numPassingTests, suite) => {
   let mode = only ? Only : Normal;
-  appendTests(numPassingTests, {pass: true, mode}, suite);
+  appendTests(numPassingTests, Simple({pass: true, mode}), suite);
 };
-let skipSuite = suite => {...suite, mode: Skip};
 let withSkippedTests = (numSkippedTests, suite) =>
-  appendTests(numSkippedTests, {pass: true, mode: Skip}, suite);
-let only = (suite) => {...suite, mode: Only};
+  appendTests(numSkippedTests, Simple({pass: true, mode: Skip}), suite);
+let withCustomTest = (test, suite) => appendTests(1, Custom(test), suite);
 
-let rec toFunction = config => {
-  open Rely.Test;
-  open Rely.Describe;
-  let tests = describeUtils =>
-    List.iter(
-      ({mode, pass}) => {
-        let body = ({expect}) => expect.bool(true).toBe(pass);
-        switch (mode) {
-        | Normal => describeUtils.test("some test", body)
-        | Skip => describeUtils.testSkip("some test", body)
-        | Only => describeUtils.testOnly("some test", body)
-        };
-      },
-      config.tests,
-    );
-  let nestedSuites =
+let skipSuite = config =>
+  transformConfig(
+    (TestSuiteConfig(config)) => TestSuiteConfig({...config, mode: Skip}),
+    config,
+  );
+
+let only = config =>
+  transformConfig(
+    (TestSuiteConfig(config)) => TestSuiteConfig({...config, mode: Only}),
+    config,
+  );
+
+let build = config => TestSuite(config);
+
+open Rely.Test;
+open Rely.Describe;
+
+module Make = (TestFramework: Rely.TestFramework) => {
+  let register:
+    type ext env finalized.
       (
-        ~describe: Rely.Describe.describeFn(unit),
-        ~describeSkip: Rely.Describe.describeFn(unit),
-        ~describeOnly: Rely.Describe.describeFn(unit),
+        t(ext, env, finalized),
+        ~describe: Rely.Describe.describeFn(unit, unit),
+        ~describeSkip: Rely.Describe.describeFn(unit, unit),
+        ~describeOnly: Rely.Describe.describeFn(unit, unit)
       ) =>
-    config.nestedSuites
-    |> List.iter(suite =>
-         toFunction(suite, ~describe, ~describeSkip, ~describeOnly)
-       );
-
-  let fn =
-      (
-        ~describe: Rely.Describe.describeFn(unit),
-        ~describeSkip: Rely.Describe.describeFn(unit),
-        ~describeOnly: Rely.Describe.describeFn(unit),
-      ) => {
-    let describeFnToUse =
-      switch (config.mode) {
-      | Normal => describe
-      | Skip => describeSkip
-      | Only => describeOnly
+      unit =
+    (config, ~describe, ~describeSkip, ~describeOnly) => {
+      let rec register = (config, describe, describeSkip, describeOnly) => {
+        let tests = describeUtils =>
+          applyToConfig(
+            (TestSuiteConfig(config)) => {
+              List.iter(
+                test =>
+                  switch ((test: test(ext, env))) {
+                  | Simple({mode, pass}) =>
+                    let body = ({expect}) => expect.bool(true).toBe(pass);
+                    switch (mode) {
+                    | Normal => describeUtils.test("some test", body)
+                    | Skip => describeUtils.testSkip("some test", body)
+                    | Only => describeUtils.testOnly("some test", body)
+                    };
+                  | Custom({mode, name, implementation}) =>
+                    switch (mode) {
+                    | Normal => describeUtils.test(name, implementation)
+                    | Skip => describeUtils.testSkip(name, implementation)
+                    | Only => describeUtils.testOnly(name, implementation)
+                    }
+                  },
+                config.tests,
+              );
+              ();
+            },
+            config,
+          );
+        applyToConfig(
+          (TestSuiteConfig(config)) => {
+            let describeFnToUse =
+              switch (config.mode) {
+              | Normal => describe
+              | Skip => describeSkip
+              | Only => describeOnly
+              };
+            describeFnToUse(
+              config.name,
+              describeUtils => {
+                tests(describeUtils);
+                List.iter(
+                  nestedSuite =>
+                    register(
+                      nestedSuite,
+                      describeUtils.describe,
+                      describeUtils.describeSkip,
+                      describeUtils.describeOnly,
+                    ),
+                  config.nestedSuites,
+                );
+              },
+            );
+          },
+          config,
+        );
       };
-    describeFnToUse(
-      config.name,
-      describeUtils => {
-        tests(describeUtils);
-        nestedSuites(describeUtils.describe, describeUtils.describeSkip, describeUtils.describeOnly);
-      },
-    );
-  };
-  fn;
+      let config = finalize(config);
+      switch (config) {
+      | Child(_) => failwith("don't do that")
+      | Simple(_) => register(config, describe, describeSkip, describeOnly)
+      | WithLifecycleAndCustomMatchers({testLifecycleFactory, customMatchers}) =>
+        let {describe, describeSkip, describeOnly} =
+          TestFramework.(
+            describeConfig
+            |> withCustomMatchers(customMatchers)
+            |> withLifecycle(testLifecycleFactory)
+            |> extendDescribe
+          );
+        register(config, describe, describeSkip, describeOnly);
+      | WithLifecycle({testLifecycleFactory}) =>
+        let {describe, describeSkip, describeOnly} =
+          TestFramework.(
+            describeConfig
+            |> withLifecycle(testLifecycleFactory)
+            |> extendDescribe
+          );
+        register(config, describe, describeSkip, describeOnly);
+      | WithCustomMatchers({customMatchers}) =>
+        let {describe, describeSkip, describeOnly} =
+          TestFramework.(
+            describeConfig
+            |> withCustomMatchers(customMatchers)
+            |> extendDescribe
+          );
+        register(config, describe, describeSkip, describeOnly);
+      };
+    };
 };

--- a/tests/__tests__/rely/TestSuiteBuilder.rei
+++ b/tests/__tests__/rely/TestSuiteBuilder.rei
@@ -14,14 +14,7 @@ type testSuite =
 
 let withLifecycle:
   (
-    RelyInternal.TestLifecycle.t(
-      beforeAll(beforeAllNotCalled, unit),
-      afterAll(afterAllNotCalled, unit),
-      beforeEach(beforeEachNotCalled, unit, unit),
-      afterEach(afterEachNotCalled, unit),
-      unit,
-      unit,
-    ) =>
+    RelyInternal.TestLifecycle.defaultLifecycle =>
     RelyInternal.TestLifecycle.t('a, 'b, 'c, 'd, 'e, 'env),
     t('ext, 'f, describeConfigNotFinalized)
   ) =>

--- a/tests/__tests__/rely/TestSuiteBuilder.rei
+++ b/tests/__tests__/rely/TestSuiteBuilder.rei
@@ -4,12 +4,76 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
-type t;
-let init: string => t;
-let withNestedTestSuite: (~child: t, t) => t;
-let withFailingTests: (~only: bool=?, int, t) => t;
-let withPassingTests: (~only: bool=?, int, t) => t;
-let withSkippedTests: (int, t) => t;
-let toFunction: (t, ~describe: Rely.Describe.describeFn(unit), ~describeSkip: Rely.Describe.describeFn(unit), ~describeOnly: Rely.Describe.describeFn(unit)) => unit;
-let skipSuite: (t) => t;
-let only: (t) => t;
+open RelyInternal.TestLifecycle;
+
+type describeConfigFinalized;
+type describeConfigNotFinalized;
+type t('ext, 'env, 'describeConfigState);
+type testSuite =
+  | TestSuite(t('ext, 'env, 'describeConfigState)): testSuite;
+
+let withLifecycle:
+  (
+    RelyInternal.TestLifecycle.t(
+      beforeAll(beforeAllNotCalled, unit),
+      afterAll(afterAllNotCalled, unit),
+      beforeEach(beforeEachNotCalled, unit, unit),
+      afterEach(afterEachNotCalled, unit),
+      unit,
+      unit,
+    ) =>
+    RelyInternal.TestLifecycle.t('a, 'b, 'c, 'd, 'e, 'env),
+    t('ext, 'f, describeConfigNotFinalized)
+  ) =>
+  t('ext, 'env, describeConfigNotFinalized);
+
+let withCustomMatchers:
+  (
+    Rely.MatcherTypes.matchersExtensionFn('ext),
+    t('a, 'env, describeConfigNotFinalized)
+  ) =>
+  t('ext, 'env, describeConfigNotFinalized);
+
+let init: string => t(unit, unit, describeConfigNotFinalized);
+
+let withName:
+  (string, t('ext, 'env, 'describeConfigState)) =>
+  t('ext, 'env, describeConfigFinalized);
+
+let withNestedTestSuite:
+  (
+    ~child: t('ext, 'env, describeConfigFinalized) =>
+            t('ext, 'env, describeConfigFinalized),
+    t('ext, 'env, 'describeConfigState)
+  ) =>
+  t('ext, 'env, describeConfigFinalized);
+let withFailingTests:
+  (~only: bool=?, int, t('ext, 'env, 'describeConfigState)) =>
+  t('ext, 'env, describeConfigFinalized);
+let withPassingTests:
+  (~only: bool=?, int, t('ext, 'env, 'describeConfigState)) =>
+  t('ext, 'env, describeConfigFinalized);
+let withSkippedTests:
+  (int, t('ext, 'env, 'describeConfigState)) =>
+  t('ext, 'env, describeConfigFinalized);
+
+let skipSuite:
+  t('ext, 'env, 'describeConfigState) =>
+  t('ext, 'env, describeConfigFinalized);
+let only:
+  t('ext, 'env, 'describeConfigState) =>
+  t('ext, 'env, describeConfigFinalized);
+let build: t('ext, 'env, 'describeConfigState) => testSuite;
+
+module Make:
+  (TestFramework: Rely.TestFramework) =>
+   {
+    let register:
+      (
+        t('ext, 'env, 'describeConfigState),
+        ~describe: Rely.Describe.describeFn(unit, unit),
+        ~describeSkip: Rely.Describe.describeFn(unit, unit),
+        ~describeOnly: Rely.Describe.describeFn(unit, unit)
+      ) =>
+      unit;
+  };

--- a/tests/__tests__/rely/TestSuiteRunner.re
+++ b/tests/__tests__/rely/TestSuiteRunner.re
@@ -13,12 +13,16 @@ module MakeTestFramework = (()) : Rely.TestFramework =>
       });
   });
 
-let runWithCustomConfig = (testSuites: list(TestSuiteBuilder.t), config: Rely.RunConfig.t) => {
+let runWithCustomConfig =
+    (testSuites: list(TestSuiteBuilder.testSuite), config: Rely.RunConfig.t) => {
   module TestFramework =
     MakeTestFramework({});
+  module TestSuiteRegisterer = TestSuiteBuilder.Make(TestFramework);
 
   testSuites
-  |> List.map(TestSuiteBuilder.toFunction)
+  |> List.map((TestSuiteBuilder.TestSuite(suite)) =>
+       TestSuiteRegisterer.register(suite)
+     )
   |> List.iter(ts =>
        ts(
          ~describe=TestFramework.describe,
@@ -28,14 +32,19 @@ let runWithCustomConfig = (testSuites: list(TestSuiteBuilder.t), config: Rely.Ru
      );
 
   TestFramework.run(config);
-}
+};
 
-let run = (testSuites: list(TestSuiteBuilder.t), reporter: Rely.Reporter.t) => {
+let run =
+    (testSuites: list(TestSuiteBuilder.testSuite), reporter: Rely.Reporter.t) => {
   module TestFramework =
     MakeTestFramework({});
 
+  module TestSuiteRegisterer = TestSuiteBuilder.Make(TestFramework);
+
   testSuites
-  |> List.map(TestSuiteBuilder.toFunction)
+  |> List.map((TestSuiteBuilder.TestSuite(suite)) =>
+       TestSuiteRegisterer.register(suite)
+     )
   |> List.iter(ts =>
        ts(
          ~describe=TestFramework.describe,
@@ -62,8 +71,12 @@ let runWithCustomTime = (getTime, testSuites, reporter) => {
         );
     });
 
+  module TestSuiteRegisterer = TestSuiteBuilder.Make(TestFramework);
+
   testSuites
-  |> List.map(TestSuiteBuilder.toFunction)
+  |> List.map((TestSuiteBuilder.TestSuite(suite)) =>
+       TestSuiteRegisterer.register(suite)
+     )
   |> List.iter(ts =>
        ts(
          ~describe=TestFramework.describe,

--- a/tests/__tests__/rely/TimingTest.re
+++ b/tests/__tests__/rely/TimingTest.re
@@ -17,13 +17,19 @@ describe("Rely timing data", ({describe, test}) => {
     let result = ref(None);
     let testSuites = [
       TestSuiteBuilder.(
-        init("foo") |> withPassingTests(15) |> withFailingTests(10)
+        TestSuite(
+          init("foo") |> withPassingTests(15) |> withFailingTests(10),
+        )
       ),
       TestSuiteBuilder.(
-        init("bar") |> withPassingTests(15) |> withFailingTests(10)
+        TestSuite(
+          init("bar") |> withPassingTests(15) |> withFailingTests(10),
+        )
       ),
       TestSuiteBuilder.(
-        init("baz") |> withPassingTests(15) |> withFailingTests(10)
+        TestSuite(
+          init("baz") |> withPassingTests(15) |> withFailingTests(10),
+        )
       ),
     ];
 
@@ -54,7 +60,9 @@ describe("Rely timing data", ({describe, test}) => {
     let result = ref(None);
     let testSuites = [
       TestSuiteBuilder.(
-        init("foo") |> withPassingTests(15) |> withFailingTests(10)
+        TestSuite(
+          init("foo") |> withPassingTests(15) |> withFailingTests(10),
+        )
       ),
     ];
 
@@ -68,9 +76,7 @@ describe("Rely timing data", ({describe, test}) => {
       | Some(aggregatedResult) =>
         let timingsPopulated =
           aggregatedResult.testSuiteResults
-          |> List.map((r: Rely.Reporter.testSuiteResult) =>
-               r.testResults
-             )
+          |> List.map((r: Rely.Reporter.testSuiteResult) => r.testResults)
           |> List.flatten
           |> List.map((r: Rely.Reporter.testResult) =>
                switch (r.duration) {
@@ -92,9 +98,7 @@ describe("Rely timing data", ({describe, test}) => {
       TestReporter.Make({});
     let result = ref(None);
     let testSuites = [
-      TestSuiteBuilder.(
-        init("foo") |> withSkippedTests(15)
-      ),
+      TestSuiteBuilder.(TestSuite(init("foo") |> withSkippedTests(15))),
     ];
 
     Reporter.onRunComplete(res => result := Some(res));
@@ -107,9 +111,7 @@ describe("Rely timing data", ({describe, test}) => {
       | Some(aggregatedResult) =>
         let timingsNotPopulated =
           aggregatedResult.testSuiteResults
-          |> List.map((r: Rely.Reporter.testSuiteResult) =>
-               r.testResults
-             )
+          |> List.map((r: Rely.Reporter.testSuiteResult) => r.testResults)
           |> List.flatten
           |> List.map((r: Rely.Reporter.testResult) =>
                switch (r.duration) {
@@ -122,20 +124,27 @@ describe("Rely timing data", ({describe, test}) => {
       };
     ();
   });
-  test("startTime should be populated with initial value from clock", ({expect}) => {
+  test(
+    "startTime should be populated with initial value from clock", ({expect}) => {
     module Reporter =
       TestReporter.Make({});
     let result = ref(None);
     let testSuites = [
       TestSuiteBuilder.(
-        init("foo") |> withPassingTests(15) |> withFailingTests(10)
+        TestSuite(
+          init("foo") |> withPassingTests(15) |> withFailingTests(10),
+        )
       ),
     ];
 
     let startTime = 10.;
     Reporter.onRunComplete(res => result := Some(res));
 
-    TestSuiteRunner.runWithCustomTime(() => Seconds(startTime), testSuites, Reporter.reporter);
+    TestSuiteRunner.runWithCustomTime(
+      () => Seconds(startTime),
+      testSuites,
+      Reporter.reporter,
+    );
 
     let _ =
       switch (result^) {


### PR DESCRIPTION
Addresses https://github.com/facebookexperimental/reason-native/issues/171

Introduces beforeAll, afterAll, beforeEach, afterEach lifecycle hooks.

usage looks like
```reason
open TestFramework;

let {describe} = describeConfig
 |> withLifecycle(l => l 
    |> beforeAll(() => getTempDir())
    |> afterAll((tempDir) => rimraf(tempDir))
    |> beforeEach((tempDir) => { cleanDir(tempDir); tempDir; }))
  |> extendDescribe;



describe("my test suite", ({test}) => {
  /*env is bound to whatever beforeEach returns (which by default returns the value of beforeAll for convenience*/
  test("my test", ({expect, env}) => {
    myCode.populateDir(env);
    expect.bool(true).toBeTrue(); 
  });
});

```

Custom matchers now uses describeConfig as well, so existing tests using custom matchers will unfortunately have to be updated. This change was probably breaking anyway because of the changes to the describe/test types. You can see further consequences by looking at some of the changes to our existing tests.

I could certainly see doing some renaming/reorganizing, however I think the approach I took seems fairly reasonable. I originally had slightly more complicated types for the lifecycle methods (you can see the difference by just looking at the 4th commit in this PR), but the error messages are still good with the final approach and it is simpler.