### PR TITLE
Pastel reset

### DIFF
--- a/src/pastel/Pastel.re
+++ b/src/pastel/Pastel.re
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */;
+open PastelInternal;
 
 include Mode;
 include Decorators;

--- a/src/pastel/Pastel.rei
+++ b/src/pastel/Pastel.rei
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */;
 
-module Make: () => PastelSig.PastelSig;
-module ColorName = ColorName;
+module Make: () => PastelInternal.PastelSig.PastelSig;
+module ColorName = PastelInternal.ColorName;
 
 type mode =
   | Terminal

--- a/src/pastel/Pastel.rei
+++ b/src/pastel/Pastel.rei
@@ -139,7 +139,9 @@ let createElement:
   let withHidden: style => style;
   let setStrikethrough: (bool, style) => style;
   let withStrikethrough: style => style;
-  
+  let withReset: style => style;
+  let setReset: (bool, style) => style;
+
   let getColor: style => option(ColorName.colorName);
   let getBackgroundColor: style => option(ColorName.colorName);
   let isBold: style => bool;
@@ -149,6 +151,7 @@ let createElement:
   let isInverse: style => bool;
   let isHidden: style => bool;
   let isStrikethrough: style => bool;
+  let isReset: style => bool;
 
   let parse: string => list((style, string));
   let apply: list((style, string)) => string;

--- a/src/pastel/PastelFactory.re
+++ b/src/pastel/PastelFactory.re
@@ -228,6 +228,9 @@ module Make = (()) => {
       strikethrough: Some(strikethrough ? Strikethrough : StrikethroughOff),
     };
   let withStrikethrough = setStrikethrough(true);
+  let setReset: (bool, style) => style =
+    (reset, style) => {...style, reset: Some(reset ? Reset : ResetOff)};
+  let withReset = setReset(true);
 
   let getColor: style => option(colorName) =
     style =>
