### PR TITLE
Expect assertions

### DIFF
--- a/src/rely/AssertionState.re
+++ b/src/rely/AssertionState.re
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+type assertionExpectation =
+  | HasAssertions(option(Printexc.location), string)
+  | NoExpectation
+  | HasNAssertions(int, option(Printexc.location), string);
+
+type assertionResult =
+  | Passed
+  | Failed(string, option(Printexc.location), string);
+
+type t = {
+  expectation: assertionExpectation,
+  assertions: list(assertionResult),
+};
+
+let initialState = {expectation: NoExpectation, assertions: []};
+
+let addAssertionResult = (assertionResult, state) => {
+  ...state,
+  assertions: state.assertions @ [assertionResult],
+};
+
+let setExpectation = (expectation, state) => {...state, expectation};
+
+type assertionStateValidationResult =
+  | Valid
+  | Invalid(string, option(Printexc.location), string);
+
+let validateAssertionState:
+  (MatcherUtils.t, t) => assertionStateValidationResult =
+  ({formatExpected, formatReceived}, state) => {
+    switch (state.expectation) {
+    | NoExpectation => Valid
+    | HasAssertions(loc, stack) =>
+      switch (state.assertions) {
+      | [] =>
+        let message =
+          String.concat(
+            "",
+            [
+              MatcherUtils.singleLevelMatcherHint(
+                ~expectType=".hasAssertions",
+                ~received="",
+                ~expected="",
+                (),
+              ),
+              "\n\n",
+              "Expected ",
+              formatExpected("at least one assertion"),
+              " to be called, but ",
+              formatReceived("received none"),
+              ".",
+            ],
+          );
+        Invalid(message, loc, stack);
+      | [h, ...t] => Valid
+      }
+    | HasNAssertions(expectedNumAssertions, loc, stack) =>
+      let actualNumAssertions = List.length(state.assertions);
+      let isValid = actualNumAssertions == expectedNumAssertions;
+      if (isValid) {
+        Valid;
+      } else {
+        let expectedAssertionsText =
+          formatExpected(
+            MatcherUtils.pluralize("assertion", expectedNumAssertions),
+          );
+        let receivedAssertionsText =
+          formatReceived(
+            MatcherUtils.pluralize("assertion call", actualNumAssertions),
+          );
+        let message =
+          String.concat(
+            "",
+            [
+              MatcherUtils.singleLevelMatcherHint(
+                ~expectType=".assertions",
+                ~received="",
+                ~expected=string_of_int(expectedNumAssertions),
+                (),
+              ),
+              "\n\n",
+              "Expected ",
+              expectedAssertionsText,
+              " to be called, but received ",
+              receivedAssertionsText,
+              ".",
+            ],
+          );
+        Invalid(message, loc, stack);
+      };
+    };
+  };

--- a/src/rely/Test.re
+++ b/src/rely/Test.re
@@ -29,7 +29,17 @@ type matchers('ext) = {
     result('a, 'b) => ResultMatchers.resultMatchersWithNot('a, 'b),
 
   ext: 'ext,
+  /**
+   * Verifies that a certain number of assertions are called during a test.
+   * This is often useful when testing asynchronous code, in order to
+   * make sure that assertions in a callback actually got called.
+   */
   assertions: int => unit,
+  /**
+   * Verifies that at least one assertion is called during a test.
+   * This is often useful when testing asynchronous code, in order to
+   * make sure that assertions in a callback actually got called.
+   */
   hasAssertions: unit => unit,
 };
 

