### PR TITLE
Fix @reason-native/refmterr to refmterr

### DIFF
--- a/docs/refmterr/quickstart.md
+++ b/docs/refmterr/quickstart.md
@@ -10,10 +10,10 @@ sidebar_label: Quickstart
 
 To install Refmterr in your project with esy, run
 ```sh
-esy add @reason-native/refmterr
+esy add refmterr
 ```
 
-This will add `@reason-native/refmterr` into your `package.json`.
+This will add `refmterr` into your `package.json`.
 
 ## Add to Build Pipeline
 


### PR DESCRIPTION
If I understand correctly, there is no one named `@reason-native/refmterr` and `refmterr` is correct.