### PR TITLE
fix opamify version bug for depending on exact versions

### DIFF
--- a/rely.opam
+++ b/rely.opam
@@ -13,7 +13,7 @@ depends: [
   "reason"   {< "4.0.0"}
   "re"
   "ocaml"   {>= "4.4.0" & < "5.0.0"}
-  "cli"   {0.0.1-alpha"}
+  "cli"   {"0.0.1-alpha"}
   "pastel"
   "file-context-printer"
   "junit"

--- a/scripts/esy-prepublish.js
+++ b/scripts/esy-prepublish.js
@@ -51,16 +51,15 @@ const opamifyVersion = v => {
       return '>= "' + postCaret + '" & < "' + (parseInt(postCaret) + 1) + '"';
     }
   } else {
-    return v.replace(/\s+<\s+/g, s => '" & < "')
+    return `"${v}"`.replace(/\s+<\s+/g, s => '" & < "')
         .replace(/\s+<=\s*/g, s => '" & <= "')
-        .replace(/^<\s+/g, s => '< "')
-        .replace(/^<=\s*/g, s => '<= "')
+        .replace(/^"<\s+/g, s => '< "')
+        .replace(/^"<=\s*/g, s => '<= "')
 
         .replace(/\s+>\s+/g, s => '" & > "')
         .replace(/\s+>=/g, s => '" & >= "')
-        .replace(/^>\s+/g, s => '> "')
-        .replace(/^>=\s*/g, s => '>= "')
-        + '"';
+        .replace(/^">\s+/g, s => '> "')
+        .replace(/^">=\s*/g, s => '>= "');
   }
 };
 const depMap = (o) => {


### PR DESCRIPTION
Tested manually with common version patterns and rerunning esy-prepublish. 

@jordwalke did you have any test cases for this/I imagine this issue will be present in a bunch of other repos. Can you tell me where else this should be fixed/do you think it would be a good idea to package all this logic up so these fixes are easier to address in the future?