--- a/src/rely/Test.re
+++ b/src/rely/Test.re
@@ -4,8 +4,37 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
+type matchers('ext) = {
+  string: string => StringMatchers.stringMatchersWithNot,
+  file: string => StringMatchers.stringMatchersWithNot,
+  lines: list(string) => StringMatchers.stringMatchersWithNot,
+  bool: bool => BoolMatchers.boolMatchersWithNot,
+  int: int => IntMatchers.intMatchersWithNot,
+  float: float => FloatMatchers.floatMatchersWithNot,
+  fn: 'a. (unit => 'a) => FnMatchers.fnMatchersWithNot,
+  list: 'a. list('a) => ListMatchers.matchersWithNot('a),
+  array: 'a. array('a) => ArrayMatchers.matchersWithNot('a),
+  equal: 'a. EqualsMatcher.equalsMatcher('a),
+  notEqual: 'a. EqualsMatcher.equalsMatcher('a),
+  same: 'a. SameMatcher.sameMatcher('a),
+  notSame: 'a. SameMatcher.sameMatcher('a),
+  mock:
+    'fn 'ret 'tupledArgs.
+    Mock.t('fn, 'ret, 'tupledArgs) =>
+    MockMatchers.matchersWithNot('tupledArgs, 'ret),
+
+  option: 'a. option('a) => OptionMatchers.optionMatchersWithNot('a),
+  result:
+    'a 'b.
+    result('a, 'b) => ResultMatchers.resultMatchersWithNot('a, 'b),
+
+  ext: 'ext,
+  assertions: int => unit,
+  hasAssertions: unit => unit,
+};
+
 type testUtils('ext, 'env) = {
-  expect: DefaultMatchers.matchers('ext),
+  expect: matchers('ext),
   env: 'env,
 };
 type testFn('ext, 'env) = (string, testUtils('ext, 'env) => unit) => unit;

--- a/src/rely/TestSuiteRunner.re
+++ b/src/rely/TestSuiteRunner.re
@@ -97,7 +97,7 @@ module Make = (Config: TestSuiteRunnerConfig) => {
             switch (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {
             | (messageThunk, true) =>
               assertionState :=
-                AssertionState.addAssertionResult(Passed, assertionState^)
+                AssertionState.addAssertionResult(assertionState^)
             | (messageThunk, false) =>
               Context.Snapshot.markSnapshotsAsCheckedForTest(testId);
               let message = messageThunk();
@@ -110,7 +110,6 @@ module Make = (Config: TestSuiteRunnerConfig) => {
                 );
               assertionState :=
                 AssertionState.addAssertionResult(
-                  Failed(message, location, stack),
                   assertionState^,
                 );
               updateTestStatus(Failed(message, location, stack));

--- a/src/rely/TestSuiteRunner.re
+++ b/src/rely/TestSuiteRunner.re
@@ -81,6 +81,7 @@ module Make = (Config: TestSuiteRunnerConfig) => {
 
       let executeTest = (describePath, name, location, usersTest, extensionFn) => {
         let testStatus = ref(None);
+        let assertionState = ref(AssertionState.initialState);
         let testPath = (name, describePath);
         let describeFileName =
           TestPath.(Describe(describePath) |> toString) |> sanitizeName;
@@ -94,10 +95,12 @@ module Make = (Config: TestSuiteRunnerConfig) => {
         let createMatcher = matcherConfig => {
           let matcher = (actualThunk, expectedThunk) => {
             switch (matcherConfig(matcherUtils, actualThunk, expectedThunk)) {
-            | (messageThunk, true) => ()
+            | (messageThunk, true) =>
+              assertionState :=
+                AssertionState.addAssertionResult(Passed, assertionState^)
             | (messageThunk, false) =>
               Context.Snapshot.markSnapshotsAsCheckedForTest(testId);
-
+              let message = messageThunk();
               let stackTrace = Context.StackTrace.getStackTrace();
               let location = Context.StackTrace.getTopLocation(stackTrace);
               let stack =
@@ -105,12 +108,18 @@ module Make = (Config: TestSuiteRunnerConfig) => {
                   stackTrace,
                   Config.maxNumStackFrames,
                 );
-              updateTestStatus(Failed(messageThunk(), location, stack));
+              assertionState :=
+                AssertionState.addAssertionResult(
+                  Failed(message, location, stack),
+                  assertionState^,
+                );
+              updateTestStatus(Failed(message, location, stack));
             };
             ();
           };
           matcher;
         };
+
         let extendUtils: MatcherTypes.extendUtils = {
           createMatcher: createMatcher,
         };
@@ -119,14 +128,65 @@ module Make = (Config: TestSuiteRunnerConfig) => {
           makeMakeSnapshotMatchers(describeFileName, testPath, testId);
 
         let env = lifecycle.beforeEach(all);
+        let baseMatchers =
+          DefaultMatchers.makeDefaultMatchers(
+            extendUtils,
+            makeSnapshotMatchers,
+            extensionFn,
+          );
+
+        let assertions = n => {
+          let stackTrace = Context.StackTrace.getStackTrace();
+          let location = Context.StackTrace.getTopLocation(stackTrace);
+          let stack =
+            Context.StackTrace.stackTraceToString(
+              stackTrace,
+              Config.maxNumStackFrames,
+            );
+          assertionState :=
+            AssertionState.setExpectation(
+              HasNAssertions(n, location, stack),
+              assertionState^,
+            );
+        };
+
+        let hasAssertions = () => {
+          let stackTrace = Context.StackTrace.getStackTrace();
+          let location = Context.StackTrace.getTopLocation(stackTrace);
+          let stack =
+            Context.StackTrace.stackTraceToString(
+              stackTrace,
+              Config.maxNumStackFrames,
+            );
+          assertionState :=
+            AssertionState.setExpectation(
+              HasAssertions(location, stack),
+              assertionState^,
+            );
+        };
 
         let testUtils = {
-          expect:
-            DefaultMatchers.makeDefaultMatchers(
-              extendUtils,
-              makeSnapshotMatchers,
-              extensionFn,
-            ),
+          expect: {
+            string: baseMatchers.string,
+            file: baseMatchers.file,
+            lines: baseMatchers.lines,
+            bool: baseMatchers.bool,
+            int: baseMatchers.int,
+            float: baseMatchers.float,
+            fn: baseMatchers.fn,
+            list: baseMatchers.list,
+            array: baseMatchers.array,
+            equal: baseMatchers.equal,
+            notEqual: baseMatchers.notEqual,
+            same: baseMatchers.same,
+            notSame: baseMatchers.notSame,
+            mock: baseMatchers.mock,
+            option: baseMatchers.option,
+            result: baseMatchers.result,
+            ext: baseMatchers.ext,
+            assertions,
+            hasAssertions,
+          },
           env,
         };
 
@@ -138,7 +198,16 @@ module Make = (Config: TestSuiteRunnerConfig) => {
                 switch (usersTest(testUtils)) {
                 | () =>
                   lifecycle.afterEach(env);
-                  updateTestStatus(Passed(location));
+                  switch (
+                    AssertionState.validateAssertionState(
+                      matcherUtils,
+                      assertionState^,
+                    )
+                  ) {
+                  | Valid => updateTestStatus(Passed(location))
+                  | Invalid(message, loc, stack) =>
+                    updateTestStatus(Failed(message, loc, stack))
+                  };
                 | exception e =>
                   let exceptionTrace =
                     Context.StackTrace.getExceptionStackTrace();

--- a/src/rely/matchers/DefaultMatchers.re
+++ b/src/rely/matchers/DefaultMatchers.re
@@ -4,24 +4,15 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
-open StringMatchers;
-open BoolMatchers;
-open SnapshotMatchers;
-open IntMatchers;
-open FloatMatchers;
-open FnMatchers;
-open MatcherTypes;
-open ListMatchers;
-open ArrayMatchers;
 
 type matchers('ext) = {
-  string: string => stringMatchersWithNot,
-  file: string => stringMatchersWithNot,
-  lines: list(string) => stringMatchersWithNot,
-  bool: bool => boolMatchersWithNot,
-  int: int => intMatchersWithNot,
-  float: float => floatMatchersWithNot,
-  fn: 'a. (unit => 'a) => fnMatchersWithNot,
+  string: string => StringMatchers.stringMatchersWithNot,
+  file: string => StringMatchers.stringMatchersWithNot,
+  lines: list(string) => StringMatchers.stringMatchersWithNot,
+  bool: bool => BoolMatchers.boolMatchersWithNot,
+  int: int => IntMatchers.intMatchersWithNot,
+  float: float => FloatMatchers.floatMatchersWithNot,
+  fn: 'a. (unit => 'a) => FnMatchers.fnMatchersWithNot,
   list: 'a. list('a) => ListMatchers.matchersWithNot('a),
   array: 'a. array('a) => ArrayMatchers.matchersWithNot('a),
   equal: 'a. EqualsMatcher.equalsMatcher('a),

--- a/src/rely/matchers/MatcherUtils.re
+++ b/src/rely/matchers/MatcherUtils.re
@@ -70,9 +70,9 @@ let matcherHint =
       [
         Pastel.dim(String.concat("", ["expect", expectType, "("])),
         receivedColor(received),
-        isNot ?
-          Pastel.dim(").") ++ "not" ++ Pastel.dim(matcherName ++ "(") :
-          Pastel.dim(String.concat("", [")", matcherName, "("])),
+        isNot
+          ? Pastel.dim(").") ++ "not" ++ Pastel.dim(matcherName ++ "(")
+          : Pastel.dim(String.concat("", [")", matcherName, "("])),
         expectedColor(expected),
         Pastel.dim(")"),
       ],
@@ -94,14 +94,27 @@ let singleLevelMatcherHint =
       ~options={comment: None},
       (),
     ) => {
+  let expectedReceived =
+    switch (expected, received) {
+    | ("", "") => ""
+    | ("", received) => receivedColor(received)
+    | (expected, "") => expectedColor(expected)
+    | (expected, received) =>
+      String.concat(
+        "",
+        [
+          expectedColor(expected),
+          Pastel.dim(", "),
+          receivedColor(received),
+        ],
+      )
+    };
   let assertion =
     String.concat(
       "",
       [
         Pastel.dim(String.concat("", ["expect", expectType, "("])),
-        expectedColor(expected),
-        Pastel.dim(", "),
-        receivedColor(received),
+        expectedReceived,
         Pastel.dim(")"),
       ],
     );
@@ -148,6 +161,10 @@ let formatInt = n =>
   } else {
     string_of_int(n);
   };
+
+let pluralize = (word, ~plural=word ++ "s", n) => {
+  String.concat(" ", [formatInt(n), n == 1 ? word : plural]);
+};
 
 let matcherUtils = {
   matcherHint,

--- a/src/rely/matchers/MatcherUtils.rei
+++ b/src/rely/matchers/MatcherUtils.rei
@@ -37,4 +37,6 @@ let formatInt: int => string;
 
 let nthToString: int => string;
 
+let pluralize: (string, ~plural:string=?, int) => string;
+
 let matcherUtils: t;

--- a/tests/__snapshots__/expect_assertions.172f636b.0.snapshot
+++ b/tests/__snapshots__/expect_assertions.172f636b.0.snapshot
@@ -1,0 +1,4 @@
+expect.assertions › mismatched assertion count plural expect, singular call
+<dim>expect.assertions(</dim><green>2</green><dim>)</dim>
+
+Expected <green>two assertions</green> to be called, but received <red>one assertion call</red>.

--- a/tests/__snapshots__/expect_assertions.309c49fd.0.snapshot
+++ b/tests/__snapshots__/expect_assertions.309c49fd.0.snapshot
@@ -1,0 +1,4 @@
+expect.assertions › mismatched assertion count singular expect, zero calls
+<dim>expect.assertions(</dim><green>1</green><dim>)</dim>
+
+Expected <green>one assertion</green> to be called, but received <red>zero assertion calls</red>.

--- a/tests/__snapshots__/expect_assertions.4f250bf7.0.snapshot
+++ b/tests/__snapshots__/expect_assertions.4f250bf7.0.snapshot
@@ -1,0 +1,4 @@
+expect.assertions › mismatched assertion count plural expect and call
+<dim>expect.assertions(</dim><green>3</green><dim>)</dim>
+
+Expected <green>three assertions</green> to be called, but received <red>two assertion calls</red>.

--- a/tests/__snapshots__/expect_hasAssertions.f0e8d850.0.snapshot
+++ b/tests/__snapshots__/expect_hasAssertions.f0e8d850.0.snapshot
@@ -1,0 +1,4 @@
+expect.hasAssertions › no assertions
+<dim>expect.hasAssertions(</dim><dim>)</dim>
+
+Expected <green>at least one assertion</green> to be called, but <red>received none</red>.

--- a/tests/__tests__/rely/ExpectAssertions_test.re
+++ b/tests/__tests__/rely/ExpectAssertions_test.re
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */;
+open TestFramework;
+
+describe("expect.assertions", ({test}) => {
+  test("works on happy path", ({expect}) => {
+    expect.assertions(2);
+    expect.bool(true).toBeTrue();
+    expect.bool(false).not.toBeTrue();
+  });
+  test("redeclare assertion count", ({expect}) => {
+    expect.assertions(3);
+    expect.bool(true).toBeTrue();
+    expect.bool(false).not.toBeTrue();
+    expect.assertions(2);
+  });
+  test("expect no assertions", ({expect}) =>
+    expect.assertions(0)
+  );
+  test("mismatched assertion count plural expect, singular call", testUtils =>
+    MatcherSnapshotTestRunner.snapshotFailingTestCase(
+      testUtils,
+      ({expect}) => {
+        expect.assertions(2);
+        expect.bool(true).toBeTrue();
+      },
+    )
+  );
+  test("mismatched assertion count plural expect and call", testUtils =>
+    MatcherSnapshotTestRunner.snapshotFailingTestCase(
+      testUtils,
+      ({expect}) => {
+        expect.assertions(3);
+        expect.bool(true).toBeTrue();
+        expect.bool(true).toBeTrue();
+      },
+    )
+  );
+  test("mismatched assertion count singular expect, zero calls", testUtils =>
+    MatcherSnapshotTestRunner.snapshotFailingTestCase(testUtils, ({expect}) =>
+      expect.assertions(1)
+    )
+  );
+});
+
+describe("expect.hasAssertions", ({test}) => {
+  test("works on happy path", ({expect}) => {
+    expect.hasAssertions();
+    expect.bool(true).toBeTrue();
+  });
+  test("no assertions", testUtils =>
+    MatcherSnapshotTestRunner.snapshotFailingTestCase(testUtils, ({expect}) =>
+      expect.hasAssertions()
+    )
+  );
+});

--- a/tests/__tests__/rely/TestLifecycle_test.re
+++ b/tests/__tests__/rely/TestLifecycle_test.re
@@ -43,6 +43,7 @@ describe("test lifecycle methods", ({test}) => {
       );
     });
     executeTestFramework(TestFrameworkInternal.run);
+    expectExternal.assertions(2);
   });
   test("before all should be called exactly once", ({expect}) => {
     let beforeAllMock = Mock.mock1(() => uniqueInstance);
@@ -107,6 +108,7 @@ describe("test lifecycle methods", ({test}) => {
       executeTestFramework(TestFrameworkInternal.run);
       expectExternal.mock(afterAllMock).toBeCalledWith(uniqueInstance);
       expectExternal.mock(afterAllMock).toBeCalled();
+      expectExternal.assertions(4);
     },
   );
   test(
@@ -146,6 +148,7 @@ describe("test lifecycle methods", ({test}) => {
         );
       });
       executeTestFramework(TestFrameworkInternal.run);
+      expect.assertions(4);
     },
   );
   test(
@@ -206,6 +209,7 @@ describe("test lifecycle methods", ({test}) => {
     );
     executeTestFramework(TestFrameworkInternal.run);
     expect.mock(afterEachMock).toBeCalledTimes(4);
+    expect.assertions(5);
     ();
   });
   test("ret of beforeAll passed as arg to beforeEach", ({expect}) => {


### PR DESCRIPTION
Addresses https://github.com/facebookexperimental/reason-native/issues/180

Adds `expect.assertions(num)` and `expect.hasAssertions` that behave pretty much how Jest does. Second commit uses them in the lifecycle tests where I had thought about wanting them previously

![image](https://user-images.githubusercontent.com/5252755/60911682-96992d00-a238-11e9-95ee-e5955ee57f5e.png)
