### PR TITLE
Fix Issue#174: Some inline records results in printing ~unknown with Console

### DIFF
--- a/shared-src/objectPrinter/ObjectPrinter.re
+++ b/shared-src/objectPrinter/ObjectPrinter.re
@@ -205,7 +205,7 @@ let base = {
         self.lazy_(self, Obj.magic(o));
       } else if (detectList(~maxLength=maxLength.contents, o)) {
         self.list(self, ~depth, Obj.magic(o));
-      } else if (tag === Obj.first_non_constant_constructor_tag) {
+      } else if (Obj.is_block(oDynamic)) {
         self.block(self, ~depth, Obj.magic(o));
       } else {
         /* Some kind a block. */

--- a/tests/__snapshots__/Console.843356e4.0.snapshot
+++ b/tests/__snapshots__/Console.843356e4.0.snapshot
@@ -1,0 +1,8 @@
+Console › Records
+===== Standard Out =====
+{0}
+{\"some string\"}
+===== Standard Err =====
+
+========================
+

--- a/tests/__tests__/console/Console_test.re
+++ b/tests/__tests__/console/Console_test.re
@@ -7,6 +7,10 @@
 
 open TestFramework;
 
+type mockedType =
+  | Foo{a: int}
+  | Bar{x: string};
+
 describe("Console", ({test}) => {
   test("Basic output", ({expect}) => {
     let (stdout, stderr, _) =
@@ -110,6 +114,16 @@ describe("Console", ({test}) => {
           ...circularList,
         ];
         Console.error(circularList);
+      });
+    let out = Utils.allOut(stdout, stderr);
+    expect.string(out).toMatchSnapshot();
+  });
+
+  test("Records", ({expect}) => {
+    let (stdout, stderr, _) =
+      IO.captureOutput(() => {
+        Console.log(Foo({a: 0}));
+        Console.log(Bar({x: "some string"}));
       });
     let out = Utils.allOut(stdout, stderr);
     expect.string(out).toMatchSnapshot();


### PR DESCRIPTION
Hey, 

This PR fixes https://github.com/facebookexperimental/reason-native/issues/174,

I just made a small fix under ObjectPrinter, using `Obj.is_block`. I took it from https://caml.inria.fr/pub/docs/manual-ocaml/libref/Obj.html.
I added the test case the same that the issue.