@@ -326,6 +329,12 @@ module Make = (()) => {
     style =>
       switch (style.strikethrough) {
       | Some(Strikethrough) => true
+      | _ => false
+      };
+  let isReset: style => bool =
+    s =>
+      switch (s.reset) {
+      | Some(Reset) => true
       | _ => false
       };
 

--- a/src/pastel/PastelSig.re
+++ b/src/pastel/PastelSig.re
@@ -48,7 +48,7 @@ module type PastelSig = {
 
   type style;
   let emptyStyle: style;
-  
+
   let withColor: (ColorName.colorName, style) => style;
   let resetColor: style => style;
   let withBackgroundColor: (ColorName.colorName, style) => style;
@@ -68,7 +68,9 @@ module type PastelSig = {
   let withHidden: style => style;
   let setStrikethrough: (bool, style) => style;
   let withStrikethrough: style => style;
-  
+  let withReset: style => style;
+  let setReset: (bool, style) => style;
+
   let getColor: style => option(ColorName.colorName);
   let getBackgroundColor: style => option(ColorName.colorName);
   let isBold: style => bool;
@@ -78,6 +80,7 @@ module type PastelSig = {
   let isInverse: style => bool;
   let isHidden: style => bool;
   let isStrikethrough: style => bool;
+  let isReset: style => bool;
 
   let parse: string => list((style, string));
   let apply: list((style, string)) => string;

--- a/src/pastel/Token.re
+++ b/src/pastel/Token.re
@@ -40,7 +40,8 @@ type escapeSequence =
   | HiddenOff
   | Strikethrough
   | StrikethroughOff
-  | Reset;
+  | Reset
+  | ResetOff;
 
 type t =
   | Text(string)

--- a/src/pastel/ansiTerminal/Ansi.re
+++ b/src/pastel/ansiTerminal/Ansi.re
@@ -35,6 +35,7 @@ let createStyle = (start: int, stop: int): style => {
 
 type modifier = {
   reset: string,
+  resetOff: string,
   bold: style,
   dim: style,
   italic: style,
@@ -72,6 +73,7 @@ type color = {
 
 let modifier: modifier = {
   reset: "\027[0m",
+  resetOff: "\027[0m\027[0m",
   /* 21 isn't widely supported and 22 does the same thing */
   bold: createStyle(1, 22),
   dim: createStyle(2, 22),

--- a/src/pastel/ansiTerminal/TerminalImplementation.re
+++ b/src/pastel/ansiTerminal/TerminalImplementation.re
@@ -129,6 +129,13 @@ module TerminalStateMachine =
         | Some(StrikethroughOff) =>
           applyCode(Ansi.modifier.strikethrough.stop, s)
         };
+      let s =
+        switch (stateDiff.reset) {
+        | None => s
+        | Some(Reset) => applyCode(Ansi.modifier.reset, s)
+        | Some(ResetOff) =>
+          applyCode(Ansi.modifier.resetOff, s)
+        };
       s;
     };
   });
@@ -159,7 +166,7 @@ let createElement =
   let color = PastelUtils.(optionMap(color, colorNameToColor));
   let backgroundColor =
     PastelUtils.(optionMap(backgroundColor, colorNameToColor));
-    
+
   fromString(
     ~reset?,
     ~bold?,

--- a/src/pastel/dune
+++ b/src/pastel/dune
@@ -2,11 +2,18 @@
 (library
    (name Pastel)
    (public_name pastel.lib)
-   (libraries re unix)
-   (c_names winCygPtySupport winConsoleColorsSupport)
-   (js_of_ocaml
-     (flags (--pretty))
-     (javascript_files winCygPtySupport.js winConsoleColorsSupport.js)
-   )
+   (libraries pastel.internal)
+   (modules pastel)
+)
+(library
+  (name PastelInternal)
+  (public_name pastel.internal)
+  (libraries re unix)
+  (c_names winCygPtySupport winConsoleColorsSupport)
+  (js_of_ocaml
+    (flags (--pretty))
+    (javascript_files winCygPtySupport.js winConsoleColorsSupport.js)
+  )
+  (modules (:standard \ Pastel))
 )
 (include_subdirs unqualified)

--- a/src/pastel/humanReadable/HumanReadable.re
+++ b/src/pastel/humanReadable/HumanReadable.re
@@ -11,7 +11,7 @@ type style = {
 };
 
 type modifier = {
-  reset: string,
+  reset: style,
   bold: style,
   dim: style,
   italic: style,
@@ -67,7 +67,10 @@ let modifier: modifier = {
   inverse: makeStyle("inverse"),
   hidden: makeStyle("hidden"),
   strikethrough: makeStyle("strikethrough"),
-  reset: "<reset />"
+  reset: {
+    start: "<reset>",
+    stop: "</reset>"
+  }
 };
 
 let color: color = {

--- a/src/pastel/humanReadable/HumanReadableImplementation.re
+++ b/src/pastel/humanReadable/HumanReadableImplementation.re
@@ -123,6 +123,12 @@ module HumanReadableStateMachine =
         | Some(StrikethroughOff) =>
           applyCode(HumanReadable.modifier.strikethrough.stop, s)
         };
+      let s =
+        switch (stateDiff.reset) {
+        | None => s
+        | Some(Reset) => applyCode(HumanReadable.modifier.reset.start, s)
+        | Some(ResetOff) => applyCode(HumanReadable.modifier.reset.stop, s)
+        };
       s;
     };
   });

--- a/src/pastel/humanReadable/HumanReadableLexer.re
+++ b/src/pastel/humanReadable/HumanReadableLexer.re
@@ -10,7 +10,7 @@
   | RawEscapeSequence(string)
   | RawText(string);
 
-let humanReadableEscapeSequenceRegex = Re.Pcre.regexp("</?[a-z|A-Z]+>")
+let humanReadableEscapeSequenceRegex = Re.Pcre.regexp("(</?[a-z|A-Z]+>)")
 
 let tokenize = (s: string): list(humanReadableToken) => {
     s
@@ -90,7 +90,8 @@ let humanReadableTokenToToken = terminalToken => {
         | token when token == HumanReadable.modifier.underline.stop => UnderlineOff
         | token when token == HumanReadable.modifier.inverse.stop => InverseOff
         | token when token == HumanReadable.modifier.hidden.stop => HiddenOff
-        | token when token == HumanReadable.modifier.reset => Reset
+        | token when token == HumanReadable.modifier.reset.start => Reset
+        | token when token == HumanReadable.modifier.reset.stop => ResetOff
         | token when token == HumanReadable.modifier.strikethrough.stop =>
           StrikethroughOff
         | _ => raise(Invalid_argument("unrecognized escape sequence '" ++ String.escaped(token) ++ "'."))

--- a/tests/__tests__/pastel/Parse_test.re
+++ b/tests/__tests__/pastel/Parse_test.re
@@ -21,7 +21,6 @@ let runTestSuite = (mode, name) => {
                 <Pastel color=Red> "world" </Pastel>
               </Pastel>;
             let parts = Pastel.parse(input);
-
             expect.int(List.length(parts)).toBe(2);
             let (firstStyle, firstText, secondStyle, secondText) =
               switch (parts) {

--- a/tests/__tests__/pastel/Pastel_reset_test.re
+++ b/tests/__tests__/pastel/Pastel_reset_test.re
@@ -1,0 +1,83 @@
+open TestFramework;
+open Pastel;
+module HumanReadablePastel =
+  Pastel.Make({});
+HumanReadablePastel.setMode(HumanReadable);
+
+describe("Pastel.reset", ({test}) => {
+  test("apply reset state to single child human readable", ({expect}) => {
+    let stateRegion = (
+      HumanReadablePastel.(emptyStyle |> withReset),
+      "hello",
+    );
+    let result = HumanReadablePastel.apply([stateRegion]);
+
+    expect.string(String.escaped(result)).toEqual("<reset>hello</reset>");
+    ();
+  });
+  test("apply reset state terminal", ({expect}) => {
+    let stateRegion = (emptyStyle |> withReset, "hello");
+    let result = Pastel.apply([stateRegion]);
+
+    expect.string(String.escaped(result)).toEqual("\\027[0mhello\\027[0m\\027[0m");
+    ();
+  });
+  test("apply reset state with other state human readable", ({expect}) => {
+    let result =
+      HumanReadablePastel.(
+        apply([
+          (emptyStyle |> withReset, "hello"),
+          (emptyStyle |> withColor(Green), "world"),
+        ])
+      );
+
+    expect.string(String.escaped(result)).toEqual(
+      "<reset>hello</reset><green>world</resetColor>",
+    );
+    ();
+  });
+  test("Terminal E2E single child", ({expect}) => {
+    let input = <Pastel reset=true> "hello" </Pastel>;
+    expect.string(input).toEqual("\027[0mhello\027[0m\027[0m");
+  });
+  test("styles inside reset", ({expect}) => {
+    let input = <Pastel reset=true color=Green> "should be green" </Pastel>;
+    expect.string(input).toEqual("\027[0m\027[32mshould be green\027[0m\027[0m\027[39m");
+    ();
+  });
+  test("Terminal E2E nested", ({expect}) => {
+    let result =
+      <Pastel color=Green>
+        "Hello"
+        <Pastel dim=true>
+          "world"
+          <Pastel reset=true>
+            "unstyled"
+            <Pastel color=Magenta> "and magenta" </Pastel>
+          </Pastel>
+          "dim and green?"
+        </Pastel>
+      </Pastel>;
+    expect.string(result).toEqual(
+      "\027[32mHello\027[2mworld\027[0munstyled\027[0m\027[35mand magenta\027[0m\027[0m\027[2m\027[32mdim and green?\027[22m\027[39m",
+    );
+  });
+  test("Human readable E2E nested", ({expect}) => {
+    let input =
+      <HumanReadablePastel color=Green>
+        "Hello"
+        <HumanReadablePastel dim=true>
+          "world"
+          <HumanReadablePastel reset=true>
+            "unstyled"
+            <HumanReadablePastel color=Magenta>
+              "and magenta"
+            </HumanReadablePastel>
+          </HumanReadablePastel>
+        </HumanReadablePastel>
+      </HumanReadablePastel>;
+    expect.string(input).toEqual(
+      "<green>Hello<dim>world<reset>unstyled<reset><magenta>and magenta</reset></resetColor>",
+    );
+  });
+});

--- a/tests/dune
+++ b/tests/dune
@@ -9,6 +9,7 @@
     dir.lib
     rely.lib
     rely.internal
+    pastel.internal
     pastel.lib
     console.lib
     pastel-console.lib


### PR DESCRIPTION
Implement reset. Reset has been part of the public API from the start but never actually did anything. This is also kind of an example of how explicit "false" overrides for things like dim/bold/underline can work. 

I essentially used a "resetOff" signal (implemented as two resets in the terminal implementation) so that we can handle cases like the below. We could do something like "reset-underlineOff-reset" to handle explicitly turning off modifiers in the future.

```reason
      <Pastel color=Green>
        "Hello"
        <Pastel dim=true>
          "world"
          <Pastel reset=true>
            "unstyled"
            <Pastel color=Magenta> "and magenta" </Pastel>
          </Pastel>
          "dim and green?"
        </Pastel>
      </Pastel>
```
produces
![image](https://user-images.githubusercontent.com/5252755/63625763-77224d80-c5b5-11e9-97e6-eee4aa997bef.png)
