### PR TITLE
remove unused extern declaration from object printer

### DIFF
--- a/shared-src/objectPrinter/ObjectPrinter.re
+++ b/shared-src/objectPrinter/ObjectPrinter.re
@@ -31,7 +31,6 @@ let setMaxLength = l => {
  * ~maxLength: Length to examine before making a decision. Must correspond to
  * the printing max length.
  */
-external _out: string => unit = "native_out";
 let rec detectList: type o. (~maxLength: int, o) => bool =
   (~maxLength, o) =>
     if (maxLength === 0) {


### PR DESCRIPTION
This was causing issues when linking Rely and not Console. I believe that we we haven't actually released a version of Rely with this bug though