### PR TITLE
[WIP] [RFC] pastel add ability to partition by a list of indices

### DIFF
--- a/src/pastel/HumanReadableImplementation.re
+++ b/src/pastel/HumanReadableImplementation.re
@@ -14,6 +14,7 @@ module HumanReadableLexer =
 
 let length = HumanReadableLexer.length;
 let partition = HumanReadableLexer.partition;
+let partition2 = HumanReadableLexer.partition2;
 let unformattedText = HumanReadableLexer.unformattedText;
 
 let makeDecorator = name => {

--- a/src/pastel/Pastel.rei
+++ b/src/pastel/Pastel.rei
@@ -69,6 +69,7 @@ type modifier = {
 
 let length: string => int;
 let partition: (int, string) => (string, string);
+let partition2: (list(int), string) => list(string);
 let unformattedText: string => string;
 
 let modifier: modifier;

--- a/src/pastel/PastelFactory.re
+++ b/src/pastel/PastelFactory.re
@@ -119,6 +119,14 @@ module Make = (()) => {
     | Disabled => DisabledImplementation.partition(s)
     };
 
+  let partition2 = s => {
+    switch (mode^) {
+    | HumanReadable => HumanReadableImplementation.partition2(s)
+    | Terminal => TerminalImplementation.partition2(s)
+    | Disabled => TerminalImplementation.partition2(s)
+    };
+  };
+
   let unformattedText = s =>
     switch (mode^) {
     | HumanReadable => HumanReadableImplementation.unformattedText(s)

--- a/src/pastel/PastelSig.re
+++ b/src/pastel/PastelSig.re
@@ -14,6 +14,7 @@ module type PastelSig = {
   let useMode: (mode, unit => 'a) => 'a;
   let length: string => int;
   let partition: (int, string) => (string, string);
+  let partition2: (list(int), string) => list(string);
   let unformattedText: string => string;
 
   let modifier: modifier;

--- a/src/pastel/TerminalImplementation.re
+++ b/src/pastel/TerminalImplementation.re
@@ -23,6 +23,7 @@ module TerminalLexer =
 
 let length = TerminalLexer.length;
 let partition = TerminalLexer.partition;
+let partition2 = TerminalLexer.partition2;
 let unformattedText = TerminalLexer.unformattedText;
 
 let rec reduceTokens = (style: Ansi.style, str, tokens) =>

--- a/tests/__snapshots__/Pastel_Pastel_Human_Readable_mode_Pastel_partition.9f56c617.0.snapshot
+++ b/tests/__snapshots__/Pastel_Pastel_Human_Readable_mode_Pastel_partition.9f56c617.0.snapshot
@@ -1,0 +1,6 @@
+Pastel › Pastel Human Readable mode › Pastel.partition2 › complicated nested formatting
+<dim>oo<green>h</green></dim>
+<dim><green>ello</green></dim>
+<dim><green> wor</green></dim>
+<dim><green>ld!</green>u</dim>
+<dim><green></green>npasteled o_O</dim>

--- a/tests/__snapshots__/Pastel_Pastel_disabled_mode_Pastel_partition.3369e703.0.snapshot
+++ b/tests/__snapshots__/Pastel_Pastel_disabled_mode_Pastel_partition.3369e703.0.snapshot
@@ -1,0 +1,6 @@
+Pastel › Pastel disabled mode › Pastel.partition2 › complicated nested formatting
+ooh
+ello
+ wor
+ld!u
+npasteled o_O

--- a/tests/__snapshots__/Pastel_Pastel_terminal_mode_Pastel_partition.f482f7df.0.snapshot
+++ b/tests/__snapshots__/Pastel_Pastel_terminal_mode_Pastel_partition.f482f7df.0.snapshot
@@ -1,0 +1,6 @@
+Pastel › Pastel terminal mode › Pastel.partition2 › complicated nested formatting
+\027[2moo\027[22m\027[2m\027[32mh\027[39m\027[22m\027[2m\027[22m
+\027[2m\027[22m\027[2m\027[32mello\027[39m\027[22m\027[2m\027[22m
+\027[2m\027[22m\027[2m\027[32m wor\027[39m\027[22m\027[2m\027[22m
+\027[2m\027[22m\027[2m\027[32mld!\027[39m\027[22m\027[2mu\027[22m
+\027[2m\027[22m\027[2m\027[32m\027[39m\027[22m\027[2mnpasteled o_O\027[22m

--- a/tests/__tests__/pastel/Pastel_test.re
+++ b/tests/__tests__/pastel/Pastel_test.re
@@ -116,20 +116,24 @@ describe("Pastel", ({describe, test}) => {
                 PastelWithSpecifiedMode.partition(45, input);
 
               expect.string(part1).toEqual(input);
-              expect.string(PastelWithSpecifiedMode.unformattedText(part2)).toBeEmpty();
+              expect.string(PastelWithSpecifiedMode.unformattedText(part2)).
+                toBeEmpty();
             });
-            test(
-              "index equal to length should return (s, '')", ({expect}) => {
+            test("index equal to length should return (s, '')", ({expect}) => {
               let input =
                 <PastelWithSpecifiedMode color=Green>
                   "Hello world"
                 </PastelWithSpecifiedMode>;
               ();
               let (part1, part2) =
-                PastelWithSpecifiedMode.partition(PastelWithSpecifiedMode.length(input), input);
+                PastelWithSpecifiedMode.partition(
+                  PastelWithSpecifiedMode.length(input),
+                  input,
+                );
 
               expect.string(part1).toEqual(input);
-              expect.string(PastelWithSpecifiedMode.unformattedText(part2)).toBeEmpty();
+              expect.string(PastelWithSpecifiedMode.unformattedText(part2)).
+                toBeEmpty();
             });
             test("negative index should return ('', s)", ({expect}) => {
               let input =
@@ -140,7 +144,8 @@ describe("Pastel", ({describe, test}) => {
               let (part1, part2) =
                 PastelWithSpecifiedMode.partition(-1, input);
 
-              expect.string(PastelWithSpecifiedMode.unformattedText(part1)).toBeEmpty();
+              expect.string(PastelWithSpecifiedMode.unformattedText(part1)).
+                toBeEmpty();
               expect.string(part2).toEqual(input);
             });
             test("index 0 should return ('', s)", ({expect}) => {
@@ -152,8 +157,38 @@ describe("Pastel", ({describe, test}) => {
               let (part1, part2) =
                 PastelWithSpecifiedMode.partition(0, input);
 
-              expect.string(PastelWithSpecifiedMode.unformattedText(part1)).toBeEmpty();
+              expect.string(PastelWithSpecifiedMode.unformattedText(part1)).
+                toBeEmpty();
               expect.string(part2).toEqual(input);
+            });
+          });
+          describe("Pastel.partition2", ({test}) => {
+            test("unformatted text", ({expect}) => {
+              let result =
+                PastelWithSpecifiedMode.partition2(
+                  [4, 6, 9],
+                  "hello world!",
+                );
+              expect.lines(result).toEqualLines([
+                "hell",
+                "o ",
+                "wor",
+                "ld!",
+              ]);
+            });
+            test("complicated nested formatting", ({expect}) => {
+              let input =
+                <PastelWithSpecifiedMode dim=true>
+                  "oo"
+                  <PastelWithSpecifiedMode color=Green>
+                    "hello world!"
+                  </PastelWithSpecifiedMode>
+                  "unpasteled o_O"
+                </PastelWithSpecifiedMode>;
+
+              let result =
+                PastelWithSpecifiedMode.partition2([3, 7, 11, 15], input);
+              expect.lines(result).toMatchSnapshot();
             });
           });
           describe("Pastel.length", ({test}) => {


### PR DESCRIPTION
Added the ability to partition by a list of indices. E.g. partitioning by [i1, i2, i3] will split a string into up to 4 substrings consisting of the ranges from (0 - i1), (i1 - i2) (i2 -i3), (i3 - endOfString). 

What remains is 
a) Naming the function (currently just partition2 as a placeholder)
b) Figuring out what preconditions we want to have on the indices (and how to handle nonsense input, the behavior for partitioning a single string can be found in the test cases for that function, but don't generalize super well)
b) Test some boundary conditions (slightly blocked by point b)