### PR TITLE
make is_cygpty_used return 0 instead of false to work with pattern ma…

### DIFF
--- a/src/pastel/SupportsColor.re
+++ b/src/pastel/SupportsColor.re
@@ -11,7 +11,7 @@ let (>>=) = (o, f) =>
   };
 
 let getenv_opt = s =>
-  try (Some(Sys.getenv(s))) {
+  try(Some(Sys.getenv(s))) {
   | Not_found => None
   };
 
@@ -22,7 +22,7 @@ type level =
   | TrueColorSupport;
 
 let geEnvOpt = s =>
-  try (Some(Sys.getenv(s))) {
+  try(Some(Sys.getenv(s))) {
   | Not_found => None
   };
 
@@ -46,11 +46,10 @@ let isTTY = fileDescriptor =>
 let inferLevel = fileDescriptor =>
   if (disable) {
     NoSupport;
+  } else if (isTTY(fileDescriptor)) {
+    BasicColorSupport;
   } else {
-    switch (isTTY(fileDescriptor)) {
-    | false => minLevel
-    | true => BasicColorSupport
-    };
+    minLevel;
   };
 
 let stdin = inferLevel(Unix.stdin);

--- a/src/pastel/winCygPtySupport.js
+++ b/src/pastel/winCygPtySupport.js
@@ -7,5 +7,5 @@
 
 //Provides: is_cygpty_used
 function is_cygpty_used() {
-  return false;
+  return 0;
 }


### PR DESCRIPTION
…tching against bools. Also refactory SupportsColor to use if else instead of pattern matching against bools as I think it looks cleaner

Basically I noticed that non tty terminals were still getting colored output with Pastel when compiled to JS, after talking with Jordan we figured out that it was due to pattern matching with false causing a triple equal comparison between 0 and false. The cygpty stub should return 0 to align with the representation used by JSOO. (I first fixed the issue by refactoring to an if/else and decided to keep it because I think it is marginally more readable in this case)