### PR TITLE
Add a `make` function to use Pastel without ppx

### DIFF
--- a/src/pastel/DisabledImplementation.re
+++ b/src/pastel/DisabledImplementation.re
@@ -79,7 +79,7 @@ let implementation: PastelImplementation.t = {
   length,
   unformattedText: identityDecorator,
   partition,
-  create:
+  make:
     (
       ~reset: option(bool)=?,
       ~bold: option(bool)=?,

--- a/src/pastel/DisabledImplementation.re
+++ b/src/pastel/DisabledImplementation.re
@@ -79,7 +79,7 @@ let implementation: PastelImplementation.t = {
   length,
   unformattedText: identityDecorator,
   partition,
-  createElement:
+  create:
     (
       ~reset: option(bool)=?,
       ~bold: option(bool)=?,
@@ -91,10 +91,9 @@ let implementation: PastelImplementation.t = {
       ~strikethrough: option(bool)=?,
       ~color: option(ColorName.colorName)=?,
       ~backgroundColor: option(ColorName.colorName)=?,
-      ~children: list(string),
-      (),
+      inputs,
     ) =>
-    String.concat("", children),
+    String.concat("", inputs),
   emptyStyle: StateMachine.initialState,
   parse: s => [(StateMachine.initialState, s)],
   apply: s =>

--- a/src/pastel/Pastel.rei
+++ b/src/pastel/Pastel.rei
@@ -103,7 +103,7 @@ let whiteBright: decorator;
 /** Pastel.create allows non-pxx users to use Pastel.
    * If you are using Reason, we recommend that you use the JSX ppx along side with Pastel.
    * `<Pastel italic=true> "World" </Pastel>` is equivalent to `Pastel.create("World", ~italic=true)` */
-let create:
+let make:
   (
     ~reset: bool=?,
     ~bold: bool=?,

--- a/src/pastel/Pastel.rei
+++ b/src/pastel/Pastel.rei
@@ -100,9 +100,9 @@ let magentaBright: decorator;
 let cyanBright: decorator;
 let whiteBright: decorator;
 
-/** Pastel.create allows non-pxx users to use Pastel.
+/** Pastel.make allows non-pxx users to use Pastel.
    * If you are using Reason, we recommend that you use the JSX ppx along side with Pastel.
-   * `<Pastel italic=true> "World" </Pastel>` is equivalent to `Pastel.create("World", ~italic=true)` */
+   * `<Pastel italic=true> "World" </Pastel>` is equivalent to `Pastel.make("World", ~italic=true)` */
 let make:
   (
     ~reset: bool=?,

--- a/src/pastel/Pastel.rei
+++ b/src/pastel/Pastel.rei
@@ -102,7 +102,7 @@ let whiteBright: decorator;
 
 /** Pastel.make allows non-pxx users to use Pastel.
    * If you are using Reason, we recommend that you use the JSX ppx along side with Pastel.
-   * `<Pastel italic=true> "World" </Pastel>` is equivalent to `Pastel.make("World", ~italic=true)` */
+   * `<Pastel italic=true> "World" </Pastel>` is equivalent to `Pastel.make(["World"], ~italic=true)` */
 let make:
   (
     ~reset: bool=?,

--- a/src/pastel/Pastel.rei
+++ b/src/pastel/Pastel.rei
@@ -100,6 +100,25 @@ let magentaBright: decorator;
 let cyanBright: decorator;
 let whiteBright: decorator;
 
+/** Pastel.create allows non-pxx users to use Pastel.
+   * If you are using Reason, we recommend that you use the JSX ppx along side with Pastel.
+   * `<Pastel italic=true> "World" </Pastel>` is equivalent to `Pastel.create("World", ~italic=true)` */
+let create:
+  (
+    ~reset: bool=?,
+    ~bold: bool=?,
+    ~dim: bool=?,
+    ~italic: bool=?,
+    ~underline: bool=?,
+    ~inverse: bool=?,
+    ~hidden: bool=?,
+    ~strikethrough: bool=?,
+    ~color: colorName=?,
+    ~backgroundColor: colorName=?,
+    list(string),
+  ) =>
+  string;
+
 let createElement:
   (
     ~reset: bool=?,

--- a/src/pastel/PastelFactory.re
+++ b/src/pastel/PastelFactory.re
@@ -148,7 +148,7 @@ module Make = (()) => {
 
   let whiteBright = color.whiteBright;
 
-  let create =
+  let make =
       (
         ~reset: option(bool)=?,
         ~bold: option(bool)=?,

--- a/src/pastel/PastelFactory.re
+++ b/src/pastel/PastelFactory.re
@@ -162,7 +162,7 @@ module Make = (()) => {
         ~backgroundColor: option(colorName)=?,
         inputs: list(string),
       ) => {
-    selectedImplementation^.create(
+    selectedImplementation^.make(
       ~reset?,
       ~bold?,
       ~dim?,
@@ -192,7 +192,7 @@ module Make = (()) => {
         ~children: list(string),
         (),
       ) => {
-    create(
+    make(
       ~reset?,
       ~bold?,
       ~dim?,

--- a/src/pastel/PastelFactory.re
+++ b/src/pastel/PastelFactory.re
@@ -148,6 +148,35 @@ module Make = (()) => {
 
   let whiteBright = color.whiteBright;
 
+  let create =
+      (
+        ~reset: option(bool)=?,
+        ~bold: option(bool)=?,
+        ~dim: option(bool)=?,
+        ~italic: option(bool)=?,
+        ~underline: option(bool)=?,
+        ~inverse: option(bool)=?,
+        ~hidden: option(bool)=?,
+        ~strikethrough: option(bool)=?,
+        ~color: option(colorName)=?,
+        ~backgroundColor: option(colorName)=?,
+        inputs: list(string),
+      ) => {
+    selectedImplementation^.create(
+      ~reset?,
+      ~bold?,
+      ~dim?,
+      ~italic?,
+      ~underline?,
+      ~inverse?,
+      ~hidden?,
+      ~strikethrough?,
+      ~color?,
+      ~backgroundColor?,
+      inputs,
+    );
+  };
+
   let createElement =
       (
         ~reset: option(bool)=?,
@@ -163,7 +192,7 @@ module Make = (()) => {
         ~children: list(string),
         (),
       ) => {
-    selectedImplementation^.createElement(
+    create(
       ~reset?,
       ~bold?,
       ~dim?,
@@ -174,8 +203,7 @@ module Make = (()) => {
       ~strikethrough?,
       ~color?,
       ~backgroundColor?,
-      ~children,
-      (),
+      children,
     );
   };
 

--- a/src/pastel/PastelImplementation.re
+++ b/src/pastel/PastelImplementation.re
@@ -12,7 +12,7 @@ type t = {
   length: string => int,
   unformattedText: string => string,
   partition: (int, string) => (string, string),
-  create:
+  make:
     (
       ~reset: bool=?,
       ~bold: bool=?,

--- a/src/pastel/PastelImplementation.re
+++ b/src/pastel/PastelImplementation.re
@@ -12,7 +12,7 @@ type t = {
   length: string => int,
   unformattedText: string => string,
   partition: (int, string) => (string, string),
-  createElement:
+  create:
     (
       ~reset: bool=?,
       ~bold: bool=?,
@@ -24,8 +24,7 @@ type t = {
       ~strikethrough: bool=?,
       ~color: ColorName.colorName=?,
       ~backgroundColor: ColorName.colorName=?,
-      ~children: list(string),
-      unit
+      list(string),
     ) =>
     string,
   emptyStyle: StateMachine.state,

--- a/src/pastel/PastelSig.re
+++ b/src/pastel/PastelSig.re
@@ -85,6 +85,22 @@ module type PastelSig = {
   let unstable_parse: string => list((style, string));
   let unstable_apply: list((style, string)) => string;
 
+  let create:
+    (
+      ~reset: bool=?,
+      ~bold: bool=?,
+      ~dim: bool=?,
+      ~italic: bool=?,
+      ~underline: bool=?,
+      ~inverse: bool=?,
+      ~hidden: bool=?,
+      ~strikethrough: bool=?,
+      ~color: colorName=?,
+      ~backgroundColor: colorName=?,
+      list(string),
+    ) =>
+    string;
+
   let createElement:
     (
       ~reset: bool=?,

--- a/src/pastel/PastelSig.re
+++ b/src/pastel/PastelSig.re
@@ -85,7 +85,7 @@ module type PastelSig = {
   let unstable_parse: string => list((style, string));
   let unstable_apply: list((style, string)) => string;
 
-  let create:
+  let make:
     (
       ~reset: bool=?,
       ~bold: bool=?,

--- a/src/pastel/StateMachine.re
+++ b/src/pastel/StateMachine.re
@@ -322,8 +322,7 @@ module Make =
         ~strikethrough: option(bool)=?,
         ~color: option(color)=?,
         ~backgroundColor: option(color)=?,
-        ~children: list(string),
-        (),
+        inputs: list(string),
       ) => {
     let state = {
       reset:
@@ -347,9 +346,9 @@ module Make =
       foreground: color,
       background: backgroundColor,
     };
-    let childrenStr = String.concat("", children);
-    let childStateRegions = parseStateRegions(childrenStr);
-    applyState(state, childStateRegions);
+    let inputsStr = String.concat("", inputs);
+    let inputsStateRegions = parseStateRegions(inputsStr);
+    applyState(state, inputsStateRegions);
   };
 
   let partitionFromStateRegions = (index: int, regions: list(stateRegion)) => {
@@ -418,75 +417,75 @@ module Make =
     s |> parseStateRegions |> unformattedTextFromStateRegions;
 
   let modifier: Decorators.modifier = {
-    bold: (s: string) => fromString(~bold=true, ~children=[s], ()),
-    dim: (s: string) => fromString(~dim=true, ~children=[s], ()),
-    italic: (s: string) => fromString(~italic=true, ~children=[s], ()),
+    bold: (s: string) => fromString(~bold=true, [s]),
+    dim: (s: string) => fromString(~dim=true, [s]),
+    italic: (s: string) => fromString(~italic=true, [s]),
     underline: (s: string) =>
-      fromString(~underline=true, ~children=[s], ()),
-    inverse: (s: string) => fromString(~inverse=true, ~children=[s], ()),
-    hidden: (s: string) => fromString(~hidden=true, ~children=[s], ()),
+      fromString(~underline=true, [s]),
+    inverse: (s: string) => fromString(~inverse=true, [s]),
+    hidden: (s: string) => fromString(~hidden=true, [s]),
     strikethrough: (s: string) =>
-      fromString(~strikethrough=true, ~children=[s], ()),
+      fromString(~strikethrough=true, [s]),
   };
 
   let color: Decorators.color = {
-    black: (s: string) => fromString(~color=Black, ~children=[s], ()),
-    red: (s: string) => fromString(~color=Red, ~children=[s], ()),
-    green: (s: string) => fromString(~color=Green, ~children=[s], ()),
-    yellow: (s: string) => fromString(~color=Yellow, ~children=[s], ()),
-    blue: (s: string) => fromString(~color=Blue, ~children=[s], ()),
-    magenta: (s: string) => fromString(~color=Magenta, ~children=[s], ()),
-    cyan: (s: string) => fromString(~color=Cyan, ~children=[s], ()),
-    white: (s: string) => fromString(~color=White, ~children=[s], ()),
+    black: (s: string) => fromString(~color=Black, [s]),
+    red: (s: string) => fromString(~color=Red, [s]),
+    green: (s: string) => fromString(~color=Green, [s]),
+    yellow: (s: string) => fromString(~color=Yellow, [s]),
+    blue: (s: string) => fromString(~color=Blue, [s]),
+    magenta: (s: string) => fromString(~color=Magenta, [s]),
+    cyan: (s: string) => fromString(~color=Cyan, [s]),
+    white: (s: string) => fromString(~color=White, [s]),
     blackBright: (s: string) =>
-      fromString(~color=BrightBlack, ~children=[s], ()),
+      fromString(~color=BrightBlack, [s]),
     redBright: (s: string) =>
-      fromString(~color=BrightRed, ~children=[s], ()),
+      fromString(~color=BrightRed, [s]),
     greenBright: (s: string) =>
-      fromString(~color=BrightGreen, ~children=[s], ()),
+      fromString(~color=BrightGreen, [s]),
     yellowBright: (s: string) =>
-      fromString(~color=BrightYellow, ~children=[s], ()),
+      fromString(~color=BrightYellow, [s]),
     blueBright: (s: string) =>
-      fromString(~color=BrightBlue, ~children=[s], ()),
+      fromString(~color=BrightBlue, [s]),
     magentaBright: (s: string) =>
-      fromString(~color=BrightMagenta, ~children=[s], ()),
+      fromString(~color=BrightMagenta, [s]),
     cyanBright: (s: string) =>
-      fromString(~color=BrightCyan, ~children=[s], ()),
+      fromString(~color=BrightCyan, [s]),
     whiteBright: (s: string) =>
-      fromString(~color=BrightWhite, ~children=[s], ()),
+      fromString(~color=BrightWhite, [s]),
   };
 
   let bg: Decorators.color = {
     black: (s: string) =>
-      fromString(~backgroundColor=Black, ~children=[s], ()),
-    red: (s: string) => fromString(~backgroundColor=Red, ~children=[s], ()),
+      fromString(~backgroundColor=Black, [s]),
+    red: (s: string) => fromString(~backgroundColor=Red, [s]),
     green: (s: string) =>
-      fromString(~backgroundColor=Green, ~children=[s], ()),
+      fromString(~backgroundColor=Green, [s]),
     yellow: (s: string) =>
-      fromString(~backgroundColor=Yellow, ~children=[s], ()),
+      fromString(~backgroundColor=Yellow, [s]),
     blue: (s: string) =>
-      fromString(~backgroundColor=Blue, ~children=[s], ()),
+      fromString(~backgroundColor=Blue, [s]),
     magenta: (s: string) =>
-      fromString(~backgroundColor=Magenta, ~children=[s], ()),
+      fromString(~backgroundColor=Magenta, [s]),
     cyan: (s: string) =>
-      fromString(~backgroundColor=Cyan, ~children=[s], ()),
+      fromString(~backgroundColor=Cyan, [s]),
     white: (s: string) =>
-      fromString(~backgroundColor=White, ~children=[s], ()),
+      fromString(~backgroundColor=White, [s]),
     blackBright: (s: string) =>
-      fromString(~backgroundColor=BrightBlack, ~children=[s], ()),
+      fromString(~backgroundColor=BrightBlack, [s]),
     redBright: (s: string) =>
-      fromString(~backgroundColor=BrightRed, ~children=[s], ()),
+      fromString(~backgroundColor=BrightRed, [s]),
     greenBright: (s: string) =>
-      fromString(~backgroundColor=BrightGreen, ~children=[s], ()),
+      fromString(~backgroundColor=BrightGreen, [s]),
     yellowBright: (s: string) =>
-      fromString(~backgroundColor=BrightYellow, ~children=[s], ()),
+      fromString(~backgroundColor=BrightYellow, [s]),
     blueBright: (s: string) =>
-      fromString(~backgroundColor=BrightBlue, ~children=[s], ()),
+      fromString(~backgroundColor=BrightBlue, [s]),
     magentaBright: (s: string) =>
-      fromString(~backgroundColor=BrightMagenta, ~children=[s], ()),
+      fromString(~backgroundColor=BrightMagenta, [s]),
     cyanBright: (s: string) =>
-      fromString(~backgroundColor=BrightCyan, ~children=[s], ()),
+      fromString(~backgroundColor=BrightCyan, [s]),
     whiteBright: (s: string) =>
-      fromString(~backgroundColor=BrightWhite, ~children=[s], ()),
+      fromString(~backgroundColor=BrightWhite, [s]),
   };
 };

--- a/src/pastel/ansiTerminal/TerminalImplementation.re
+++ b/src/pastel/ansiTerminal/TerminalImplementation.re
@@ -136,7 +136,7 @@ let bg = TerminalStateMachine.bg;
 let modifier = TerminalStateMachine.modifier;
 let partition = TerminalStateMachine.partitionFromString;
 
-let createElement =
+let create =
     (
       ~reset: option(bool)=?,
       ~bold: option(bool)=?,
@@ -148,8 +148,7 @@ let createElement =
       ~strikethrough: option(bool)=?,
       ~color: option(ColorName.colorName)=?,
       ~backgroundColor: option(ColorName.colorName)=?,
-      ~children: list(string),
-      (),
+      inputs: list(string),
     ) => {
   let color = PastelUtils.(optionMap(color, colorNameToColor));
   let backgroundColor =
@@ -166,8 +165,7 @@ let createElement =
     ~strikethrough?,
     ~color?,
     ~backgroundColor?,
-    ~children,
-    (),
+    inputs,
   );
 };
 
@@ -178,7 +176,7 @@ let implementation: PastelImplementation.t = {
   length,
   unformattedText,
   partition,
-  createElement,
+  create,
   emptyStyle: StateMachine.initialState,
   parse: TerminalStateMachine.parseStateRegions,
   apply: TerminalStateMachine.resolveStateRegions,

--- a/src/pastel/ansiTerminal/TerminalImplementation.re
+++ b/src/pastel/ansiTerminal/TerminalImplementation.re
@@ -136,7 +136,7 @@ let bg = TerminalStateMachine.bg;
 let modifier = TerminalStateMachine.modifier;
 let partition = TerminalStateMachine.partitionFromString;
 
-let create =
+let make =
     (
       ~reset: option(bool)=?,
       ~bold: option(bool)=?,

--- a/src/pastel/ansiTerminal/TerminalImplementation.re
+++ b/src/pastel/ansiTerminal/TerminalImplementation.re
@@ -176,7 +176,7 @@ let implementation: PastelImplementation.t = {
   length,
   unformattedText,
   partition,
-  create,
+  make,
   emptyStyle: StateMachine.initialState,
   parse: TerminalStateMachine.parseStateRegions,
   apply: TerminalStateMachine.resolveStateRegions,

--- a/src/pastel/humanReadable/HumanReadableImplementation.re
+++ b/src/pastel/humanReadable/HumanReadableImplementation.re
@@ -208,7 +208,7 @@ let implementation: PastelImplementation.t = {
   length,
   unformattedText,
   partition,
-  create,
+  make,
   emptyStyle: StateMachine.initialState,
   parse: HumanReadableStateMachine.parseStateRegions,
   apply: HumanReadableStateMachine.resolveStateRegions,

--- a/src/pastel/humanReadable/HumanReadableImplementation.re
+++ b/src/pastel/humanReadable/HumanReadableImplementation.re
@@ -168,7 +168,7 @@ let colorNameToColor: option(ColorName.colorName) => option(Token.color) =
       )
     };
 
-let create =
+let make =
     (
       ~reset: option(bool)=?,
       ~bold: option(bool)=?,

--- a/src/pastel/humanReadable/HumanReadableImplementation.re
+++ b/src/pastel/humanReadable/HumanReadableImplementation.re
@@ -168,7 +168,7 @@ let colorNameToColor: option(ColorName.colorName) => option(Token.color) =
       )
     };
 
-let createElement =
+let create =
     (
       ~reset: option(bool)=?,
       ~bold: option(bool)=?,
@@ -180,8 +180,7 @@ let createElement =
       ~strikethrough: option(bool)=?,
       ~color: option(ColorName.colorName)=?,
       ~backgroundColor: option(ColorName.colorName)=?,
-      ~children: list(string),
-      (),
+      inputs: list(string),
     ) => {
   let color = PastelUtils.(optionMap(color, colorNameToColor));
   let backgroundColor =
@@ -198,8 +197,7 @@ let createElement =
     ~strikethrough?,
     ~color?,
     ~backgroundColor?,
-    ~children,
-    (),
+    inputs,
   );
 };
 
@@ -210,7 +208,7 @@ let implementation: PastelImplementation.t = {
   length,
   unformattedText,
   partition,
-  createElement,
+  create,
   emptyStyle: StateMachine.initialState,
   parse: HumanReadableStateMachine.parseStateRegions,
   apply: HumanReadableStateMachine.resolveStateRegions,


### PR DESCRIPTION
This PR creates a function `create` as an alternative to the createElement function used by the JSX ppx.

This allows users who don't use the PPX (OCaml) to use Pastel with a nicer API.

In OCaml:
```
Pastel.create ~color:Pastel.Blue ["World"]
```
vs 
```
Pastel.createElement ~color:Pastel.Blue ~children:["World"] ()
```