### PR TITLE
update changelog and rely.json for rely 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# July 23, 2019
+### Rely 3.1.0
+* Add matchers for ensuring that a particular number of assertions have run (useful for testing assertions inside of callbacks)
+  - expect.assertions(int) verifies a specific number of (non expect.assertions/hasAssertions) assertions have been called
+  - expect.hasAssertions matchers verifies at least one (non expect.assertions/hasAssertions) assertion has been called
+
 # July 2, 2019
 ### Rely 3.0.0
 * Added functions for performing setup and teardown operations

--- a/rely.json
+++ b/rely.json
@@ -1,6 +1,6 @@
 {
   "name": "@reason-native/rely",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A native Reason test runner that is heavily inspired by Jest",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Landing directly, does't need to be reviewed