### PR TITLE
Generate opam file for cli

### DIFF
--- a/cli.json
+++ b/cli.json
@@ -1,35 +1,36 @@
 {
-    "name": "@reason-native/cli",
-    "version": "0.0.1-alpha",
-    "author": "Facebook Engineering",
-    "homepage": "https://reason-native.com",
-    "esy-prepublish-generate-opam": false,
-    "repository": {
-      "type": "git",
-      "url": "https://github.com/facebookexperimental/reason-native"
-    },
-    "license": "MIT",
-    "keywords": [
-      "cli",
-      "reasonml",
-      "reason",
-      "ocaml",
-      "esy"
-    ],
-    "esy": {
-      "build": "dune build -p cli"
-    },
-    "scripts": {
-      "release": "node ./scripts/esy-prepublish.js cli.json"
-    },
-    "dependencies": {
-      "@opam/dune": "*",
-      "@opam/re": "*",
-      "@reason-native/pastel": "*",
-      "@esy-ocaml/reason": "< 4.0.0",
-      "ocaml": "^4.2.0"
-    },
-    "devDependencies": {
-      "@opam/merlin": "*"
-    }
+  "name": "@reason-native/cli",
+  "version": "0.0.1-alpha",
+  "description": "Build Command Line Interfaces in Reason",
+  "author": "Facebook Engineering",
+  "homepage": "https://reason-native.com",
+  "esy-prepublish-generate-opam": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebookexperimental/reason-native"
+  },
+  "license": "MIT",
+  "keywords": [
+    "cli",
+    "reasonml",
+    "reason",
+    "ocaml",
+    "esy"
+  ],
+  "esy": {
+    "build": "dune build -p cli"
+  },
+  "scripts": {
+    "release": "node ./scripts/esy-prepublish.js cli.json"
+  },
+  "dependencies": {
+    "@opam/dune": "*",
+    "@opam/re": "*",
+    "@reason-native/pastel": "*",
+    "@esy-ocaml/reason": "< 4.0.0",
+    "ocaml": "^4.2.0"
+  },
+  "devDependencies": {
+    "@opam/merlin": "*"
   }
+}

--- a/cli.opam
+++ b/cli.opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+maintainer: "Facebook Engineering"
+authors: ["Facebook Engineering"]
+license: "MIT"
+homepage: "https://reason-native.com"
+doc: "https://reason-native.com"
+bug-reports: "https://github.com/facebookexperimental/reason-native"
+dev-repo: "git://github.com/facebookexperimental/reason-native"
+tags: ["cli" "reasonml" "reason" "ocaml" "esy"]
+build: [ ["dune" "build" "-p" "cli" ] ]
+depends: [
+  "dune"
+  "re"
+  "pastel"
+  "reason"   {< "4.0.0"}
+  "ocaml"   {>= "4.2.0" & < "5.0.0"}
+]
+synopsis: "Build Command Line Interfaces in Reason"
+description: "Build Command Line Interfaces in Reason"


### PR DESCRIPTION
This adds an opam file for `cli`.

I'd like to use Rely with Opam, and even though it's not released on Opam yet, I can use `opam pin` as a workaround. Problem is, I also need to pin all of Rely's dependencies in the reason-native repository. As `cli` is one of them, I would need to be able to pin it, thus the need for an opam file.

I haven't changed the json file much, it's mostly indentation, but I have added a `description` field as it is required by `esy-prepublish.js`.