### PR TITLE
add documentation for mock functions, reorganize Rely docs in sidebars, update Rely index

### DIFF
--- a/docs/rely/index.md
+++ b/docs/rely/index.md
@@ -4,14 +4,15 @@ title: Rely Introduction
 sidebar_label: Introduction
 ---
 
-Rely is a strongly typed, [Jest-like](https://jestjs.io/) native test framework with blazing fast performance 🔥🔥🔥.
+Rely is a [Jest-inspired](https://jestjs.io/) native Reason testing framework. 
 
-It comes with built in support for both traditional and snapshot testing, and bootstraps tests in **milliseconds**.
+We took the things we loved about Jest (beautiful output, descriptive assertion framework, and snapshot testing), added some type safety, and built a library that can compile and run entire test suites both natively and in JS with [Js_of_ocaml](https://ocsigen.org/js_of_ocaml/3.1.0/manual/overview) in **milliseconds**.
+
 
 ```re
 describe("Example", ({test}) => {
   test("ints", ({expect}) =>
-    expect.int(7).toBe(5)
+    expect.int(1 + 1).toBe(3)
   );
   test("bools", ({expect}) =>
     expect.bool(true).not.toBe(false)

--- a/docs/rely/mock-functions.md
+++ b/docs/rely/mock-functions.md
@@ -1,0 +1,209 @@
+---
+id: mock-functions
+title: Mock Functions
+sidebar_label: Mock Functions
+---
+
+Mock functions (or "spies") in Rely can be used to track information about the arguments and return values of functions and allow for test-time configuration of return values. Rely has built in matchers for dealing with mock functions that are documented extensively [here](expect.md#expectmock).
+
+> Unlike Jest in JavaScript, module level mocking is not supported. The functionality available in Rely is analagous to what Jest offers via [`jest.fn` ](https://jestjs.io/docs/en/jest-object#jestfnimplementation) and there is no direct [`jest.mock`](https://jestjs.io/docs/en/jest-object#jestmockmodulename-factory-options) analogy. Many situations in which `jest.mock` would be useful can be addressed through dependency management and the structuring of side effects within your application. A simple example using functors is shown [below](#injecting-via-functor).
+
+## Using Mock Functions
+
+### Creating Mocks
+
+There are constructors for creating mocks that take up to 7 arguments. A default implementation must be specified.
+
+```reason
+open TestFramework;
+
+let calculateInterest = Mock.mock3((p, r, t) => p *. exp(r *. t));
+```
+
+```reason
+module Mock: {
+  type t('fn, 'returnType, 'tupledArgs);
+
+  let mock1: ('args => 'ret) => t('args => 'ret, 'ret, 'args);
+
+  let mock2:
+    (('arg1, 'arg2) => 'ret) =>
+    t(('arg1, 'arg2) => 'ret, 'ret, ('arg1, 'arg2));
+
+  let mock3:
+    (('arg1, 'arg2, 'arg3) => 'ret) =>
+    t(('arg1, 'arg2, 'arg3) => 'ret, 'ret, ('arg1, 'arg2, 'arg3));
+
+  let mock4:
+    (('arg1, 'arg2, 'arg3, 'arg4) => 'ret) =>
+    t(
+      ('arg1, 'arg2, 'arg3, 'arg4) => 'ret,
+      'ret,
+      ('arg1, 'arg2, 'arg3, 'arg4),
+    );
+
+  let mock5:
+    (('arg1, 'arg2, 'arg3, 'arg4, 'arg5) => 'ret) =>
+    t(
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5) => 'ret,
+      'ret,
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5),
+    );
+
+  let mock6:
+    (('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6) => 'ret) =>
+    t(
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6) => 'ret,
+      'ret,
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6),
+    );
+
+  let mock7:
+    (('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6, 'arg7) => 'ret) =>
+    t(
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6, 'arg7) => 'ret,
+      'ret,
+      ('arg1, 'arg2, 'arg3, 'arg4, 'arg5, 'arg6, 'arg7),
+    );
+};
+```
+
+### Calling Mock Functions
+
+The `Mock.mockN` constructor returns a mutable opaque type for tracking call information. To access the underlying function, use `Mock.fn`.
+
+```reason
+open TestFramework;
+
+describe("Mock documentation", ({test}) => {
+  test("calling a mock function", ({expect}) => {
+    let mockDouble = Mock.mock1(x => x * 2);
+    let mockFunction = Mock.fn(mockDouble);
+
+    expect.int(mockFunction(2)).toBe(4);
+  })
+});
+```
+
+### Injecting via Functor
+
+When testing code with side effects such as talking to a database or making network requests, it is often desirable to be able to mock out these side effects. A straightforward way of achieving this is by passing the side effect performing functions as arguments, however this is not always desirable due to the problem of threading such arguments through deeply nested code. The use of module functions (functors) can accomplish a similar thing and somewhat alleviate this issue. 
+
+For example suppose that we have some code that uses a logger. In production we want the logger to make HTTP requests to some endpoint, however we deem this behavior undesirable for our test.
+
+Without abstracting away the dependendency on our http logger, our code might look like this.
+#### MyModule.re
+
+```reasonml
+module MyApp {
+  let doSomethingThatGetsLogged = ()  => {
+    HTTPLogger.log("starting to do someting");
+    SomeModule.doSomething();
+    HTTPLogger.log("did the thing!");
+  }
+}
+```
+
+Instead we could inject the code via a functor (module function) or via an ordinary function.
+
+#### MyModule.re
+```reason {
+module Make = (Dependencies: { let log: string => unit }) => {
+  let doSomethingThatGetsLogged = ()  => {
+    Dependencies.log("starting to do something");
+    SomeModule.doSomething();
+    Dependencies.log("did the thing!");
+  }
+}
+/* Making the "real" versions of the module could easily be handled elsewhere
+ *  in the application but is shown here for simplicity */
+include Make({
+  /* Generally it would be better practice to have some Logger module type and 
+   * specify that there is a logger module in the functor signature, but for the 
+   * simplicity of this example a function instead */
+  let log = HTTPLogger.log;
+});
+```
+
+In your tests you can do this
+#### MyModuleTest.re
+```reason {
+open TestFramework;
+
+let mockLog = Mock.mock1(_ => ());
+module MyModule =
+  RelyTalk.MyModule.Make({
+    let log = Mock.fn(mockLog);
+  });
+
+let {describe} =
+  describeConfig
+  |> withLifecycle(testLifecycle =>
+       testLifecycle |> beforeEach(() => Mock.reset(mockLog))
+     )
+  |> build;
+
+describe("MyModule", ({test}) => {
+  test("Should log a start message", ({expect}) => {
+    MyModule.doSomethingThatGetsLogged();
+    expect.mock(mockLog).toBeCalledWith("starting to do something");
+  });
+  test("should log a completion message", ({expect}) => {
+    MyModule.doSomethingThatGetsLogged();
+    expect.mock(mockLog).toBeCalledWith("did the thing!");
+  });
+});
+```
+
+## API reference
+
+### Mock.changeImplementation(implementation, mock)
+
+Accepts an implementation to be used for calls to the underlying mock function. The original implementation passed to the Mock constructor can be restored via [`Mock.reset`](#mockresetmock) or [`Mock.resetImplementation`](#mockresetimplementationmock).
+
+```reason
+open TestFramework;
+
+describe("Mock.changeImplementation", ({test}) => {
+  test("changes function implementation", ({expect}) => {
+    let mock = Mock.mock1(() => 42);
+    let fn = Mock.fn(mock);
+    expect.int(fn()).toBe(42);
+
+    Mock.changeImplementation(() => 43, mock);
+
+    expect.int(fn()).toBe(43);
+  });
+});
+```
+
+
+
+### Mock.reset(mock)
+Resets all information relating to stored calls and results as well as restoring the mock to the original implementation it was constructed with.
+
+Equivalent to calling both [`Mock.resetHistory`](#mockresethistorymock) and [`Mock.resetImplementation`](#mockresetimplementationmock)
+
+### Mock.resetHistory(mock)
+Resets all information relating to stored calls and results.
+
+Often this is useful when you want to clean up a mock's usage data between two assertions.
+
+### Mock.resetImplementation(mock)
+Restores the original mock implementation to what it was first constructed with, regardless of how many times [`Mock.changeImplementation`](#mockchangeimplementationimplementation-mock) has been called.
+
+### Mock.getCalls(mock)
+
+Returns a list of the arguments that have been passed to the underlying function. The calls are ordered from most to least recent. Generally the [built in mock matchers](expect.md#expectmock) should be used instead of `Mock.getCalls`.
+
+### Mock.getResults(mock)
+
+Returns a list of `Mock.result` from the underlying function. The calls are ordered from most to least recent. Generally the [built in mock matchers](expect.md#expectmock) should be used instead of `Mock.getResults`.
+
+```reason
+module Mock {
+    type result('a) =
+    | Return('a)
+    | Exception(exn, option(Printexc.location), string);
+}
+```

--- a/docs/rely/mock-functions.md
+++ b/docs/rely/mock-functions.md
@@ -4,7 +4,7 @@ title: Mock Functions
 sidebar_label: Mock Functions
 ---
 
-Mock functions (or "spies") in Rely can be used to track information about the arguments and return values of functions and allow for test-time configuration of return values. Rely has built in matchers for dealing with mock functions that are documented extensively [here](expect.md#expectmock).
+Mock functions (or "spies") in Rely can be used to track information about the arguments and return values of functions, and allow for test-time configuration of return values. Rely has built-in matchers for dealing with mock functions that are documented extensively [here](expect.md#expectmock).
 
 > Unlike Jest in JavaScript, module level mocking is not supported. The functionality available in Rely is analagous to what Jest offers via [`jest.fn` ](https://jestjs.io/docs/en/jest-object#jestfnimplementation) and there is no direct [`jest.mock`](https://jestjs.io/docs/en/jest-object#jestmockmodulename-factory-options) analogy. Many situations in which `jest.mock` would be useful can be addressed through dependency management and the structuring of side effects within your application. A simple example using functors is shown [below](#injecting-via-functor).
 
@@ -87,11 +87,11 @@ describe("Mock documentation", ({test}) => {
 
 ### Injecting via Functor
 
-When testing code with side effects such as talking to a database or making network requests, it is often desirable to be able to mock out these side effects. A straightforward way of achieving this is by passing the side effect performing functions as arguments, however this is not always desirable due to the problem of threading such arguments through deeply nested code. The use of module functions (functors) can accomplish a similar thing and somewhat alleviate this issue.
+When testing code with side effects such as talking to a database or making network requests, it is often desirable to be able to mock out these side effects. A straightforward way of achieving this is by passing functions that perform side effects as arguments. However, this is not always desirable due to the problem of threading such arguments through deeply nested code. The use of module functions (functors) can accomplish a similar thing and somewhat alleviate this issue.
 
-For example suppose that we have some code that uses a logger. In production we want the logger to make HTTP requests to some endpoint, however we deem this behavior undesirable for our test.
+For example, suppose that we have some code that uses a logger. In production we want the logger to make HTTP requests to some endpoint, but we deem this behavior undesirable for our test.
 
-Without abstracting away the dependendency on our http logger, our code might look like this.
+Without abstracting away the dependendency on our HTTP logger, our code might look like this.
 
 #### MyModule.re
 
@@ -125,7 +125,7 @@ include Make({
   /*
    * Generally it would be better practice to have some Logger module type and
    * specify that there is a logger module in the functor signature, but for the
-   * simplicity of this example a function instead
+   * simplicity of this example we use a function instead
    */
   let log = HTTPLogger.log;
 });
@@ -187,7 +187,7 @@ describe("Mock.changeImplementation", ({test}) => {
 
 ### Mock.reset(mock)
 
-Resets all information relating to stored calls and results as well as restoring the mock to the original implementation it was constructed with.
+Resets all information relating to stored calls and results, as well as restoring the mock to the original implementation it was constructed with.
 
 Equivalent to calling both [`Mock.resetHistory`](#mockresethistorymock) and [`Mock.resetImplementation`](#mockresetimplementationmock)
 

--- a/docs/rely/mock-functions.md
+++ b/docs/rely/mock-functions.md
@@ -87,46 +87,54 @@ describe("Mock documentation", ({test}) => {
 
 ### Injecting via Functor
 
-When testing code with side effects such as talking to a database or making network requests, it is often desirable to be able to mock out these side effects. A straightforward way of achieving this is by passing the side effect performing functions as arguments, however this is not always desirable due to the problem of threading such arguments through deeply nested code. The use of module functions (functors) can accomplish a similar thing and somewhat alleviate this issue. 
+When testing code with side effects such as talking to a database or making network requests, it is often desirable to be able to mock out these side effects. A straightforward way of achieving this is by passing the side effect performing functions as arguments, however this is not always desirable due to the problem of threading such arguments through deeply nested code. The use of module functions (functors) can accomplish a similar thing and somewhat alleviate this issue.
 
 For example suppose that we have some code that uses a logger. In production we want the logger to make HTTP requests to some endpoint, however we deem this behavior undesirable for our test.
 
 Without abstracting away the dependendency on our http logger, our code might look like this.
+
 #### MyModule.re
 
 ```reasonml
-module MyApp {
-  let doSomethingThatGetsLogged = ()  => {
+module MyApp = {
+  let doSomethingThatGetsLogged = () => {
     HTTPLogger.log("starting to do someting");
     SomeModule.doSomething();
     HTTPLogger.log("did the thing!");
-  }
-}
+  };
+};
 ```
 
 Instead we could inject the code via a functor (module function) or via an ordinary function.
 
 #### MyModule.re
+
 ```reason {
-module Make = (Dependencies: { let log: string => unit }) => {
-  let doSomethingThatGetsLogged = ()  => {
+module Make = (Dependencies: {let log: string => unit;}) => {
+  let doSomethingThatGetsLogged = () => {
     Dependencies.log("starting to do something");
     SomeModule.doSomething();
     Dependencies.log("did the thing!");
-  }
-}
-/* Making the "real" versions of the module could easily be handled elsewhere
- *  in the application but is shown here for simplicity */
+  };
+};
+/*
+ * Making the "real" versions of the module could easily be handled elsewhere
+ *  in the application but is shown here for simplicity
+ */
 include Make({
-  /* Generally it would be better practice to have some Logger module type and 
-   * specify that there is a logger module in the functor signature, but for the 
-   * simplicity of this example a function instead */
+  /*
+   * Generally it would be better practice to have some Logger module type and
+   * specify that there is a logger module in the functor signature, but for the
+   * simplicity of this example a function instead
+   */
   let log = HTTPLogger.log;
 });
 ```
 
 In your tests you can do this
+
 #### MyModuleTest.re
+
 ```reason {
 open TestFramework;
 
@@ -177,19 +185,20 @@ describe("Mock.changeImplementation", ({test}) => {
 });
 ```
 
-
-
 ### Mock.reset(mock)
+
 Resets all information relating to stored calls and results as well as restoring the mock to the original implementation it was constructed with.
 
 Equivalent to calling both [`Mock.resetHistory`](#mockresethistorymock) and [`Mock.resetImplementation`](#mockresetimplementationmock)
 
 ### Mock.resetHistory(mock)
+
 Resets all information relating to stored calls and results.
 
 Often this is useful when you want to clean up a mock's usage data between two assertions.
 
 ### Mock.resetImplementation(mock)
+
 Restores the original mock implementation to what it was first constructed with, regardless of how many times [`Mock.changeImplementation`](#mockchangeimplementationimplementation-mock) has been called.
 
 ### Mock.getCalls(mock)
@@ -201,9 +210,9 @@ Returns a list of the arguments that have been passed to the underlying function
 Returns a list of `Mock.result` from the underlying function. The calls are ordered from most to least recent. Generally the [built in mock matchers](expect.md#expectmock) should be used instead of `Mock.getResults`.
 
 ```reason
-module Mock {
-    type result('a) =
+module Mock = {
+  type result('a) =
     | Return('a)
     | Exception(exn, option(Printexc.location), string);
-}
+};
 ```

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -80,6 +80,10 @@
         "title": "Rely Introduction",
         "sidebar_label": "Introduction"
       },
+      "rely/mock-functions": {
+        "title": "Mock Functions",
+        "sidebar_label": "Mock Functions"
+      },
       "rely/quickstart": {
         "title": "Rely Quickstart",
         "sidebar_label": "Quickstart"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,33 +1,32 @@
 {
   "docs": {
-    "Overview": [
-      "introduction",
-      "native-basics",
-      "getting-started"
-    ],
+    "Overview": ["introduction", "native-basics", "getting-started"],
     "Rely": [
       "rely/index",
       "rely/quickstart",
-      "rely/api",
-      "rely/expect",
-      "rely/setup-teardown",
+      {
+        "type": "subcategory",
+        "label": "Guides",
+        "ids": ["rely/setup-teardown", "rely/mock-functions"]
+      },
+      {
+        "type": "subcategory",
+        "label": "API Reference",
+        "ids": [
+          "rely/api",
+          "rely/expect"
+        ]
+      },
       "rely/advanced"
     ],
-    "Console": [
-      "console/index",
-      "console/quickstart",
-      "console/api"
-    ],
+    "Console": ["console/index", "console/quickstart", "console/api"],
     "Pastel": [
       "pastel/index",
       "pastel/quickstart",
       "pastel/api",
       "pastel/console"
     ],
-    "Refmterr": [
-      "refmterr/index",
-      "refmterr/quickstart"
-    ],
+    "Refmterr": ["refmterr/index", "refmterr/quickstart"],
     "File Context Printer": [
       "file-context-printer/index",
       "file-context-printer/quickstart",


### PR DESCRIPTION
Added docs for mock functions and updated the intro based on some feedback from Jim.

Rely sidebars look like this now (organization help also from Jim)
![image](https://user-images.githubusercontent.com/5252755/69263195-d7b02f00-0b92-11ea-8252-6ae25eac3331.png)
