### PR TITLE
Let refmeterr be built with 4.9.0 ocaml

### DIFF
--- a/refmterr.json
+++ b/refmterr.json
@@ -9,7 +9,7 @@
     "@opam/dune": "*",
     "@opam/re": "*",
     "@esy-ocaml/reason": "< 4.0.0",
-    "ocaml": " >= 4.2.0  < 4.9.0",
+    "ocaml": " >= 4.2.0  < 4.10.0",
     "@reason-native/pastel": "*",
     "@opam/atdgen": "*",
     "@reason-native/console": "*"


### PR DESCRIPTION
This unblocks rely and refmterr on 4.9.0 of ocaml since the work to fix `Re` was already done this makes sense.